### PR TITLE
fix: migrate crypto to cbc 0.2 / aes 0.9 / block-padding 0.4 APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,11 +451,11 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -589,11 +589,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "98db6aeaef0eeef2c1e3ce9a27b739218825dae116076352ac3777076aa22225"
 dependencies = [
- "cipher 0.4.4",
+ "cipher 0.5.1",
 ]
 
 [[package]]
@@ -2426,7 +2426,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -2436,6 +2435,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
+ "block-padding",
  "hybrid-array",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ rust-mcp-sdk = { version = "0.9", default-features = false, features = ["server"
 # NATIVE COOKIE DECRYPTION (macOS: AES-128-CBC + PBKDF2-SHA1 + Keychain)
 # ═══════════════════════════════════════════════════════════════════════════════
 aes = "0.9"                         # AES-128 block cipher (RustCrypto)
-cbc = { version = "0.1", features = ["block-padding"] }  # CBC mode + PKCS7 unpadding
+cbc = { version = "0.2", features = ["block-padding"] }  # CBC mode + PKCS7 unpadding
 hmac = "0.13"                       # HMAC-SHA1 PRF for Chromium cookie key derivation
 sha1 = "0.11"                       # SHA-1 for PBKDF2 (Chrome/Brave use SHA1)
 sha2 = "0.11"                       # SHA-256 for v24+ domain-integrity strip

--- a/src/auth/cookies/crypto.rs
+++ b/src/auth/cookies/crypto.rs
@@ -168,7 +168,7 @@ pub fn decrypt_cookie_value(encrypted: &[u8], key: &[u8], has_domain_tag: bool) 
     // This cipher + IV combination is fixed by the Chromium on-disk cookie format.
     // Reference: chromium/components/os_crypt/os_crypt_mac.mm OSCryptImpl::DecryptString
     use aes::Aes128;
-    use cbc::cipher::{BlockDecryptMut, KeyIvInit, block_padding::Pkcs7};
+    use cbc::cipher::{BlockModeDecrypt, KeyIvInit, block_padding::Pkcs7};
     type Aes128CbcDec = cbc::Decryptor<Aes128>;
 
     anyhow::ensure!(
@@ -195,7 +195,7 @@ pub fn decrypt_cookie_value(encrypted: &[u8], key: &[u8], has_domain_tag: bool) 
 
     let mut buf = ciphertext.to_vec();
     let plaintext = decryptor
-        .decrypt_padded_mut::<Pkcs7>(&mut buf)
+        .decrypt_padded::<Pkcs7>(&mut buf)
         .map_err(|e| anyhow::anyhow!("AES-CBC unpadding failed: {e}"))?;
 
     let value_bytes = if has_domain_tag {

--- a/src/auth/cookies/tests.rs
+++ b/src/auth/cookies/tests.rs
@@ -11,14 +11,14 @@ use super::{CookieSource, crypto::*, db::*};
 /// For schema-v24 blobs the caller should prepend 32 SHA-256 bytes itself.
 fn encrypt_v10(inner_plaintext: &[u8], key: &[u8]) -> Vec<u8> {
     use aes::Aes128;
-    use cbc::cipher::{BlockEncryptMut, KeyIvInit, block_padding::Pkcs7};
+    use cbc::cipher::{BlockModeEncrypt, KeyIvInit, block_padding::Pkcs7};
     type Aes128CbcEnc = cbc::Encryptor<Aes128>;
 
     let out_len = inner_plaintext.len() + 16;
     let mut out = vec![0u8; out_len];
     let enc = Aes128CbcEnc::new_from_slices(key, &AES_CBC_IV).unwrap();
     let ciphertext = enc
-        .encrypt_padded_b2b_mut::<Pkcs7>(inner_plaintext, &mut out)
+        .encrypt_padded_b2b::<Pkcs7>(inner_plaintext, &mut out)
         .expect("output buffer is always large enough");
 
     let mut blob = V10_PREFIX.to_vec();


### PR DESCRIPTION
## Summary

Unblocks main CI. Main has been failing since #54 merged `aes 0.8 -> 0.9` without the companion `cbc` bump. `aes 0.9` uses `cipher 0.5`, but `cbc 0.1` still pulled `cipher 0.4`, so `Decryptor<Aes128>` trait bounds no longer resolved.

This migrates the RustCrypto v0.4 -> v0.5 trait split in our only two CBC call sites (`auth/cookies/{crypto,tests}.rs`):

- `cbc 0.1 -> 0.2`
- `block-padding 0.3 -> 0.4` (transitive via cbc)
- `BlockDecryptMut` -> `BlockModeDecrypt`
- `BlockEncryptMut` -> `BlockModeEncrypt`
- `.decrypt_padded_mut::<Pkcs7>` -> `.decrypt_padded::<Pkcs7>`
- `.encrypt_padded_b2b_mut::<Pkcs7>` -> `.encrypt_padded_b2b::<Pkcs7>`

`KeyIvInit`, `new_from_slices`, and `block_padding::Pkcs7` paths are unchanged.

AES-128-CBC semantics preserved: static 0x20 IV, PKCS7 padding, Chromium cookie on-disk format untouched.

Closes #50 (superseded — this bumps cbc together with the API migration).

## Test plan

- [x] `cargo check` clean
- [x] `cargo test --lib auth::cookies` -> 29/29 pass, incl. `derive_cookie_key_known_vector`, `decrypt_cookie_value_round_trip_*`, and v24 domain-tag round-trips
- [x] `cargo clippy` on the touched files (no new warnings; pre-existing warnings in unrelated files out of scope)
- [x] Diff is 4 files, +12/-12 lines

## Note

Other dependabot bumps (rustls, tokio, rand, rust-bindgen, etc.) are deliberately NOT included — they each need their own PR after this lands.