### PR TITLE
feat(site-rules): add browser engine routing

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -220,7 +220,7 @@ site/
 │   └── ooxml/          # OOXML parsing (docx/xlsx/pptx via zip + roxmltree)
 └── rules/              # Config-driven rule engine
     ├── mod.rs           # Rule loading: user overrides + embedded defaults
-    ├── config.rs        # TOML rule schema (SiteRuleConfig)
+    ├── config.rs        # TOML rule schema (SiteRuleConfig, engine routing)
     ├── config_tests.rs  # Config parsing tests
     ├── helpers.rs       # Template and extraction helpers
     ├── provider.rs      # ApiRuleProvider: generic rule-based SiteProvider
@@ -244,6 +244,10 @@ site/
 2. Rule-based providers from embedded defaults (9 rules compiled into binary)
 3. Hardcoded Rust providers for platforms not covered by a rule (hackernews, github, google-workspace, linkedin)
 4. CSS extractor plugins from `~/.config/nab/plugins.toml`
+
+`[site] engine = "api"` is the default. `[site] engine = "browser"` marks a
+rule as a browser-path routing directive; it can omit API-provider sections and
+causes matching fetches to skip config-driven API providers.
 
 **Used By**: Fetch pipeline (before generic HTML conversion), MCP fetch tool
 
@@ -556,7 +560,8 @@ MCP `fetch` layers query-focused extraction (`content/focus.rs`) and token budge
 
 **Optional configuration files** (in `~/.config/nab/`):
 - `plugins.toml`: CSS extractor and binary plugin definitions
-- `sites/*.toml`: User overrides for built-in site rules
+- `sites/*.toml`: User overrides for built-in site rules, including optional
+  browser routing directives via `[site] engine = "browser"`
 
 **Optional environment variables**:
 - `RUST_LOG=nab=debug`: Enable debug logging
@@ -586,7 +591,7 @@ MCP `fetch` layers query-focused extraction (`content/focus.rs`) and token budge
 2. **New auth method**: Extend `CredentialRetriever` or `OtpRetriever` in `auth.rs`
 3. **New fingerprint profile**: Add profile function in `fingerprint/mod.rs`
 4. **New output format**: Add to `OutputFormat` enum in `cmd/output.rs`
-5. **New site rule**: Add TOML file to `~/.config/nab/sites/` or `site/rules/defaults/`
+5. **New site rule**: Add TOML file to `~/.config/nab/sites/` or `site/rules/defaults/`; use `[site] engine = "browser"` for hosts that must bypass API providers
 6. **New CSS extractor plugin**: Add entry to `~/.config/nab/plugins.toml` with CSS selectors
 7. **New site provider (Rust)**: Implement `SiteProvider` trait, register in `SiteRouter::new()`
 8. **New content handler**: Implement `ContentHandler` trait, register in `ContentRouter::new()`

--- a/src/bin/mcp_server/tools/fetch.rs
+++ b/src/bin/mcp_server/tools/fetch.rs
@@ -258,21 +258,25 @@ impl FetchTool {
 
         // ── Standard path (no session) ────────────────────────────────────────
 
-        let site_router = nab::site::SiteRouter::new();
         let cookie_opt = if cookie_header.is_empty() {
             None
         } else {
             Some(cookie_header.as_str())
         };
+        let force_browser_engine = nab::site::rules::engine_for_url(&self.url)
+            .is_some_and(nab::site::rules::config::RuleEngine::is_browser);
+        let site_content = if force_browser_engine {
+            None
+        } else {
+            nab::site::SiteRouter::new()
+                .try_extract(&self.url, client, cookie_opt)
+                .await
+        };
 
         // Determine markdown, status, content_type, and elapsed_ms from either
         // a specialized site provider or the standard HTTP fetch path.  Both
         // paths converge below into the single diff + structured_content pipeline.
-        let (markdown, status_u16, content_type, elapsed_ms, diagnostics) = if let Some(
-            site_content,
-        ) =
-            site_router.try_extract(&self.url, client, cookie_opt).await
-        {
+        let fetch_result = if let Some(site_content) = site_content {
             let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
             output.push_str("\n📄 Content (from specialized provider):\n\n");
             (
@@ -363,6 +367,7 @@ impl FetchTool {
                 diagnostics,
             )
         };
+        let (markdown, status_u16, content_type, elapsed_ms, diagnostics) = fetch_result;
 
         self.finish_fetch(
             output,

--- a/src/cmd/context.rs
+++ b/src/cmd/context.rs
@@ -140,15 +140,21 @@ async fn fetch_one_inner(url: &str, cookies: &str) -> Result<(String, String)> {
     let cookie_opt = non_empty(&cookie_header);
 
     // Try site rule providers first (Wikipedia, YouTube, Twitter, etc.).
-    let site_router = SiteRouter::new();
-    if let Some(content) = site_router.try_extract(url, &client, cookie_opt).await {
-        let title = content
-            .metadata
-            .title
-            .clone()
-            .or_else(|| extract_title_from_markdown(&content.markdown))
-            .unwrap_or_else(|| url.to_owned());
-        return Ok((title, content.markdown));
+    // Browser-engine rules are routing directives, so they intentionally skip
+    // API providers and fall through to the generic HTTP conversion path.
+    let force_browser_engine = nab::site::rules::engine_for_url(url)
+        .is_some_and(nab::site::rules::config::RuleEngine::is_browser);
+    if !force_browser_engine {
+        let site_router = SiteRouter::new();
+        if let Some(content) = site_router.try_extract(url, &client, cookie_opt).await {
+            let title = content
+                .metadata
+                .title
+                .clone()
+                .or_else(|| extract_title_from_markdown(&content.markdown))
+                .unwrap_or_else(|| url.to_owned());
+            return Ok((title, content.markdown));
+        }
     }
 
     // No rule matched — fall back to generic HTTP fetch + content conversion.

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -171,12 +171,20 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
         }
     }
 
+    let force_browser_engine = nab::site::rules::engine_for_url(&cfg.url)
+        .is_some_and(nab::site::rules::config::RuleEngine::is_browser);
+    if force_browser_engine && matches!(cfg.format, OutputFormat::Full) {
+        write_stdout_line(
+            "🌐 Site rule requests engine=browser; skipping API site providers for this URL",
+        )?;
+    }
+
     // Site providers produce structured markdown, which is incompatible with
-    // --raw-html (the user is asking for the wire HTML). Skip the site router
-    // entirely when raw HTML is requested so that the generic fetch path runs
-    // and emits the unmodified HTML body. Cookies + impersonation still apply
-    // via the lower-level fetch_safe path.
-    if !cfg.raw_html {
+    // --raw-html (the user is asking for the wire HTML). Browser-engine site
+    // rules are routing directives, so they also skip API providers and fall
+    // through to the lower-level fetch path. Cookies + impersonation still
+    // apply via fetch_safe/manual request below.
+    if !cfg.raw_html && !force_browser_engine {
         let site_router = nab::site::SiteRouter::new();
         let cookie_opt = non_empty(&cookie_header);
         if let Some(site_content) = site_router.try_extract(&cfg.url, &client, cookie_opt).await {

--- a/src/site/rules/config.rs
+++ b/src/site/rules/config.rs
@@ -3,6 +3,7 @@
 //! TOML deserialization types for site rule configuration.
 //!
 //! The schema supports `type = "api"` rules that specify:
+//! - Engine selection (`api` by default, or `browser` to force browser-path routing)
 //! - URL pattern matching
 //! - URL rewriting (with regex capture groups or `{url}` placeholder)
 //! - HTTP request configuration
@@ -60,6 +61,11 @@ pub struct SiteRuleConfig {
     /// Engagement metrics field mapping.
     #[serde(default)]
     pub engagement: EngagementConfig,
+}
+
+#[derive(Debug, Deserialize)]
+struct SiteOnlyConfig {
+    site: SiteConfig,
 }
 
 /// `[[fetch_additional]]` — one additional sequential HTTP fetch.
@@ -218,8 +224,67 @@ pub struct FallbackConfig {
 pub struct SiteConfig {
     /// Provider name (e.g., `"twitter"`, `"youtube"`).
     pub name: String,
+    /// Extraction engine requested for matching URLs.
+    ///
+    /// `"api"` (default) builds a normal [`ApiRuleProvider`]. `"browser"`
+    /// marks the rule as a routing directive: matching URLs skip the API site
+    /// provider path so the fetch ladder can take its browser-capable route.
+    ///
+    /// [`ApiRuleProvider`]: crate::site::rules::provider::ApiRuleProvider
+    #[serde(default)]
+    pub engine: RuleEngine,
     /// List of regex patterns (case-insensitive) that URLs must match.
     pub patterns: Vec<String>,
+}
+
+impl SiteConfig {
+    /// Validate the common `[site]` section fields.
+    fn validate(&self) -> Result<()> {
+        if self.name.is_empty() {
+            bail!("site.name must not be empty");
+        }
+        if self.patterns.is_empty() {
+            bail!("site.patterns must not be empty for rule '{}'", self.name);
+        }
+        for pattern in &self.patterns {
+            regex::Regex::new(pattern).with_context(|| {
+                format!(
+                    "invalid pattern regex '{}' in rule '{}'",
+                    pattern, self.name
+                )
+            })?;
+        }
+        Ok(())
+    }
+}
+
+/// Site rule extraction engine.
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RuleEngine {
+    /// Config-driven API/HTML extraction through [`ApiRuleProvider`].
+    #[default]
+    Api,
+    /// Browser-capable route. The rule is a routing directive, not an API provider.
+    Browser,
+}
+
+impl RuleEngine {
+    /// Return `true` when this rule asks the caller to skip API providers and
+    /// take the browser-capable path instead.
+    #[must_use]
+    pub const fn is_browser(self) -> bool {
+        matches!(self, Self::Browser)
+    }
+
+    /// Return the TOML string representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Api => "api",
+            Self::Browser => "browser",
+        }
+    }
 }
 
 /// `[rewrite]` — URL rewrite configuration.
@@ -461,6 +526,22 @@ pub struct EngagementConfig {
 // ─────────────────────────────────────────────────────────────────────────────
 
 impl SiteRuleConfig {
+    /// Parse and validate only the `[site]` section from a TOML string.
+    ///
+    /// This accepts browser-engine routing rules that intentionally omit API
+    /// provider sections such as `[rewrite]`, `[json]`, and `[template]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the TOML is malformed, `[site]` is missing, or
+    /// common site fields are invalid.
+    pub fn site_from_toml(toml_str: &str) -> Result<SiteConfig> {
+        let config: SiteOnlyConfig =
+            toml::from_str(toml_str).context("failed to parse site rule TOML")?;
+        config.site.validate()?;
+        Ok(config.site)
+    }
+
     /// Parse and validate a TOML string into a [`SiteRuleConfig`].
     ///
     /// # Errors
@@ -475,24 +556,7 @@ impl SiteRuleConfig {
 
     /// Validate that required fields are present and regexes compile.
     fn validate(&self) -> Result<()> {
-        if self.site.name.is_empty() {
-            bail!("site.name must not be empty");
-        }
-        if self.site.patterns.is_empty() {
-            bail!(
-                "site.patterns must not be empty for rule '{}'",
-                self.site.name
-            );
-        }
-        // Validate that each pattern compiles as a regex.
-        for pattern in &self.site.patterns {
-            regex::Regex::new(pattern).with_context(|| {
-                format!(
-                    "invalid pattern regex '{}' in rule '{}'",
-                    pattern, self.site.name
-                )
-            })?;
-        }
+        self.site.validate()?;
         // Validate that the rewrite `from` regex compiles.
         regex::Regex::new(&self.rewrite.from).with_context(|| {
             format!(

--- a/src/site/rules/config_tests.rs
+++ b/src/site/rules/config_tests.rs
@@ -24,8 +24,43 @@ fn stackoverflow_toml() -> &'static str {
 fn parse_twitter_toml_succeeds() {
     let cfg = SiteRuleConfig::from_toml(twitter_toml()).unwrap();
     assert_eq!(cfg.site.name, "twitter");
+    assert_eq!(cfg.site.engine, RuleEngine::Api);
     assert_eq!(cfg.site.patterns.len(), 1);
     assert!(cfg.site.patterns[0].contains("status"));
+}
+
+#[test]
+fn site_engine_defaults_to_api() {
+    let cfg = SiteRuleConfig::from_toml(youtube_toml()).unwrap();
+    assert_eq!(cfg.site.engine, RuleEngine::Api);
+}
+
+#[test]
+fn site_engine_browser_parses_from_site_section_only() {
+    let toml_str = r#"
+[site]
+name = "linkedin-browser"
+engine = "browser"
+patterns = ["(?i)linkedin\\.com/in/"]
+"#;
+
+    let site = SiteRuleConfig::site_from_toml(toml_str).unwrap();
+    assert_eq!(site.name, "linkedin-browser");
+    assert_eq!(site.engine, RuleEngine::Browser);
+    assert!(site.engine.is_browser());
+}
+
+#[test]
+fn site_engine_rejects_unknown_value() {
+    let toml_str = r#"
+[site]
+name = "bad-engine"
+engine = "spaceship"
+patterns = ["example\\.com"]
+"#;
+
+    let err = SiteRuleConfig::site_from_toml(toml_str).unwrap_err();
+    assert!(err.to_string().contains("failed to parse site rule TOML"));
 }
 
 #[test]

--- a/src/site/rules/mod.rs
+++ b/src/site/rules/mod.rs
@@ -37,7 +37,7 @@ use std::path::PathBuf;
 use provider::ApiRuleProvider;
 
 use super::SiteProvider;
-use crate::site::rules::config::SiteRuleConfig;
+use crate::site::rules::config::{RuleEngine, SiteConfig, SiteRuleConfig};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Embedded defaults
@@ -82,6 +82,34 @@ pub fn load_site_rules() -> Vec<Box<dyn SiteProvider>> {
     overrides.into_iter().chain(defaults).collect()
 }
 
+/// Return the configured engine for the first site rule that matches `url`.
+///
+/// User rules in `~/.config/nab/sites/*.toml` are checked before embedded
+/// defaults. Browser-engine rules may contain only a `[site]` section; they
+/// act as routing directives rather than API providers.
+#[must_use]
+pub fn engine_for_url(url: &str) -> Option<RuleEngine> {
+    let (user_sites, overridden_names) = load_user_site_configs();
+
+    if let Some(engine) = matching_engine(url, user_sites.iter()) {
+        return Some(engine);
+    }
+
+    let embedded_sites = embedded_rules()
+        .into_iter()
+        .filter(|(name, _)| !overridden_names.contains(*name))
+        .filter_map(|(name, toml)| match SiteRuleConfig::site_from_toml(toml) {
+            Ok(site) => Some(site),
+            Err(e) => {
+                tracing::warn!("Skipping invalid embedded site rule '{name}': {e}");
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    matching_engine(url, embedded_sites.iter())
+}
+
 /// Returns the set of rule names provided by embedded defaults.
 ///
 /// Useful for [`SiteRouter`] to skip hardcoded Rust providers whose name
@@ -118,13 +146,21 @@ fn load_user_overrides() -> (Vec<Box<dyn SiteProvider>>, HashSet<String>) {
             continue;
         }
         match parse_rule_file(&path) {
-            Ok((name, provider)) => {
+            Ok(ParsedRuleFile::Provider { name, provider }) => {
                 tracing::debug!(
                     "Loaded user site rule override: {name} from {}",
                     path.display()
                 );
                 names.insert(name);
                 providers.push(provider);
+            }
+            Ok(ParsedRuleFile::DirectiveOnly { name, engine }) => {
+                tracing::debug!(
+                    "Loaded user site rule directive: {name} engine={} from {}",
+                    engine.as_str(),
+                    path.display()
+                );
+                names.insert(name);
             }
             Err(e) => {
                 tracing::warn!("Skipping invalid site rule '{}': {e}", path.display());
@@ -150,13 +186,40 @@ fn load_embedded_defaults(overridden_names: &HashSet<String>) -> Vec<Box<dyn Sit
         .collect()
 }
 
-/// Read a TOML file at `path`, parse it, and return `(name, boxed_provider)`.
-fn parse_rule_file(path: &std::path::Path) -> anyhow::Result<(String, Box<dyn SiteProvider>)> {
+enum ParsedRuleFile {
+    Provider {
+        name: String,
+        provider: Box<dyn SiteProvider>,
+    },
+    DirectiveOnly {
+        name: String,
+        engine: RuleEngine,
+    },
+}
+
+/// Read a TOML file at `path`, parse it, and return the provider or directive.
+fn parse_rule_file(path: &std::path::Path) -> anyhow::Result<ParsedRuleFile> {
     let toml = std::fs::read_to_string(path).map_err(|e| anyhow::anyhow!("read error: {e}"))?;
-    let config = SiteRuleConfig::from_toml(&toml)?;
+    parse_rule_toml(&toml)
+}
+
+/// Parse TOML content and return the provider or directive.
+fn parse_rule_toml(toml: &str) -> anyhow::Result<ParsedRuleFile> {
+    let site = SiteRuleConfig::site_from_toml(toml)?;
+    if site.engine.is_browser() {
+        return Ok(ParsedRuleFile::DirectiveOnly {
+            name: site.name,
+            engine: site.engine,
+        });
+    }
+
+    let config = SiteRuleConfig::from_toml(toml)?;
     let name = config.site.name.clone();
     let provider = ApiRuleProvider::new(config)?;
-    Ok((name, Box::new(provider)))
+    Ok(ParsedRuleFile::Provider {
+        name,
+        provider: Box::new(provider),
+    })
 }
 
 /// Parse TOML content and build a boxed [`SiteProvider`].
@@ -164,6 +227,51 @@ pub(crate) fn parse_and_build(toml: &str) -> anyhow::Result<Box<dyn SiteProvider
     let config = SiteRuleConfig::from_toml(toml)?;
     let provider = ApiRuleProvider::new(config)?;
     Ok(Box::new(provider))
+}
+
+/// Load user-supplied `[site]` sections, including browser-only directives.
+fn load_user_site_configs() -> (Vec<SiteConfig>, HashSet<String>) {
+    let sites_dir = user_sites_dir();
+    let mut sites = Vec::new();
+    let mut names = HashSet::new();
+
+    let Ok(entries) = std::fs::read_dir(&sites_dir) else {
+        return (sites, names);
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_none_or(|e| e != "toml") {
+            continue;
+        }
+        let Ok(toml) = std::fs::read_to_string(&path) else {
+            tracing::warn!("Skipping unreadable site rule '{}'", path.display());
+            continue;
+        };
+        match SiteRuleConfig::site_from_toml(&toml) {
+            Ok(site) => {
+                names.insert(site.name.clone());
+                sites.push(site);
+            }
+            Err(e) => tracing::warn!("Skipping invalid site rule '{}': {e}", path.display()),
+        }
+    }
+
+    (sites, names)
+}
+
+fn matching_engine<'a>(
+    url: &str,
+    sites: impl IntoIterator<Item = &'a SiteConfig>,
+) -> Option<RuleEngine> {
+    for site in sites {
+        for pattern in &site.patterns {
+            if regex::Regex::new(pattern).is_ok_and(|re| re.is_match(url)) {
+                return Some(site.engine);
+            }
+        }
+    }
+    None
 }
 
 /// Return `~/.config/nab/sites/`.
@@ -343,6 +451,64 @@ mod tests {
     fn parse_and_build_fails_for_invalid_toml() {
         let result = parse_and_build("not valid toml %%%");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn browser_engine_rule_parses_as_directive_only() {
+        let toml = r#"
+[site]
+name = "linkedin-browser"
+engine = "browser"
+patterns = ["(?i)linkedin\\.com/in/"]
+"#;
+
+        match parse_rule_toml(toml).expect("browser directive") {
+            ParsedRuleFile::DirectiveOnly { name, engine } => {
+                assert_eq!(name, "linkedin-browser");
+                assert_eq!(engine, RuleEngine::Browser);
+            }
+            ParsedRuleFile::Provider { .. } => panic!("browser rule must not build API provider"),
+        }
+    }
+
+    #[test]
+    fn matching_engine_returns_browser_for_matching_pattern() {
+        let site = SiteConfig {
+            name: "linkedin-browser".to_string(),
+            engine: RuleEngine::Browser,
+            patterns: vec![r"(?i)linkedin\.com/in/".to_string()],
+        };
+
+        assert_eq!(
+            matching_engine("https://www.linkedin.com/in/example", [&site]),
+            Some(RuleEngine::Browser)
+        );
+        assert_eq!(matching_engine("https://example.com", [&site]), None);
+    }
+
+    #[test]
+    fn parse_and_build_rejects_browser_engine_api_provider() {
+        let toml = r#"
+[site]
+name = "browser-api"
+engine = "browser"
+patterns = ["example\\.com"]
+
+[rewrite]
+from = ".*"
+to = "https://api.example.com"
+
+[json]
+title = ".title"
+
+[template]
+format = "{title}"
+"#;
+
+        match parse_and_build(toml) {
+            Ok(_) => panic!("browser engine rule must not build an API provider"),
+            Err(err) => assert!(err.to_string().contains("engine='browser'")),
+        }
     }
 
     #[test]

--- a/src/site/rules/provider.rs
+++ b/src/site/rules/provider.rs
@@ -69,6 +69,14 @@ impl ApiRuleProvider {
     ///
     /// Returns an error if any regex in `config` fails to compile.
     pub fn new(config: SiteRuleConfig) -> Result<Self> {
+        if config.site.engine.is_browser() {
+            bail!(
+                "rule '{}' uses engine='{}'; ApiRuleProvider only supports engine='api'",
+                config.site.name,
+                config.site.engine.as_str()
+            );
+        }
+
         let patterns = config
             .site
             .patterns


### PR DESCRIPTION
Refs MIK-3061

## Summary
- Add `[site] engine = "api" | "browser"` to the site-rule TOML schema, defaulting to API behavior.
- Allow browser-engine rules to act as directive-only `[site]` configs and reject them in `ApiRuleProvider` construction.
- Route CLI, context fetch, and MCP fetch around API site providers when a matching rule requests `engine = "browser"`, so the lower-level/browser-capable fetch ladder handles the URL.
- Document the schema and routing behavior in `docs/ARCHITECTURE.md`.

## Validation
- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= cargo test --locked site_engine --lib`
- `RUSTC_WRAPPER= cargo test --locked site::rules --lib`
- `RUSTC_WRAPPER= cargo check --locked --bin nab --bin nab-mcp`
- `RUSTC_WRAPPER= cargo clippy --locked --all-targets -- -D warnings`
- `RUSTC_WRAPPER= cargo test --locked --lib` (1321 passed, 7 ignored)
- `RUSTC_WRAPPER= cargo test --locked --bins` (101 CLI bin tests, 100 MCP bin tests, 0 test_autoupdate tests)
- `git diff --check`
- `cargo audit` (passes with the repo's existing 5 allowed warnings)
- `npx gitnexus analyze` / `npx gitnexus status` (up to date on `e4d73c5` before this commit)

## GitNexus / Risk Notes
- Impact analysis for `load_site_rules` and `matching_engine` reported HIGH blast radius because fetch routing depends on rule loading; direct and downstream callers were covered by targeted rules tests, CLI/MCP binary tests, and full lib tests.
- The documented `gitnexus_detect_changes` command is not exposed by the installed CLI (`unknown command 'detect_changes'`), so scope was verified with refreshed GitNexus index plus `git diff --name-status`.
