### PR TITLE
Fix Substack readability and budgeted fetch output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a first-class Substack site provider for `*.substack.com/p/*` posts, generic `nab fetch --readability`, CLI `--max-output-tokens`, and MCP `fetch.readability`. HTML conversion now prefers readability when raw markdown exceeds a caller token budget, and CLI/MCP budgeted output uses 80% of `max_tokens` for response headroom.
+
 ### Security
 
 - Added `nab-yara-engine`, a YARA-X fetch-time signature guard wired into CLI `nab fetch`, batch fetch, media fetch output, site-provider output, and MCP `fetch`. It is default-on, redacts matched sections with a clear `NAB YARA SANITIZED` marker, supports `NAB_YARA_ACTION=refuse`, and supports audited emergency bypass with `NAB_YARA_BYPASS=1`.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ nab watch add https://status.openai.com --interval 5m         # subscribe to cha
 
 | Command | What it does |
 |---------|--------------|
-| `nab fetch <url>` | Fetch any URL as clean markdown. HTTP/3, browser cookie injection (Brave / Chrome / Firefox / Safari / Edge / Dia), 1Password auto-login, fingerprint spoofing, fetch-time YARA-X redaction for prompt-injection/exfil signatures, 11 site providers. MCP fetch also supports query-focused extraction and token budgets. |
+| `nab fetch <url>` | Fetch any URL as clean markdown. HTTP/3, browser cookie injection (Brave / Chrome / Firefox / Safari / Edge / Dia), 1Password auto-login, fingerprint spoofing, fetch-time YARA-X redaction for prompt-injection/exfil signatures, 12 site providers. MCP fetch also supports query-focused extraction, readability, and token budgets. |
 | `nab analyze <video\|audio>` | Transcribe and diarize. FluidAudio (Parakeet TDT v3) on Apple Neural Engine, 131x realtime on a 2-hour clip, word-level timestamps, 25 EU languages, optional Qwen3-ASR for zh/ja/ko/vi, optional active reading via MCP sampling. |
 | `nab watch add <url>` | Monitor a URL and push notifications via subscribable MCP resources. RSS for the entire web. Conditional GETs, semantic diff, adaptive backoff. |
 | `nab models fetch <name>` | Persistent install of inference model binaries. Supports `fluidaudio` (default on macOS Apple Silicon), `sherpa-onnx` (cross-platform Parakeet TDT, ~30× realtime CPU), and `whisper` (universal fallback, whisper-large-v3-turbo, 99 langs). |
@@ -161,12 +161,14 @@ Common flags for `fetch`:
 | `--proxy <url>` | HTTP or SOCKS5 proxy |
 | `--format <fmt>` | `full` (default), `compact`, `json` |
 | `--raw-html` | Skip markdown conversion |
+| `--readability` | Force readability extraction for generic HTML pages |
+| `--max-output-tokens <n>` | Apply an output token envelope; returned markdown uses 80% for headroom |
 | `--remote-fallback` | Opt in to remote thin-content recovery via `r.jina.ai`; avoid for internal, authenticated, or sensitive URLs |
 | `--diff` | Show what changed since the last fetch |
 | `-X <method>` `-d <data>` | HTTP method + body |
 | `-o <path>` | Write body to file |
 
-MCP `fetch` additionally supports `focus`, `max_tokens`, and `session` parameters for query-focused extraction, structure-aware token budgets, and persistent encrypted cookie sessions.
+MCP `fetch` additionally supports `focus`, `readability`, `max_tokens`, and `session` parameters for query-focused extraction, readability extraction, structure-aware token budgets, and persistent encrypted cookie sessions.
 
 ### Analyze
 
@@ -324,7 +326,7 @@ The 12 MCP tools:
 
 ## Site providers
 
-nab detects URLs for 11 platforms and uses their APIs or structured data instead of scraping HTML.
+nab detects URLs for 12 platforms and uses APIs or stable structured page data instead of broad HTML scraping.
 
 | Provider | URL pattern | Method |
 |----------|-------------|--------|
@@ -339,6 +341,7 @@ nab detects URLs for 11 platforms and uses their APIs or structured data instead
 | Mastodon | `*/users/*/statuses/*` | ActivityPub |
 | LinkedIn | `linkedin.com/posts/*` | oEmbed |
 | Instagram | `instagram.com/p/*`, `*/reel/*` | oEmbed |
+| Substack | `*.substack.com/p/*`, `substack.com/*/p/*` | Article DOM (`.available-content`) |
 
 If no provider matches, nab falls back to standard HTML fetch + markdown conversion.
 

--- a/docs/design-mcp-innovations.md
+++ b/docs/design-mcp-innovations.md
@@ -453,7 +453,7 @@ Add a `session` parameter to `fetch`, `submit`, and `login`. Named sessions pers
 
 ### Problem
 
-nab has 11 hardcoded site providers in `src/site/` (Twitter, Reddit, HackerNews, GitHub, Google Workspace, Instagram, YouTube, Wikipedia, StackOverflow, Mastodon, LinkedIn). Adding a new provider requires writing Rust code, rebuilding, and redeploying. Users who need custom extraction for internal sites or niche platforms cannot extend nab without forking.
+nab has 12 hardcoded site providers in `src/site/` (Twitter, Reddit, HackerNews, GitHub, Google Workspace, Instagram, YouTube, Wikipedia, StackOverflow, Mastodon, LinkedIn, Substack). Adding a new provider requires writing Rust code, rebuilding, and redeploying. Users who need custom extraction for internal sites or niche platforms cannot extend nab without forking.
 
 ### Solution
 
@@ -616,7 +616,7 @@ Processing: session client → fetch → diff (full, markers tagged) → focus (
 
 ### Phase 0: Pipeline Unification (prerequisite)
 
-Refactor `FetchTool::run()` so site provider output enters the same post-processing pipeline as standard fetches. Currently providers return early at `tools.rs:109-131`, bypassing all new features. Also extend `SiteProvider::extract()` signature with `prefetched_html: Option<&[u8]>` (mechanical update to 11 providers).
+Refactor `FetchTool::run()` so site provider output enters the same post-processing pipeline as standard fetches. Currently providers return early at `tools.rs:109-131`, bypassing all new features. Also extend `SiteProvider::extract()` signature with `prefetched_html: Option<&[u8]>` (mechanical update to 12 providers).
 
 **Deliverables**:
 - Refactored `FetchTool::run()` (~30 LOC)

--- a/llms.txt
+++ b/llms.txt
@@ -25,7 +25,7 @@ Transport: stdio (default) or Streamable HTTP (--http HOST:PORT)
 
 ## MCP Tools (12)
 
-- fetch(url, [cookies, focus, max_tokens, session, raw_html, diff, proxy, tor]) — Fetch URL as markdown
+- fetch(url, [cookies, focus, readability, max_tokens, session, raw_html, diff, proxy, tor]) — Fetch URL as markdown
 - fetch_batch(urls, [cookies, parallel]) — Parallel multi-URL fetch with task-augmented async
 - submit(url, fields, [csrf_from, cookies]) — Submit form with CSRF + smart field extraction
 - login(url, [use_1password, save_session, cookies]) — 1Password auto-login with TOTP
@@ -50,7 +50,8 @@ Transport: stdio (default) or Streamable HTTP (--http HOST:PORT)
 nab fetch https://example.com                          # fetch as markdown
 nab fetch URL --cookies brave                          # use browser cookies
 nab fetch URL --1password                              # auto-login via 1Password
-# MCP fetch supports focus="pricing", max_tokens=2000  # query-focused extraction
+nab fetch URL --readability --max-output-tokens 2000   # article extraction with budget headroom
+# MCP fetch supports focus="pricing", readability=true, max_tokens=2000
 nab fetch --batch urls.txt --parallel 8                # batch fetch
 nab spa URL                                            # extract SPA/JS data
 nab analyze interview.mp4 --diarize                    # transcribe + speakers

--- a/src/bin/mcp_server/helpers.rs
+++ b/src/bin/mcp_server/helpers.rs
@@ -12,6 +12,7 @@ use rust_mcp_sdk::schema::schema_utils::CallToolError;
 use url::Url;
 
 use nab::content::ContentRouter;
+use nab::content::html::HtmlConversionOptions;
 use nab::{AcceleratedClient, SafeFetchConfig, SafeRequestOptions};
 
 // ─── Cookie helpers ───────────────────────────────────────────────────────────
@@ -184,10 +185,26 @@ pub(crate) async fn convert_body_async(
     content_type: &str,
     url: &str,
 ) -> Result<nab::content::ConversionResult, CallToolError> {
+    convert_body_async_with_options(
+        body_bytes,
+        content_type,
+        url,
+        HtmlConversionOptions::default(),
+    )
+    .await
+}
+
+/// Convert body bytes to markdown asynchronously with explicit HTML options.
+pub(crate) async fn convert_body_async_with_options(
+    body_bytes: &bytes::Bytes,
+    content_type: &str,
+    url: &str,
+    html_options: HtmlConversionOptions,
+) -> Result<nab::content::ConversionResult, CallToolError> {
     let bytes_clone = body_bytes.to_vec();
     let ct_clone = content_type.to_string();
     let url_clone = url.to_string();
-    let router = ContentRouter::new();
+    let router = ContentRouter::with_html_options(html_options);
     tokio::task::spawn_blocking(move || {
         router.convert_with_url(&bytes_clone, &ct_clone, Some(&url_clone))
     })

--- a/src/bin/mcp_server/tools/fetch.rs
+++ b/src/bin/mcp_server/tools/fetch.rs
@@ -7,10 +7,11 @@ use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
 use rust_mcp_sdk::schema::{CallToolResult, TextContent, schema_utils::CallToolError};
 use serde::{Deserialize, Serialize};
 
-use nab::content::budget::truncate_to_budget;
+use nab::content::budget::{max_tokens_with_output_headroom, truncate_to_budget};
 use nab::content::diff::{ContentSnapshot, compute_diff};
 use nab::content::diff_format::format_diff_markdown;
 use nab::content::focus::extract_focused;
+use nab::content::html::HtmlConversionOptions;
 use nab::content::response_classifier::{
     ResponseAnalysis, ResponseClass, classify_response, classify_thin_content,
 };
@@ -18,8 +19,8 @@ use nab::content::snapshot_store::SnapshotStore;
 use nab::{AcceleratedClient, SafeFetchConfig};
 
 use crate::helpers::{
-    convert_body_async, fetch_safe_response, fetch_with_cookies, fetch_with_session_response,
-    resolve_cookie_header, write_body_info, write_response_summary,
+    convert_body_async_with_options, fetch_safe_response, fetch_with_cookies,
+    fetch_with_session_response, resolve_cookie_header, write_body_info, write_response_summary,
 };
 use crate::structured::{FetchStructuredParams, build_fetch_structured_v2, truncate_markdown};
 use crate::tools::client::{get_client, persist_session, resolve_session_client};
@@ -62,7 +63,9 @@ Focus mode (focus: query):
 - Diff markers are always preserved regardless of relevance
 
 Token budget (max_tokens: N):
+- Triggers readability preference for HTML when raw markdown exceeds the budget
 - Structure-aware truncation preserving headings, code, and tables
+- Caps returned markdown at 80% of the requested budget for response headroom
 - Priority: title > code/tables > headings (30% cap) > body > blockquotes
 
 Returns: Markdown-converted body with timing info (or diff when diff: true).",
@@ -107,6 +110,13 @@ pub struct FetchTool {
     /// then headings (capped at 30% of budget), then body text.
     #[serde(default)]
     max_tokens: Option<u64>,
+    /// Force readability extraction for HTML pages.
+    ///
+    /// Specialized site providers still run first. For generic HTML pages,
+    /// this prefers Mozilla-style readability extraction whenever an article
+    /// candidate exists.
+    #[serde(default)]
+    readability: bool,
     /// Named session for cookie persistence across calls.
     ///
     /// When set, nab uses an isolated per-session cookie jar so that
@@ -141,6 +151,7 @@ impl FetchTool {
             url_host = %url_host,
             has_focus = self.focus.is_some(),
             has_budget = self.max_tokens.is_some(),
+            readability = self.readability,
             has_session = self.session.is_some(),
             diff = self.diff,
             tor = self.tor,
@@ -207,7 +218,13 @@ impl FetchTool {
             );
             write_body_info(&mut output, body_bytes.len());
 
-            let conversion = convert_body_async(&body_bytes, &content_type, &self.url).await?;
+            let conversion = convert_body_async_with_options(
+                &body_bytes,
+                &content_type,
+                &self.url,
+                self.html_options(),
+            )
+            .await?;
             let diagnostics = trace_fetch_classification(
                 status.as_u16(),
                 &content_type,
@@ -285,7 +302,13 @@ impl FetchTool {
             );
             write_body_info(&mut output, body_bytes.len());
 
-            let conversion = convert_body_async(&body_bytes, &content_type, &self.url).await?;
+            let conversion = convert_body_async_with_options(
+                &body_bytes,
+                &content_type,
+                &self.url,
+                self.html_options(),
+            )
+            .await?;
             if let Some(pages) = conversion.page_count {
                 let _ = writeln!(
                     output,
@@ -396,7 +419,8 @@ impl FetchTool {
         // Budget: structure-aware truncation with priority scoring.
         let max_tok = self
             .max_tokens
-            .map(|t| usize::try_from(t).unwrap_or(usize::MAX));
+            .map(|t| usize::try_from(t).unwrap_or(usize::MAX))
+            .map(max_tokens_with_output_headroom);
         let budget_result = truncate_to_budget(&processed_markdown, max_tok);
 
         let structured = build_fetch_structured_v2(&FetchStructuredParams {
@@ -419,6 +443,17 @@ impl FetchTool {
         let mut result = CallToolResult::text_content(vec![TextContent::from(output)]);
         result.structured_content = Some(structured);
         Ok(result)
+    }
+
+    fn html_options(&self) -> HtmlConversionOptions {
+        HtmlConversionOptions {
+            allow_spa_extraction: true,
+            allow_jina_fallback: false,
+            force_readability: self.readability,
+            max_output_tokens: self
+                .max_tokens
+                .map(|tokens| usize::try_from(tokens).unwrap_or(usize::MAX)),
+        }
     }
 }
 

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use reqwest::header::{CONTENT_TYPE, COOKIE, HeaderMap, HeaderName, HeaderValue, REFERER};
 use serde_json::json;
 
+use nab::content::budget::{max_tokens_with_output_headroom, truncate_to_budget};
 use nab::content::diff::ContentSnapshot;
 use nab::content::diff_format::format_diff_terminal;
 use nab::content::ocr::fetch_integration::FetchOcrEnricher;
@@ -36,6 +37,7 @@ pub struct FetchConfig {
     pub raw_html: bool,
     pub links: bool,
     pub max_body: usize,
+    pub max_output_tokens: Option<usize>,
     pub custom_headers: Vec<String>,
     pub auto_referer: bool,
     pub warmup_url: Option<String>,
@@ -151,6 +153,7 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
                     "cli_fetch_media",
                     &cfg.url,
                 )?;
+                let markdown = apply_output_token_budget(&markdown, cfg.max_output_tokens);
                 if !cfg.no_save {
                     save_to_hebb(&cfg.url, &markdown, "").await;
                 }
@@ -182,6 +185,7 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
                 "cli_fetch_site_provider",
                 &cfg.url,
             )?;
+            let markdown = apply_output_token_budget(&markdown, cfg.max_output_tokens);
             output_body(
                 &markdown,
                 cfg.output_file.as_deref(),
@@ -402,11 +406,6 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
     };
     let body_text = nab::security::guard_fetch_output(&body_text, "cli_fetch", &cfg.url)?;
 
-    // ── Auto-save to hebb kv:urls ──────────────────────────────────────────
-    if !cfg.no_save {
-        save_to_hebb(&cfg.url, &body_text, &raw_text).await;
-    }
-
     for warning in build_fetch_diagnostics(
         status.as_u16(),
         &raw_text,
@@ -417,6 +416,13 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
         cfg.html_options.allow_jina_fallback,
     ) {
         eprintln!("⚠️  {warning}");
+    }
+
+    let body_text = apply_output_token_budget(&body_text, cfg.max_output_tokens);
+
+    // ── Auto-save to hebb kv:urls ──────────────────────────────────────────
+    if !cfg.no_save {
+        save_to_hebb(&cfg.url, &body_text, &raw_text).await;
     }
 
     if cfg.show_diff {
@@ -743,6 +749,14 @@ fn print_output(cfg: &FetchConfig, resp: &FetchResponse<'_>) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn apply_output_token_budget(markdown: &str, max_output_tokens: Option<usize>) -> String {
+    let Some(max_tokens) = max_output_tokens else {
+        return markdown.to_string();
+    };
+    let content_budget = max_tokens_with_output_headroom(max_tokens);
+    truncate_to_budget(markdown, Some(content_budget)).markdown
 }
 
 /// Load the previous snapshot, compute diff, print it, then save new snapshot.

--- a/src/cmd/fetch_batch.rs
+++ b/src/cmd/fetch_batch.rs
@@ -8,6 +8,8 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 
 use nab::content::ContentRouter;
+use nab::content::budget::{max_tokens_with_output_headroom, truncate_to_budget};
+use nab::content::html::HtmlConversionOptions;
 use nab::rate_limit::DomainRateLimiter;
 
 use super::fetch::{FetchConfig, build_client};
@@ -61,6 +63,8 @@ pub async fn cmd_fetch_batch(cfg: &FetchConfig) -> Result<()> {
         no_redirect: cfg.no_redirect,
         auto_referer: cfg.auto_referer,
         raw_html: cfg.raw_html,
+        html_options: cfg.html_options,
+        max_output_tokens: cfg.max_output_tokens,
     });
 
     for url in urls {
@@ -113,6 +117,8 @@ struct BatchRequestParams {
     no_redirect: bool,
     auto_referer: bool,
     raw_html: bool,
+    html_options: HtmlConversionOptions,
+    max_output_tokens: Option<usize>,
 }
 
 /// Fetch a single URL in a batch context and return a JSON result.
@@ -185,17 +191,20 @@ async fn fetch_one_batch_url(url: String, params: &BatchRequestParams) -> serde_
             let markdown = if params.raw_html {
                 raw_text
             } else {
-                let router = ContentRouter::new();
-                router.convert(&body_bytes, &content_type).map_or_else(
-                    |_| String::from_utf8_lossy(&body_bytes).to_string(),
-                    |r| r.markdown,
-                )
+                let router = ContentRouter::with_html_options(params.html_options);
+                router
+                    .convert_with_url(&body_bytes, &content_type, Some(&url))
+                    .map_or_else(
+                        |_| String::from_utf8_lossy(&body_bytes).to_string(),
+                        |r| r.markdown,
+                    )
             };
             let markdown =
                 match nab::security::guard_fetch_output(&markdown, "cli_fetch_batch", &url) {
                     Ok(markdown) => markdown,
                     Err(e) => return serde_json::json!({"url": url, "error": e.to_string()}),
                 };
+            let markdown = apply_output_token_budget(&markdown, params.max_output_tokens);
 
             let title = extract_title_from_bytes(&body_bytes);
             let metadata = serde_json::json!({
@@ -215,6 +224,14 @@ async fn fetch_one_batch_url(url: String, params: &BatchRequestParams) -> serde_
         }
         Err(e) => serde_json::json!({"url": url, "error": e.to_string()}),
     }
+}
+
+fn apply_output_token_budget(markdown: &str, max_output_tokens: Option<usize>) -> String {
+    let Some(max_tokens) = max_output_tokens else {
+        return markdown.to_string();
+    };
+    let content_budget = max_tokens_with_output_headroom(max_tokens);
+    truncate_to_budget(markdown, Some(content_budget)).markdown
 }
 
 /// Extract `<title>` from raw HTML bytes.

--- a/src/content/budget.rs
+++ b/src/content/budget.rs
@@ -46,6 +46,9 @@ pub const STRUCTURED_CONTENT_MAX_CHARS: usize = 16_000;
 /// Using integer arithmetic avoids float-cast warnings.
 const HEADING_BUDGET_PERCENT: usize = 30;
 
+/// Returned content should leave caller headroom for instructions and metadata.
+pub const OUTPUT_BUDGET_HEADROOM_PERCENT: usize = 80;
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 /// Priority level assigned to each markdown block.
@@ -116,6 +119,22 @@ pub struct BudgetResult {
 #[must_use]
 pub fn estimate_tokens(text: &str) -> usize {
     text.len().div_ceil(CHARS_PER_TOKEN)
+}
+
+/// Convert a caller-provided token budget into the actual content budget.
+///
+/// `max_tokens` is treated as an envelope for the whole response. nab caps the
+/// extracted markdown at 80% of that value so MCP clients and CLI callers retain
+/// headroom for metadata, tool framing, and follow-up instructions.
+#[must_use]
+pub fn max_tokens_with_output_headroom(max_tokens: usize) -> usize {
+    if max_tokens == 0 {
+        return 0;
+    }
+    max_tokens
+        .saturating_mul(OUTPUT_BUDGET_HEADROOM_PERCENT)
+        .saturating_div(100)
+        .max(1)
 }
 
 /// Truncate `markdown` to fit within `max_tokens` using structure-aware
@@ -672,6 +691,14 @@ mod tests {
         let result = truncate_to_budget(md, Some(10_000));
         assert!(!result.truncated);
         assert_eq!(result.markdown, md);
+    }
+
+    #[test]
+    fn max_tokens_with_output_headroom_caps_at_eighty_percent() {
+        assert_eq!(max_tokens_with_output_headroom(0), 0);
+        assert_eq!(max_tokens_with_output_headroom(1), 1);
+        assert_eq!(max_tokens_with_output_headroom(10), 8);
+        assert_eq!(max_tokens_with_output_headroom(10_000), 8_000);
     }
 
     #[test]

--- a/src/content/html.rs
+++ b/src/content/html.rs
@@ -20,6 +20,7 @@ use anyhow::Result;
 use scraper::Selector;
 use std::sync::LazyLock;
 
+use super::budget;
 use super::quality;
 use super::readability;
 use super::spa_extract;
@@ -55,6 +56,12 @@ pub struct HtmlConversionOptions {
     pub allow_spa_extraction: bool,
     /// Opt in to remote thin-content recovery via `r.jina.ai`.
     pub allow_jina_fallback: bool,
+    /// Prefer readability extraction whenever an article candidate exists.
+    pub force_readability: bool,
+    /// Caller-provided output token envelope. When direct HTML markdown exceeds
+    /// this budget, readability is preferred to reduce boilerplate before any
+    /// final output truncation happens.
+    pub max_output_tokens: Option<usize>,
 }
 
 impl Default for HtmlConversionOptions {
@@ -62,6 +69,8 @@ impl Default for HtmlConversionOptions {
         Self {
             allow_spa_extraction: true,
             allow_jina_fallback: false,
+            force_readability: false,
+            max_output_tokens: None,
         }
     }
 }
@@ -222,29 +231,22 @@ where
 
     // Try readability extraction with real URL (or fallback placeholder)
     let effective_url = url.unwrap_or("https://example.com");
-    let readability_md =
-        readability::extract_article(&cleaned_html, effective_url).map(|article| {
-            let md = html2md::parse_html(&article.content_html);
-            let lines: Vec<&str> = md
-                .lines()
-                .map(str::trim)
-                .filter(|l| !l.is_empty())
-                .collect();
-            let md_result = lines.join("\n");
-
-            // html2md sometimes truncates list-heavy content (<ol>/<li>).
-            // If the article's plain text is significantly longer than the
-            // markdown output, fall back to the plain text which preserves
-            // all content from the DOM.
-            if article.text_content.len() > md_result.len() + 100 {
-                article.text_content
-            } else {
-                md_result
-            }
-        });
+    let readability_md = readability::extract_article(&cleaned_html, effective_url)
+        .map(|article| readability::article_to_markdown(&article));
 
     // Direct html2md on cleaned HTML (preserves tables, lists, etc.)
     let direct_md = html_to_markdown(&cleaned_html);
+    let direct_exceeds_budget = options.max_output_tokens.is_some_and(|max_tokens| {
+        max_tokens > 0 && budget::estimate_tokens(&direct_md) > max_tokens
+    });
+    if direct_exceeds_budget {
+        tracing::debug!(
+            direct_tokens = budget::estimate_tokens(&direct_md),
+            max_tokens = ?options.max_output_tokens,
+            "output token budget triggered readability preference"
+        );
+    }
+    let prefer_readability = options.force_readability || direct_exceeds_budget;
 
     // Pick the better result.  Readability produces clean article content but
     // is much shorter than direct conversion (which includes navigation, CSS,
@@ -253,6 +255,7 @@ where
     // that direct_md preserves.  Only fall back to direct when readability
     // produced nearly nothing.
     let markdown = match readability_md {
+        Some(ref r_md) if prefer_readability && r_md.len() >= MIN_READABILITY_LEN => r_md.clone(),
         Some(ref r_md) if r_md.len() >= MIN_READABILITY_LEN => r_md.clone(),
         Some(ref r_md) if r_md.len() > direct_md.len() => r_md.clone(),
         _ => direct_md,
@@ -1004,6 +1007,7 @@ mod tests {
             HtmlConversionOptions {
                 allow_spa_extraction: true,
                 allow_jina_fallback: true,
+                ..HtmlConversionOptions::default()
             },
             |url| {
                 calls.set(calls.get() + 1);
@@ -1033,6 +1037,7 @@ mod tests {
             HtmlConversionOptions {
                 allow_spa_extraction: true,
                 allow_jina_fallback: true,
+                ..HtmlConversionOptions::default()
             },
             |_html| Some(code_sample.clone()),
             |url| {
@@ -1063,6 +1068,7 @@ mod tests {
             HtmlConversionOptions {
                 allow_spa_extraction: true,
                 allow_jina_fallback: false,
+                ..HtmlConversionOptions::default()
             },
             |_url| {
                 calls.set(calls.get() + 1);
@@ -1113,6 +1119,7 @@ mod tests {
             HtmlConversionOptions {
                 allow_spa_extraction: true,
                 allow_jina_fallback: false,
+                ..HtmlConversionOptions::default()
             },
             |_html| Some(code_sample.clone()),
             |_url| {
@@ -1144,12 +1151,45 @@ mod tests {
             HtmlConversionOptions {
                 allow_spa_extraction: false,
                 allow_jina_fallback: false,
+                ..HtmlConversionOptions::default()
             },
             |_url| Some("Recovered remotely".to_string()),
         );
 
         assert!(!markdown.contains(&article_body));
         assert!(markdown.contains("Loading"));
+    }
+
+    #[test]
+    fn max_output_tokens_prefers_readability_when_direct_markdown_exceeds_budget() {
+        let chrome = "Navigation Subscribe Comments Related ".repeat(200);
+        let article = "This article body is the useful content and should dominate the output after readability extraction. ".repeat(8);
+        let html = format!(
+            r"<html><body>
+                <nav>{chrome}</nav>
+                <main>
+                    <article>
+                        <h1>Budgeted Article</h1>
+                        <p>{article}</p>
+                    </article>
+                </main>
+                <footer>{chrome}</footer>
+            </body></html>"
+        );
+
+        let markdown = html_to_markdown_with_url_and_fetcher(
+            &html,
+            Some("https://example.com/post"),
+            HtmlConversionOptions {
+                max_output_tokens: Some(200),
+                ..HtmlConversionOptions::default()
+            },
+            |_url| Some("Recovered remotely".to_string()),
+        );
+
+        assert!(markdown.contains("Budgeted Article"));
+        assert!(markdown.contains("useful content"));
+        assert!(!markdown.contains("Navigation Subscribe"));
     }
 
     #[test]

--- a/src/content/readability.rs
+++ b/src/content/readability.rs
@@ -107,6 +107,49 @@ pub fn extract_article(html: &str, url: &str) -> Option<Article> {
     }
 }
 
+/// Convert an extracted article into compact markdown.
+#[must_use]
+pub fn article_to_markdown(article: &Article) -> String {
+    let md = html2md::parse_html(&article.content_html);
+    let lines: Vec<&str> = md
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    let md_result = lines.join("\n\n");
+
+    // html2md sometimes truncates list-heavy content (<ol>/<li>). If the
+    // article's plain text is significantly longer than the markdown output,
+    // fall back to the plain text which preserves all content from the DOM.
+    if article.text_content.len() > md_result.len() + 100 {
+        plain_text_to_markdown_blocks(&article.text_content)
+    } else {
+        md_result
+    }
+}
+
+fn plain_text_to_markdown_blocks(text: &str) -> String {
+    const MAX_PARAGRAPH_CHARS: usize = 1_000;
+
+    let mut paragraphs = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        let separator_len = usize::from(!current.is_empty());
+        if !current.is_empty() && current.len() + separator_len + word.len() > MAX_PARAGRAPH_CHARS {
+            paragraphs.push(std::mem::take(&mut current));
+        }
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(word);
+    }
+    if !current.is_empty() {
+        paragraphs.push(current);
+    }
+
+    paragraphs.join("\n\n")
+}
+
 /// Extract the authored body from Substack's static post DOM.
 ///
 /// Substack pages include the complete post body in `.available-content
@@ -671,6 +714,23 @@ mod tests {
         assert_eq!(text, "Hello world with links");
         assert!(!text.contains('<'));
         assert!(!text.contains('>'));
+    }
+
+    #[test]
+    fn plain_text_fallback_keeps_budgetable_block_boundaries() {
+        let text = (0..260)
+            .map(|idx| format!("word{idx}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        let markdown = plain_text_to_markdown_blocks(&text);
+
+        assert!(markdown.contains("\n\n"));
+        assert!(
+            markdown
+                .split("\n\n")
+                .all(|paragraph| paragraph.len() <= 1_000)
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,14 @@ enum Commands {
         #[arg(long, default_value = "0")]
         max_body: usize,
 
+        /// Force readability extraction for HTML pages
+        #[arg(long)]
+        readability: bool,
+
+        /// Maximum output token envelope; returned markdown uses 80% for headroom
+        #[arg(long)]
+        max_output_tokens: Option<usize>,
+
         /// Add custom request headers (can be repeated: --add-header "Accept: application/json")
         #[arg(long = "add-header", action = clap::ArgAction::Append)]
         add_headers: Vec<String>,
@@ -837,6 +845,8 @@ async fn main() -> Result<()> {
                 raw_html,
                 links,
                 max_body,
+                readability,
+                max_output_tokens,
                 add_headers,
                 auto_referer,
                 warmup_url,
@@ -871,6 +881,7 @@ async fn main() -> Result<()> {
                     raw_html,
                     links,
                     max_body,
+                    max_output_tokens,
                     custom_headers: add_headers,
                     auto_referer,
                     warmup_url,
@@ -892,6 +903,8 @@ async fn main() -> Result<()> {
                     html_options: nab::content::html::HtmlConversionOptions {
                         allow_spa_extraction: !no_spa,
                         allow_jina_fallback: remote_fallback && !no_fallback,
+                        force_readability: readability,
+                        max_output_tokens,
                     },
                 };
                 cmd::cmd_fetch(&cfg).await?;

--- a/src/site/mod.rs
+++ b/src/site/mod.rs
@@ -42,6 +42,7 @@ pub mod lesswrong;
 pub mod linkedin;
 pub mod reddit;
 pub mod rules;
+pub mod substack;
 pub mod wasm_manifest;
 #[cfg(feature = "wasm-providers")]
 pub mod wasm_provider;
@@ -167,6 +168,7 @@ impl SiteRouter {
             Box::new(google::GoogleWorkspaceProvider),
             Box::new(lesswrong::LessWrongProvider),
             Box::new(linkedin::LinkedInProvider),
+            Box::new(substack::SubstackProvider),
         ];
 
         for p in hardcoded {

--- a/src/site/substack.rs
+++ b/src/site/substack.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+//! Substack article extraction.
+//!
+//! Substack posts ship authored content in a stable `.available-content
+//! .body.markup` subtree. The generic HTML path can extract it, but a provider
+//! makes Substack posts first-class and keeps post chrome out of the returned
+//! markdown before budget/focus post-processing runs.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use reqwest::header::{COOKIE, HeaderMap, HeaderValue};
+use url::Url;
+
+use super::{SiteContent, SiteMetadata, SiteProvider};
+use crate::content::readability;
+use crate::http_client::AcceleratedClient;
+use crate::{SafeFetchConfig, SafeRequestOptions};
+
+/// Provider for Substack post URLs.
+pub struct SubstackProvider;
+
+#[async_trait]
+impl SiteProvider for SubstackProvider {
+    fn name(&self) -> &'static str {
+        "substack"
+    }
+
+    fn matches(&self, url: &str) -> bool {
+        is_substack_post_url(url)
+    }
+
+    async fn extract(
+        &self,
+        url: &str,
+        client: &AcceleratedClient,
+        cookies: Option<&str>,
+        prefetched_html: Option<&[u8]>,
+    ) -> Result<SiteContent> {
+        let html = match prefetched_html {
+            Some(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+            None => fetch_html(client, url, cookies).await?,
+        };
+
+        site_content_from_html(&html, url)
+    }
+}
+
+fn is_substack_post_url(url: &str) -> bool {
+    let Ok(parsed) = Url::parse(url) else {
+        return false;
+    };
+    let Some(host) = parsed.host_str().map(str::to_ascii_lowercase) else {
+        return false;
+    };
+    let is_substack_host =
+        host == "substack.com" || host == "www.substack.com" || host.ends_with(".substack.com");
+    if !is_substack_host {
+        return false;
+    }
+
+    let segments: Vec<&str> = parsed
+        .path_segments()
+        .map(|segments| segments.filter(|segment| !segment.is_empty()).collect())
+        .unwrap_or_default();
+    segments.first().is_some_and(|segment| *segment == "p")
+        || segments.windows(2).any(|window| window[1] == "p")
+}
+
+async fn fetch_html(
+    client: &AcceleratedClient,
+    url: &str,
+    cookies: Option<&str>,
+) -> Result<String> {
+    let mut headers = HeaderMap::new();
+    if let Some(cookie_header) = cookies.filter(|value| !value.trim().is_empty()) {
+        headers.insert(
+            COOKIE,
+            HeaderValue::from_str(cookie_header).context("invalid cookie header for Substack")?,
+        );
+    }
+
+    let response = client
+        .request_safe(
+            url,
+            SafeRequestOptions {
+                headers,
+                config: SafeFetchConfig::default(),
+                ..SafeRequestOptions::default()
+            },
+        )
+        .await
+        .with_context(|| format!("failed to fetch Substack post '{url}'"))?;
+
+    Ok(String::from_utf8_lossy(&response.body).into_owned())
+}
+
+fn site_content_from_html(html: &str, url: &str) -> Result<SiteContent> {
+    let article = readability::extract_article(html, url)
+        .with_context(|| format!("Substack article body not found for {url}"))?;
+    let markdown = readability::article_to_markdown(&article);
+    let canonical_url = canonicalize_url(url);
+
+    Ok(SiteContent {
+        markdown,
+        metadata: SiteMetadata {
+            author: None,
+            title: Some(article.title),
+            published: None,
+            platform: "Substack".to_string(),
+            canonical_url,
+            media_urls: Vec::new(),
+            engagement: None,
+        },
+    })
+}
+
+fn canonicalize_url(url: &str) -> String {
+    Url::parse(url).map_or_else(
+        |_| url.to_string(),
+        |mut parsed| {
+            parsed.set_fragment(None);
+            parsed.to_string()
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt::Write as _;
+
+    fn substack_fixture(title: &str, body: &[&str], chrome_repeat: usize) -> String {
+        let chrome = "Subscribe Archive Comments Share Recommended ".repeat(chrome_repeat);
+        let mut body_html = String::new();
+        for paragraph in body {
+            let _ = write!(body_html, "<p>{paragraph}</p>");
+        }
+        format!(
+            r#"
+            <html>
+              <head><title>Chrome title</title></head>
+              <body>
+                <header>{chrome}</header>
+                <article class="typography newsletter-post post">
+                  <div class="post-header">
+                    <h1 class="post-title published">{title}</h1>
+                    <div class="post-ufi">451 likes 90 comments Share</div>
+                  </div>
+                  <div class="available-content">
+                    <div dir="auto" class="body markup">
+                      {body_html}
+                      <div class="subscription-widget-wrap">
+                        <p>Subscribe now for more posts.</p>
+                      </div>
+                    </div>
+                  </div>
+                </article>
+                <section class="comments">{chrome}</section>
+                <footer>{chrome}</footer>
+              </body>
+            </html>
+            "#
+        )
+    }
+
+    fn body_ratio(markdown: &str, body: &[&str]) -> f64 {
+        let body_chars: usize = body.iter().map(|part| part.len()).sum();
+        #[allow(clippy::cast_precision_loss)]
+        {
+            body_chars as f64 / markdown.len().max(1) as f64
+        }
+    }
+
+    #[test]
+    fn matches_substack_post_urls_only() {
+        let provider = SubstackProvider;
+
+        assert!(provider.matches("https://freddiedeboer.substack.com/p/we-are-still-living"));
+        assert!(provider.matches("https://www.substack.com/@writer/p/post-title"));
+        assert!(!provider.matches("https://freddiedeboer.substack.com/archive"));
+        assert!(!provider.matches("https://example.com/p/not-substack"));
+    }
+
+    #[test]
+    fn extracts_substack_article_with_body_ratio_above_eighty_percent() {
+        let cases = [
+            (
+                "https://freddiedeboer.substack.com/p/we-are-still-living-in-the-long-boring",
+                "We Are Still Living in the Long Boring",
+                vec![
+                    "This short post opens with a compact argument that still needs to survive extraction intact.",
+                    "The point is not the surrounding navigation; the authored paragraph is the payload that agents should receive.",
+                    "Even a brief note needs enough original prose to keep the body ratio check meaningful.",
+                ],
+                120,
+            ),
+            (
+                "https://examplewriter.substack.com/p/a-medium-post",
+                "A Medium Post",
+                vec![
+                    "The first medium-length paragraph lays out context, stakes, and the claim being evaluated.",
+                    "The second paragraph adds counterarguments and concrete examples for the reader to inspect.",
+                    "The final paragraph closes the loop without needing comments, subscribe widgets, or footer links.",
+                ],
+                160,
+            ),
+            (
+                "https://policy.substack.com/p/a-long-policy-note",
+                "A Long Policy Note",
+                vec![
+                    "Long-form Substack posts often include enough interface chrome to overwhelm extraction if selectors are too broad.",
+                    "The article body should remain the dominant returned markdown even when recommendations and comments are present.",
+                    "This paragraph represents the middle of the piece and should not be discarded by the provider.",
+                    "The conclusion remains part of the authored body and gives downstream summarizers the final claim.",
+                ],
+                220,
+            ),
+            (
+                "https://research.substack.com/p/another-long-post",
+                "Another Long Post",
+                vec![
+                    "A representative research essay starts by framing the evidence and defining the central question.",
+                    "It then walks through the supporting observations, preserving named concepts and local context.",
+                    "A later section may include caveats, but it is still article text and must remain in markdown.",
+                    "The extraction should exclude buttons, signup forms, related posts, and comments from the output.",
+                ],
+                240,
+            ),
+            (
+                "https://letters.substack.com/p/a-brief-letter",
+                "A Brief Letter",
+                vec![
+                    "Brief posts are the hard case because a small amount of chrome can dominate the output quickly.",
+                    "The provider keeps only the authored body so the useful text stays above the ratio invariant.",
+                    "A final sentence gives the fixture realistic length without adding any interface chrome.",
+                ],
+                100,
+            ),
+        ];
+
+        for (url, title, body, chrome_repeat) in cases {
+            let html = substack_fixture(title, &body, chrome_repeat);
+            let content = site_content_from_html(&html, url).unwrap();
+
+            assert!(content.markdown.contains(title));
+            for paragraph in &body {
+                assert!(content.markdown.contains(paragraph));
+            }
+            assert!(!content.markdown.contains("Subscribe now"));
+            assert!(!content.markdown.contains("451 likes"));
+            assert!(
+                body_ratio(&content.markdown, &body) >= 0.80,
+                "body ratio too low for {url}: {:.2}\n{}",
+                body_ratio(&content.markdown, &body),
+                content.markdown
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #74

## Summary
- Adds a first-class Substack provider using the authored article body instead of newsletter chrome.
- Adds CLI `--readability` and `--max-output-tokens`, plus MCP `fetch.readability`.
- Applies the requested 80% output-budget headroom and triggers readability when raw HTML markdown exceeds the requested budget.
- Updates README, llms.txt, changelog, design notes, and provider counts.

## Validation
- `cargo fmt --all`
- `RUSTC_WRAPPER= cargo check --locked --bin nab --bin nab-mcp`
- `RUSTC_WRAPPER= cargo test --locked --lib`
- `RUSTC_WRAPPER= cargo test --locked --bins`
- `RUSTC_WRAPPER= cargo test --locked substack --lib`
- `RUSTC_WRAPPER= cargo test --locked max_output_tokens_prefers_readability --lib`
- `RUSTC_WRAPPER= cargo test --locked max_tokens_with_output_headroom --lib`
- `RUSTC_WRAPPER= cargo test --locked plain_text_fallback_keeps_budgetable_block_boundaries --lib`
- `RUSTC_WRAPPER= cargo clippy --locked --all-targets -- -D warnings`
- `git diff --check` and `git diff --cached --check`
- Live Substack smoke: Freddie deBoer URL with `--max-output-tokens 2000` returned article content, emitted 1600-token truncation marker, and did not include Subscribe/Comments/Recommended chrome.

## DoD / scope evidence
- DoR: pass; issue has acceptance criteria, scope, ROI/value, risk notes, and test strategy.
- GitNexus impact was checked for modified core symbols; `html_to_markdown_with_url_and_sources` reported CRITICAL blast radius, so the change was kept additive and covered with regression tests.
- GitNexus change-detection is not exposed by the installed CLI; staged `git diff --name-status` and clean `git status` were used as fallback scope evidence.
- GitNexus index refreshed after commit with `npx gitnexus analyze`.