### PR TITLE
Fix cookie export www-domain expansion

### DIFF
--- a/src/auth/cookies/db.rs
+++ b/src/auth/cookies/db.rs
@@ -95,16 +95,41 @@ pub(super) fn query_cookie_db(temp_db: &std::path::Path, domain: &str) -> Result
 
 /// Build SQL `host_key` conditions for `domain` and its parent domains.
 pub(super) fn build_domain_conditions(domain: &str) -> Vec<String> {
+    domain_candidates(domain)
+        .into_iter()
+        .map(|host_key| format!("host_key = '{}'", host_key.replace('\'', "''")))
+        .collect()
+}
+
+pub(super) fn domain_candidates(domain: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+    push_host_key_pair(&mut candidates, domain);
+
+    if let Some(base_domain) = domain.strip_prefix("www.") {
+        if !base_domain.is_empty() {
+            push_host_key_pair(&mut candidates, base_domain);
+        }
+    } else if !domain.is_empty() {
+        push_host_key_pair(&mut candidates, &format!("www.{domain}"));
+    }
+
     let parts: Vec<&str> = domain.split('.').collect();
-    let mut conditions = vec![
-        format!("host_key = '{domain}'"),
-        format!("host_key = '.{domain}'"),
-    ];
     for i in 1..parts.len() {
         let parent = parts[i..].join(".");
-        conditions.push(format!("host_key = '.{parent}'"));
+        push_host_key(&mut candidates, &format!(".{parent}"));
     }
-    conditions
+    candidates
+}
+
+fn push_host_key_pair(candidates: &mut Vec<String>, domain: &str) {
+    push_host_key(candidates, domain);
+    push_host_key(candidates, &format!(".{domain}"));
+}
+
+fn push_host_key(candidates: &mut Vec<String>, host_key: &str) {
+    if !candidates.iter().any(|candidate| candidate == host_key) {
+        candidates.push(host_key.to_string());
+    }
 }
 
 /// Parse tab-separated output from `sqlite3` into [`CookieRow`] structs.

--- a/src/auth/cookies/mod.rs
+++ b/src/auth/cookies/mod.rs
@@ -25,7 +25,7 @@ use anyhow::{Context, Result};
 use tracing::{debug, info, warn};
 
 use super::{Credential, OnePasswordAuth};
-use db::{copy_db_to_temp, decrypt_rows, has_domain_tag, query_cookie_db};
+use db::{copy_db_to_temp, decrypt_rows, domain_candidates, has_domain_tag, query_cookie_db};
 
 // ─── CookieSource ─────────────────────────────────────────────────────────────
 
@@ -172,6 +172,7 @@ impl CookieSource {
             CookieSource::Firefox => "firefox",
             CookieSource::Safari => "safari",
         };
+        let domain_candidates_json = serde_json::to_string(&domain_candidates(domain))?;
 
         let script = format!(
             r#"
@@ -179,15 +180,22 @@ import json
 try:
     import browser_cookie3 as bc
     cj = bc.{browser_fn}()
+    request_domains = {domain_candidates_json}
 
-    def matches_cookie_domain(cookie_domain, request_domain):
+    def matches_cookie_domain(cookie_domain, request_domains):
+        for request_domain in request_domains:
+            if matches_single_cookie_domain(cookie_domain, request_domain):
+                return True
+        return False
+
+    def matches_single_cookie_domain(cookie_domain, request_domain):
         if cookie_domain.startswith('.'):
             parent = cookie_domain[1:]
             return request_domain == parent or request_domain.endswith('.' + parent)
         else:
             return cookie_domain == request_domain
 
-    cookies = {{c.name: c.value for c in cj if matches_cookie_domain(c.domain, '{domain}')}}
+    cookies = {{c.name: c.value for c in cj if matches_cookie_domain(c.domain, request_domains)}}
     print(json.dumps(cookies))
 except Exception as e:
     print(json.dumps({{"__error__": str(e)}}))

--- a/src/auth/cookies/tests.rs
+++ b/src/auth/cookies/tests.rs
@@ -401,6 +401,26 @@ fn build_domain_conditions_apex_domain() {
     assert!(conds.iter().any(|c| c.contains("'.example.com'")));
 }
 
+#[test]
+fn build_domain_conditions_apex_domain_includes_www_variants() {
+    let conds = build_domain_conditions("linkedin.com");
+
+    assert!(conds.contains(&"host_key = 'linkedin.com'".to_string()));
+    assert!(conds.contains(&"host_key = '.linkedin.com'".to_string()));
+    assert!(conds.contains(&"host_key = 'www.linkedin.com'".to_string()));
+    assert!(conds.contains(&"host_key = '.www.linkedin.com'".to_string()));
+}
+
+#[test]
+fn build_domain_conditions_www_domain_includes_apex_variants() {
+    let conds = build_domain_conditions("www.linkedin.com");
+
+    assert!(conds.contains(&"host_key = 'www.linkedin.com'".to_string()));
+    assert!(conds.contains(&"host_key = '.www.linkedin.com'".to_string()));
+    assert!(conds.contains(&"host_key = 'linkedin.com'".to_string()));
+    assert!(conds.contains(&"host_key = '.linkedin.com'".to_string()));
+}
+
 // ─── parse_cookie_rows ────────────────────────────────────────────────────────
 
 #[test]

--- a/src/cmd/linkedin.rs
+++ b/src/cmd/linkedin.rs
@@ -5,9 +5,8 @@
 //! retrieval. See `src/site/linkedin/export.rs` for the protocol details.
 //!
 //! Workflow:
-//! 1. Resolve cookies for `www.linkedin.com` (note MIK-3068: bare
-//!    `linkedin.com` only returns 10 cookies; the auth-critical `li_at`
-//!    + `JSESSIONID` live under `www.`).
+//! 1. Resolve cookies for `www.linkedin.com`, where LinkedIn stores
+//!    auth-critical cookies such as `li_at` and `JSESSIONID`.
 //! 2. Extract csrf-token from JSESSIONID.
 //! 3. POST the archive request (FAST or FULL).
 //! 4. If `--wait` is set: poll the settings page on exponential backoff

--- a/src/main.rs
+++ b/src/main.rs
@@ -682,7 +682,7 @@ enum McpAction {
 enum CookiesAction {
     /// Export cookies for a domain in Netscape format
     Export {
-        /// Domain to export cookies for (e.g., "github.com")
+        /// Domain to export cookies for (e.g., "github.com"). Bare domains also include www. variants.
         domain: String,
 
         /// Browser to export from (auto, brave, chrome, firefox, safari, edge)


### PR DESCRIPTION
Summary:
- expand native cookie DB host_key matching so bare domains include www variants and www domains include apex variants
- reuse the same domain candidate set in the Python browser_cookie3 fallback
- document the implicit www expansion in nab cookies export help

Validation:
- cargo fmt --all --check
- RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo test --lib auth::cookies::tests -- --nocapture
- RUSTC_WRAPPER= SCCACHE_DISABLE=1 cargo run --quiet --bin nab -- cookies export --help | grep -F Bare domains also include www. variants

Linear: MIK-3068