### PR TITLE
fix(release): unblock release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,13 +105,13 @@ jobs:
           fi
 
       - name: Upload nab artifact
-        uses: actions/upload-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: nab-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/nab-${{ matrix.target }}${{ matrix.suffix }}
 
       - name: Upload nab-mcp artifact
-        uses: actions/upload-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: nab-mcp-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/nab-mcp-${{ matrix.target }}${{ matrix.suffix }}


### PR DESCRIPTION
## Root cause

`actions/upload-artifact` was pinned to commit SHA `d3f86a106a0bac45b974a628896c90dbdf5c8093` (labelled v4.3.0). That SHA no longer resolves on GitHub — every build job failed immediately at **"Prepare all required actions"**:

```
Unable to resolve action `actions/upload-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093`,
unable to find version `d3f86a106a0bac45b974a628896c90dbdf5c8093`
```

No Rust code was ever compiled. The v0.8.1 (run 24391383957) and v0.8.2 (run 24542454225) tags failed identically.

## Fix

Updated both `upload-artifact` references to `ea165f8d65b6e75b540449e92b4886f43607fa02` (v4.6.2) — the same SHA already in use for `download-artifact` in the release job.

## After merge

Re-tag or cut v0.8.3 to trigger a fresh Release run. Alternatively rerun the existing tags:

```
gh run rerun 24542454225 -R MikkoParkkola/nab
gh run rerun 24391383957 -R MikkoParkkola/nab
```

## Test results

- `cargo test --locked`: 44 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)