### PR TITLE
feat(security): gate WebMCP ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `nab-yara-engine`, a YARA-X fetch-time signature guard wired into CLI `nab fetch`, batch fetch, media fetch output, site-provider output, and MCP `fetch`. It is default-on, redacts matched sections with a clear `NAB YARA SANITIZED` marker, supports `NAB_YARA_ACTION=refuse`, and supports audited emergency bypass with `NAB_YARA_BYPASS=1`.
 - Safe fetch now uses the SSRF-validated socket address for the actual request connection, strips credential-bearing headers across cross-origin redirects, keeps MCP Tor fetches on the configured SOCKS proxy for manually validated redirect hops, and leaves remote `r.jina.ai` thin-content recovery disabled unless `--remote-fallback` is explicitly passed.
+- Secure Ingestion now reports WebMCP manifest advertisements as `DirectiveKind::WebMcpManifest` with `Info` severity for both HTML `<link rel="mcp">` and `/.well-known/mcp.json` manifest bodies. Default behavior remains non-blocking, while `NAB_WEBMCP_STRICT=true` refuses unopted WebMCP ingestion unless the source matches `NAB_WEBMCP_OPT_IN`; rationale: the 2026-04-25 WebMCP scope discussion is browser+human-centric, while nab is a headless agent ingestion surface.
 
 ## [0.10.3] - 2026-04-26
 

--- a/src/content/html.rs
+++ b/src/content/html.rs
@@ -119,7 +119,10 @@ impl HtmlHandler {
     ) -> Result<ConversionResult> {
         let start = std::time::Instant::now();
         let html = String::from_utf8_lossy(bytes);
-        let markdown = html_to_markdown_with_url_and_options(&html, url, options);
+        let (sanitized_html, report) = crate::security::sanitize_with_env_policy(&html, url)?;
+        log_secure_ingestion_report(&report);
+        let markdown =
+            html_to_markdown_sanitized_with_url_and_options(&sanitized_html, url, options);
         let quality = quality::score_extraction(bytes, &markdown);
 
         Ok(ConversionResult {
@@ -158,6 +161,11 @@ pub fn html_to_markdown_with_url_and_options(
     options: HtmlConversionOptions,
 ) -> String {
     let (sanitized_html, report) = crate::security::sanitize(html);
+    log_secure_ingestion_report(&report);
+    html_to_markdown_sanitized_with_url_and_options(&sanitized_html, url, options)
+}
+
+fn log_secure_ingestion_report(report: &crate::security::DetectionReport) {
     if !report.is_clean() {
         tracing::warn!(
             total = report.total(),
@@ -166,10 +174,18 @@ pub fn html_to_markdown_with_url_and_options(
             machine_classes = report.machine_class_count,
             hidden_inline = report.hidden_inline_count,
             aria_hidden = report.aria_hidden_count,
-            "secure ingestion stripped machine-targeted HTML metadata"
+            webmcp_manifests = report.webmcp_manifest_count,
+            "secure ingestion detected or sanitized machine-targeted HTML metadata"
         );
     }
-    html_to_markdown_with_url_and_fetcher(&sanitized_html, url, options, fetch_jina_reader)
+}
+
+fn html_to_markdown_sanitized_with_url_and_options(
+    sanitized_html: &str,
+    url: Option<&str>,
+    options: HtmlConversionOptions,
+) -> String {
+    html_to_markdown_with_url_and_fetcher(sanitized_html, url, options, fetch_jina_reader)
 }
 
 fn html_to_markdown_with_url_and_fetcher<F>(

--- a/src/security/ingestion_guard.rs
+++ b/src/security/ingestion_guard.rs
@@ -2,8 +2,7 @@
 
 //! Detect and strip machine-targeted markup from HTML.
 //!
-//! Five detector kinds, all regex-based for now (the channels we target
-//! are flat-text or attribute-shaped, not deeply nested DOM):
+//! Six detector kinds, all local and non-networked:
 //!
 //! 1. `AiAddressedComment` — HTML comments whose body contains tokens like
 //!    "machine intelligence", "AI agent", "machine-readable".
@@ -17,6 +16,9 @@
 //!    addressed to a non-human audience.
 //! 5. `AriaHiddenText` — `aria-hidden="true"` containers with readable
 //!    text. Severity `Block` for the same reason.
+//! 6. `WebMcpManifest` — `WebMCP` manifest advertisements via HTML
+//!    `<link rel="mcp">` or a manifest JSON body. Severity `Info`; strict
+//!    refusal is controlled by [`IngestionPolicy`].
 //!
 //! ## Public API
 //!
@@ -31,15 +33,21 @@
 //! - `class="m"` → left intact; the visible text was for humans, the
 //!   class is just a styling hook. The agent-only payload travels in the
 //!   `data-*` attributes that this pass already strips.
+//! - `WebMCP` advertisements → reported only; not stripped by default.
 
-use std::sync::OnceLock;
+use std::{error::Error, fmt, sync::OnceLock};
 
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 
 // ── Public types ──────────────────────────────────────────────────────────
 
 /// Severity rating attached to a detection.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub const NAB_WEBMCP_STRICT_ENV: &str = "NAB_WEBMCP_STRICT";
+pub const NAB_WEBMCP_OPT_IN_ENV: &str = "NAB_WEBMCP_OPT_IN";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Severity {
     /// Informational. The site advertises a machine-readable layer; not
     /// adversarial in itself.
@@ -53,7 +61,8 @@ pub enum Severity {
 }
 
 /// Kind of machine-targeted markup detected.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum DirectiveKind {
     /// HTML comment addressed to AI agents
     /// (e.g., `<!-- Machine Intelligence Notice: … -->`).
@@ -67,6 +76,8 @@ pub enum DirectiveKind {
     HiddenInlineStyle,
     /// `aria-hidden="true"` content carrying readable text.
     AriaHiddenText,
+    /// `WebMCP` manifest advertisement via `<link rel="mcp">` or manifest JSON.
+    WebMcpManifest,
 }
 
 /// One detection sample. Holds an excerpt for human review.
@@ -86,6 +97,7 @@ pub struct DetectionReport {
     pub machine_class_count: usize,
     pub hidden_inline_count: usize,
     pub aria_hidden_count: usize,
+    pub webmcp_manifest_count: usize,
     pub samples: Vec<Sample>,
 }
 
@@ -98,6 +110,7 @@ impl DetectionReport {
             + self.machine_class_count
             + self.hidden_inline_count
             + self.aria_hidden_count
+            + self.webmcp_manifest_count
     }
 
     /// `true` if no machine-targeted markup was detected.
@@ -106,6 +119,80 @@ impl DetectionReport {
         self.total() == 0
     }
 }
+
+/// Secure Ingestion policy controls that need operator context.
+///
+/// Detection remains non-destructive and default-permissive. Strict `WebMCP`
+/// refusal is opt-in because legitimate sites may advertise MCP manifests.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct IngestionPolicy {
+    /// Refuse `WebMCP` manifest advertisements unless the source is explicitly opted in.
+    pub webmcp_strict: bool,
+    /// Comma-separated allow-list parsed from `NAB_WEBMCP_OPT_IN`.
+    ///
+    /// Entries may be `*`, a host (`example.com`), an origin
+    /// (`https://example.com`), or an exact URL.
+    pub webmcp_opt_in: Vec<String>,
+}
+
+impl IngestionPolicy {
+    /// Build policy from process environment.
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self::from_env_values(
+            std::env::var(NAB_WEBMCP_STRICT_ENV).ok().as_deref(),
+            std::env::var(NAB_WEBMCP_OPT_IN_ENV).ok().as_deref(),
+        )
+    }
+
+    /// Build policy from explicit env-like values.
+    #[must_use]
+    pub fn from_env_values(strict: Option<&str>, opt_in: Option<&str>) -> Self {
+        let webmcp_strict = strict.is_some_and(is_truthy_env);
+        let webmcp_opt_in = opt_in
+            .unwrap_or_default()
+            .split(',')
+            .map(str::trim)
+            .filter(|entry| !entry.is_empty())
+            .map(str::to_owned)
+            .collect();
+
+        Self {
+            webmcp_strict,
+            webmcp_opt_in,
+        }
+    }
+}
+
+/// Error returned when operator policy refuses ingestion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IngestionGuardError {
+    /// A `WebMCP` manifest was advertised while strict mode was enabled and the
+    /// source was not listed in `NAB_WEBMCP_OPT_IN`.
+    WebMcpManifestRequiresOptIn {
+        source_url: Option<String>,
+        opt_in_env: &'static str,
+    },
+}
+
+impl fmt::Display for IngestionGuardError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WebMcpManifestRequiresOptIn {
+                source_url,
+                opt_in_env,
+            } => {
+                let source = source_url.as_deref().unwrap_or("<unknown source>");
+                write!(
+                    f,
+                    "WebMCP manifest advertised by {source}; strict ingestion requires explicit opt-in via {opt_in_env}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for IngestionGuardError {}
 
 // ── Lazy regexes ──────────────────────────────────────────────────────────
 
@@ -185,6 +272,70 @@ fn excerpt(s: &str) -> String {
     out
 }
 
+fn is_truthy_env(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn detect_webmcp_link(html: &str) -> Option<String> {
+    crate::webmcp::extract_link_href(html).map(|href| format!("WebMCP manifest link: {href}"))
+}
+
+fn detect_webmcp_manifest_json(input: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(input).ok()?;
+    let object = value.as_object()?;
+    if !object.contains_key("tools") && !object.contains_key("serverUrl") {
+        return None;
+    }
+
+    let crate::webmcp::DiscoveryResult::Found(manifest) =
+        crate::webmcp::parse_manifest_bytes(input.as_bytes())
+    else {
+        return None;
+    };
+
+    let name = if manifest.name.is_empty() {
+        "unnamed"
+    } else {
+        manifest.name.as_str()
+    };
+    Some(format!(
+        "WebMCP manifest JSON: {name} ({} tools)",
+        manifest.tools.len()
+    ))
+}
+
+fn webmcp_opted_in(source_url: Option<&str>, opt_in: &[String]) -> bool {
+    if opt_in.iter().any(|entry| entry == "*") {
+        return true;
+    }
+
+    let Some(source_url) = source_url else {
+        return false;
+    };
+    let Ok(source) = url::Url::parse(source_url) else {
+        return opt_in.iter().any(|entry| entry == source_url);
+    };
+    let source_origin = source.origin().ascii_serialization();
+    let source_host = source.host_str();
+
+    opt_in.iter().any(|entry| {
+        if entry == source_url || entry == &source_origin {
+            return true;
+        }
+        if let Ok(allowed_url) = url::Url::parse(entry) {
+            let origin_only = allowed_url.path() == "/"
+                && allowed_url.query().is_none()
+                && allowed_url.fragment().is_none();
+            return allowed_url.as_str() == source_url
+                || (origin_only && allowed_url.origin().ascii_serialization() == source_origin);
+        }
+        source_host.is_some_and(|host| entry == host)
+    })
+}
+
 // ── Public functions ──────────────────────────────────────────────────────
 
 /// Scan `html` for machine-targeted markup. Non-destructive.
@@ -244,6 +395,17 @@ pub fn detect(html: &str) -> DetectionReport {
         }
     }
 
+    if let Some(excerpt_text) =
+        detect_webmcp_link(html).or_else(|| detect_webmcp_manifest_json(html))
+    {
+        report.webmcp_manifest_count += 1;
+        report.samples.push(Sample {
+            kind: DirectiveKind::WebMcpManifest,
+            severity: Severity::Info,
+            excerpt: excerpt(&excerpt_text),
+        });
+    }
+
     report
 }
 
@@ -290,6 +452,57 @@ pub fn sanitize(html: &str) -> (String, DetectionReport) {
     out = machine_attr_re().replace_all(&out, "").into_owned();
 
     (out, report)
+}
+
+/// Enforce operator policy against an already-built detection report.
+///
+/// # Errors
+///
+/// Returns [`IngestionGuardError::WebMcpManifestRequiresOptIn`] when strict
+/// `WebMCP` mode is enabled and the source URL is not explicitly opted in.
+pub fn enforce_policy(
+    report: &DetectionReport,
+    source_url: Option<&str>,
+    policy: &IngestionPolicy,
+) -> Result<(), IngestionGuardError> {
+    if policy.webmcp_strict
+        && report.webmcp_manifest_count > 0
+        && !webmcp_opted_in(source_url, &policy.webmcp_opt_in)
+    {
+        return Err(IngestionGuardError::WebMcpManifestRequiresOptIn {
+            source_url: source_url.map(str::to_owned),
+            opt_in_env: NAB_WEBMCP_OPT_IN_ENV,
+        });
+    }
+
+    Ok(())
+}
+
+/// Strip machine-targeted markup and then enforce caller-provided policy.
+///
+/// # Errors
+///
+/// Returns an [`IngestionGuardError`] when policy refuses ingestion.
+pub fn sanitize_with_policy(
+    html: &str,
+    source_url: Option<&str>,
+    policy: &IngestionPolicy,
+) -> Result<(String, DetectionReport), IngestionGuardError> {
+    let (cleaned, report) = sanitize(html);
+    enforce_policy(&report, source_url, policy)?;
+    Ok((cleaned, report))
+}
+
+/// Strip machine-targeted markup and enforce policy from process environment.
+///
+/// # Errors
+///
+/// Returns an [`IngestionGuardError`] when env-configured policy refuses ingestion.
+pub fn sanitize_with_env_policy(
+    html: &str,
+    source_url: Option<&str>,
+) -> Result<(String, DetectionReport), IngestionGuardError> {
+    sanitize_with_policy(html, source_url, &IngestionPolicy::from_env())
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────
@@ -341,6 +554,32 @@ mod tests {
         let report = detect(html);
         assert_eq!(report.aria_hidden_count, 1);
         assert_eq!(report.samples[0].severity, Severity::Block);
+    }
+
+    #[test]
+    fn directive_kind_webmcp_manifest_json_round_trips() {
+        let json = serde_json::to_string(&DirectiveKind::WebMcpManifest).unwrap();
+        assert_eq!(json, "\"web_mcp_manifest\"");
+        let kind: DirectiveKind = serde_json::from_str(&json).unwrap();
+        assert_eq!(kind, DirectiveKind::WebMcpManifest);
+    }
+
+    #[test]
+    fn detects_webmcp_link_as_info() {
+        let html = r#"<html><head><link rel="mcp" href="/mcp.json"></head></html>"#;
+        let report = detect(html);
+        assert_eq!(report.webmcp_manifest_count, 1);
+        assert_eq!(report.samples[0].kind, DirectiveKind::WebMcpManifest);
+        assert_eq!(report.samples[0].severity, Severity::Info);
+    }
+
+    #[test]
+    fn detects_webmcp_manifest_json_as_info() {
+        let json = r#"{"name":"Docs","description":"","tools":[{"name":"search"}]}"#;
+        let report = detect(json);
+        assert_eq!(report.webmcp_manifest_count, 1);
+        assert_eq!(report.samples[0].kind, DirectiveKind::WebMcpManifest);
+        assert!(report.samples[0].excerpt.contains("Docs"));
     }
 
     #[test]
@@ -397,5 +636,52 @@ mod tests {
         let (out, report) = sanitize(html);
         assert!(report.is_clean());
         assert_eq!(out, html);
+    }
+
+    #[test]
+    fn strict_policy_blocks_unopted_webmcp_manifest() {
+        let html = r#"<link rel="mcp" href="/mcp.json">"#;
+        let policy = IngestionPolicy {
+            webmcp_strict: true,
+            webmcp_opt_in: Vec::new(),
+        };
+        let error =
+            sanitize_with_policy(html, Some("https://example.com/page"), &policy).unwrap_err();
+        assert!(error.to_string().contains(NAB_WEBMCP_OPT_IN_ENV));
+    }
+
+    #[test]
+    fn strict_policy_allows_opted_in_origin() {
+        let html = r#"<link rel="mcp" href="/mcp.json">"#;
+        let policy = IngestionPolicy {
+            webmcp_strict: true,
+            webmcp_opt_in: vec!["https://example.com".to_owned()],
+        };
+        let (out, report) =
+            sanitize_with_policy(html, Some("https://example.com/page"), &policy).unwrap();
+        assert_eq!(report.webmcp_manifest_count, 1);
+        assert!(out.contains("rel=\"mcp\""));
+    }
+
+    #[test]
+    fn strict_policy_url_path_opt_in_requires_exact_url() {
+        let html = r#"<link rel="mcp" href="/mcp.json">"#;
+        let policy = IngestionPolicy {
+            webmcp_strict: true,
+            webmcp_opt_in: vec!["https://example.com/allowed".to_owned()],
+        };
+        let error =
+            sanitize_with_policy(html, Some("https://example.com/other"), &policy).unwrap_err();
+        assert!(error.to_string().contains(NAB_WEBMCP_OPT_IN_ENV));
+
+        sanitize_with_policy(html, Some("https://example.com/allowed"), &policy).unwrap();
+    }
+
+    #[test]
+    fn policy_parses_env_values() {
+        let policy =
+            IngestionPolicy::from_env_values(Some("true"), Some("example.com, https://acme.test"));
+        assert!(policy.webmcp_strict);
+        assert_eq!(policy.webmcp_opt_in, ["example.com", "https://acme.test"]);
     }
 }

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -19,14 +19,17 @@
 //! agent reads the page. Operators can opt back in when they want the
 //! machine-readable layer.
 //!
-//! See [`ingestion_guard`] for the v0 detector + sanitiser. Future work:
-//! `WebMCP` advertisement detection (manifest discovery is in
-//! [`crate::webmcp`]) is on the same trust path; promotion of the `WebMCP`
-//! discovery output into a sanctioned/strict policy gate will land here.
+//! See [`ingestion_guard`] for the detector + sanitiser. `WebMCP`
+//! advertisement detection is informational by default and can be made
+//! strict with `NAB_WEBMCP_STRICT=true` plus an explicit
+//! `NAB_WEBMCP_OPT_IN` allow-list.
 
 pub mod fetch_yara;
 pub mod ingestion_guard;
 pub mod yara_engine;
 
 pub use fetch_yara::{guard_fetch_output, guard_fetch_output_with_config};
-pub use ingestion_guard::{DetectionReport, DirectiveKind, Sample, Severity, detect, sanitize};
+pub use ingestion_guard::{
+    DetectionReport, DirectiveKind, IngestionGuardError, IngestionPolicy, Sample, Severity, detect,
+    enforce_policy, sanitize, sanitize_with_env_policy, sanitize_with_policy,
+};

--- a/tests/fixtures/webmcp/page-with-link.html
+++ b/tests/fixtures/webmcp/page-with-link.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <title>WebMCP fixture</title>
+    <link rel="mcp" href="/.well-known/mcp.json">
+  </head>
+  <body>
+    <main>
+      <h1>Human-readable page</h1>
+      <p>This content should remain visible to normal extraction.</p>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/webmcp/well-known-mcp.json
+++ b/tests/fixtures/webmcp/well-known-mcp.json
@@ -1,0 +1,11 @@
+{
+  "name": "Fixture Docs",
+  "description": "A test WebMCP manifest exposed from /.well-known/mcp.json",
+  "serverUrl": "https://example.com/mcp",
+  "tools": [
+    {
+      "name": "search",
+      "description": "Search the fixture documentation"
+    }
+  ]
+}

--- a/tests/webmcp_ingestion.rs
+++ b/tests/webmcp_ingestion.rs
@@ -1,0 +1,96 @@
+use nab::content::ContentRouter;
+use nab::security::{DirectiveKind, IngestionPolicy, Severity, detect, sanitize_with_policy};
+
+const WEBMCP_LINK_HTML: &str = include_str!("fixtures/webmcp/page-with-link.html");
+const WELL_KNOWN_MANIFEST: &str = include_str!("fixtures/webmcp/well-known-mcp.json");
+
+#[test]
+fn detect_reports_webmcp_link_non_destructively() {
+    let report = detect(WEBMCP_LINK_HTML);
+
+    assert_eq!(report.webmcp_manifest_count, 1);
+    assert!(report.samples.iter().any(|sample| {
+        sample.kind == DirectiveKind::WebMcpManifest && sample.severity == Severity::Info
+    }));
+
+    let (cleaned, report) = sanitize_with_policy(
+        WEBMCP_LINK_HTML,
+        Some("https://example.com/docs"),
+        &IngestionPolicy::default(),
+    )
+    .unwrap();
+    assert_eq!(report.webmcp_manifest_count, 1);
+    assert!(cleaned.contains(r#"rel="mcp""#));
+}
+
+#[test]
+fn detect_reports_well_known_mcp_json_manifest() {
+    let report = detect(WELL_KNOWN_MANIFEST);
+
+    assert_eq!(report.webmcp_manifest_count, 1);
+    assert!(report.samples.iter().any(|sample| {
+        sample.kind == DirectiveKind::WebMcpManifest
+            && sample.severity == Severity::Info
+            && sample.excerpt.contains("Fixture Docs")
+    }));
+}
+
+#[test]
+fn strict_policy_refuses_unopted_webmcp_link() {
+    let policy = IngestionPolicy {
+        webmcp_strict: true,
+        webmcp_opt_in: Vec::new(),
+    };
+
+    let error = sanitize_with_policy(WEBMCP_LINK_HTML, Some("https://example.com/docs"), &policy)
+        .unwrap_err();
+
+    let message = error.to_string();
+    assert!(message.contains("WebMCP manifest"));
+    assert!(message.contains("NAB_WEBMCP_OPT_IN"));
+}
+
+#[test]
+fn strict_policy_allows_explicitly_opted_host() {
+    let policy = IngestionPolicy {
+        webmcp_strict: true,
+        webmcp_opt_in: vec!["example.com".to_owned()],
+    };
+
+    let (cleaned, report) =
+        sanitize_with_policy(WEBMCP_LINK_HTML, Some("https://example.com/docs"), &policy).unwrap();
+
+    assert_eq!(report.webmcp_manifest_count, 1);
+    assert!(cleaned.contains(r#"href="/.well-known/mcp.json""#));
+}
+
+#[test]
+fn strict_policy_refuses_unopted_well_known_manifest() {
+    let policy = IngestionPolicy {
+        webmcp_strict: true,
+        webmcp_opt_in: Vec::new(),
+    };
+
+    let error = sanitize_with_policy(
+        WELL_KNOWN_MANIFEST,
+        Some("https://example.com/.well-known/mcp.json"),
+        &policy,
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("NAB_WEBMCP_OPT_IN"));
+}
+
+#[test]
+fn content_router_converts_webmcp_link_by_default() {
+    let router = ContentRouter::new();
+    let conversion = router
+        .convert_with_url(
+            WEBMCP_LINK_HTML.as_bytes(),
+            "text/html",
+            Some("https://example.com/docs"),
+        )
+        .unwrap();
+
+    assert!(conversion.markdown.contains("Human-readable page"));
+}


### PR DESCRIPTION
Refs MIK-3048

## Summary
- add `DirectiveKind::WebMcpManifest` as an informational Secure Ingestion directive with serde JSON roundtrip coverage
- wire WebMCP manifest/link detection into Secure Ingestion and the HTML `ContentRouter` path without stripping by default
- add strict WebMCP policy via `NAB_WEBMCP_STRICT=true` and `NAB_WEBMCP_OPT_IN`
- add HTML `<link rel="mcp">` and `/.well-known/mcp.json` fixtures plus integration coverage
- document the v0.11.0 behavior and rationale in the changelog

## Validation
- `cargo fmt --all -- --check`
- `RUSTC_WRAPPER= cargo test --locked ingestion_guard --lib`
- `RUSTC_WRAPPER= cargo test --locked --test webmcp_ingestion`
- `RUSTC_WRAPPER= cargo test --locked webmcp --lib`
- `RUSTC_WRAPPER= cargo test --locked html --lib`
- `RUSTC_WRAPPER= cargo test --locked --test html_tests`
- `RUSTC_WRAPPER= cargo test --locked content:: --lib`
- `RUSTC_WRAPPER= cargo check --locked --bin nab --bin nab-mcp`
- `RUSTC_WRAPPER= cargo clippy --locked --all-targets -- -D warnings`
- `RUSTC_WRAPPER= cargo test --locked --lib`
- `RUSTC_WRAPPER= cargo test --locked --bins`
- `RUSTC_WRAPPER= cargo test --locked --tests`
- `git diff --check`
- `git diff --cached --check`
- `cargo audit` (passes with existing allowed warnings)
- `npx gitnexus analyze` + `npx gitnexus status` at commit `b4b2e5d`

## Risk notes
- GitNexus impact was LOW for `DirectiveKind` and `DetectionReport`.
- GitNexus impact was CRITICAL for `detect`, `sanitize`, `html_to_markdown_with_url_and_options`, and `to_markdown_with_url_and_options` because they sit on shared ingestion/content-router paths. The change is additive/default-permissive, strict mode is env-gated, and broad content/security tests passed.
- This installed GitNexus CLI does not expose `detect_changes` (`unknown command 'detect_changes'`), so diff scope and post-commit indexing were used as the fallback scope evidence.
