### PR TITLE
docs: capture Browser Run interactive mode spike

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -12,6 +12,14 @@ Three features that landed in 0.7.0 and unlock the multimodal local-first story.
 | [url-watch-resources.md](url-watch-resources.md) | shipped (0.7.0) | URL monitoring exposed as MCP subscribable resources. RSS for the entire web. Conditional GETs, semantic diff, adaptive backoff. New `watch_create`/`watch_list`/`watch_remove` MCP tools. |
 | [active-reading.md](active-reading.md) | shipped (0.7.0) | Active reading via MCP `sampling/createMessage`. nab calls back to the host LLM to identify references in transcripts and inlines them as footnotes. Novel for ASR pipelines. |
 
+## Browser rendering and JS-heavy pages
+
+Keeping the default path HTTP-first while defining explicit browser-rendering escalation.
+
+| Document | Status | Summary |
+|----------|--------|---------|
+| [browser-run-interactive-mode.md](browser-run-interactive-mode.md) | research spike | Cloudflare Browser Run / Browserbase / external-CDP build-vs-buy note for `nab browser`, with live Browser Run latency and cost evidence. |
+
 ## Phase 2 — MCP spec closure
 
 Bringing nab from ~80% to 100% MCP 2025-11-25 spec compliance.

--- a/docs/design/browser-run-interactive-mode.md
+++ b/docs/design/browser-run-interactive-mode.md
@@ -1,0 +1,116 @@
+# Browser Run Interactive Mode Spike
+
+Status: research spike + follow-up issue filed
+Date: 2026-05-12
+Phase: MIK-2924 Phase 1 / Phase 2 scoping
+Novelty: opt-in remote browser runtime for JS-heavy pages, without changing nab's HTTP-first default
+
+## Thesis
+
+`nab fetch` should stay a fast, local-first HTTP microfetch path. Browser rendering is still useful for the narrow class of pages that require live JavaScript execution, DOM interaction, or login/CAPTCHA handoff. The right shape is provider-neutral and explicit: `nab browser <url>` or `nab fetch --render/--interactive` should connect to a configured CDP browser endpoint, while default `nab fetch` only suggests that path when thin-content/SPA heuristics fire.
+
+## Source Check
+
+Cloudflare's Browser Run docs now expose two integration categories:
+
+- Quick Actions for simple screenshot/PDF/scrape/markdown/json/crawl jobs.
+- Browser Sessions for direct control through Puppeteer, Playwright, CDP, Stagehand, and MCP clients.
+
+Current Cloudflare pricing, checked 2026-05-12:
+
+- Free: 10 browser minutes per day.
+- Workers Paid: 10 browser hours per month included, then $0.09 per additional browser hour.
+- Browser Sessions also charge for concurrency: 10 concurrent browsers averaged monthly included, then $2.00 per additional browser.
+- Paid plan limits list 120 concurrent Browser Sessions, one new Browser Session per second, and 10 Quick Actions per second.
+
+Browserbase pricing, checked 2026-05-12:
+
+- Free: 1 browser hour and 3 concurrent browsers.
+- Developer: $20/month, 100 browser hours, 25 concurrent browsers, then $0.12/browser hour.
+- Startup: $99/month, 500 browser hours, 100 concurrent browsers, then $0.10/browser hour.
+- Browserbase documents a one-minute minimum for browser sessions.
+
+Anchor Browser did not expose comparable public pricing during this spike, so it stays out of the cost table until quote-backed numbers exist.
+
+## Live Browser Run Trial
+
+Environment already had `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_BROWSER_RUN_TOKEN`, and `wrangler` installed. No secret values were printed or recorded.
+
+Representative task:
+
+1. Connect to Browser Run over CDP WebSocket.
+2. Navigate to `https://developers.cloudflare.com/browser-run/`.
+3. Click the `Pricing` navigation link.
+4. Extract the resulting page URL, heading, and body text marker.
+
+10-trial result:
+
+| Metric | Result |
+| --- | ---: |
+| Success rate | 10/10 |
+| Average latency | 707 ms |
+| Median latency | 566 ms |
+| p95 latency | 1361 ms |
+| Total browser time measured locally | 7401 ms |
+| Marginal browser-hour cost at $0.09/hour | $0.000185 |
+
+This is comfortably below the ticket's fail-fast threshold of $0.50 for a 3-step browsing task. The measurement is a controlled docs-site workflow, not a guarantee for CAPTCHA-heavy or authenticated SaaS workflows.
+
+## Decision
+
+Build the `nab` interface as a provider-neutral external CDP path, not a Cloudflare-specific integration.
+
+Recommended first implementation:
+
+```text
+nab browser <url> [--cdp-url <wss://...>] [--headers-env <ENV_NAME>]
+nab fetch <url> --render
+nab fetch <url> --interactive
+```
+
+Default behavior:
+
+- `nab fetch` never auto-launches a local browser or remote browser provider.
+- Thin-content/SPA heuristics may print a hint that suggests `nab browser`.
+- Remote browser providers are disabled unless explicitly configured.
+- Cookie/session handoff must be documented as provider-boundary-sensitive. Local browser cookies do not automatically become remote browser cookies.
+
+Configuration should prefer env or existing config extension:
+
+```text
+NAB_BROWSER_CDP_WS=wss://...
+NAB_BROWSER_CDP_HEADERS_ENV=NAB_BROWSER_CDP_HEADERS
+NAB_BROWSER_PROVIDER=cdp
+```
+
+The browser implementation should accept Cloudflare Browser Run, Browserbase, and a local Chrome `--remote-debugging-port` session through the same CDP adapter. Provider-specific setup belongs in docs, not in the core execution path.
+
+## Why Not Bundle Chromium
+
+The ticket's kill criterion is correct: a 100+ MB bundled Chromium fallback would undermine nab's single-binary, fast-install story. Keep `browser` feature-gated and external-provider-based. A local Chromium path is acceptable only when the user already has a browser running with CDP enabled.
+
+## Public Follow-Up
+
+Filed public GitHub issue:
+
+- https://github.com/MikkoParkkola/nab/issues/93
+
+Issue #93 carries the implementation acceptance criteria for the `nab`-owned slice. MIK-2924 should remain the cross-product decision record.
+
+## Product Recommendation
+
+- Botnaut interactive web browsing: buy before build. Browser Run is viable and cheap for early usage when Cloudflare is already acceptable infrastructure. Browserbase remains a credible alternative when built-in identity/CAPTCHA/session inspector features outweigh the higher base plan price. Native Playwright infrastructure should require a concrete sovereignty or high-volume cost reason.
+- nab: implement only explicit render/interactive mode. Do not reposition nab as a browser.
+- WebMCP markup: continue tracking, but treat it as early-preview browser-agent surface area. For nab itself, Secure Ingestion should detect WebMCP manifests defensively before nab encourages public docs to advertise them.
+
+## References
+
+- Cloudflare Browser Run overview: https://developers.cloudflare.com/browser-run/
+- Cloudflare Browser Run MCP/CDP client docs: https://developers.cloudflare.com/browser-run/cdp/mcp-clients/
+- Cloudflare Browser Run pricing: https://developers.cloudflare.com/browser-run/pricing/
+- Cloudflare Browser Run limits: https://developers.cloudflare.com/browser-run/limits/
+- Cloudflare launch post: https://blog.cloudflare.com/browser-run-for-ai-agents/
+- Chrome WebMCP early preview: https://developer.chrome.com/blog/webmcp-epp
+- Chrome DevTools MCP: https://github.com/ChromeDevTools/chrome-devtools-mcp
+- Browserbase pricing: https://www.browserbase.com/pricing/
+- Browserbase concurrency docs: https://docs.browserbase.com/optimizations/concurrency/overview


### PR DESCRIPTION
Refs MIK-2924

## Summary
- records the MIK-2924 Browser Run / Browserbase / external-CDP source check in a public-safe nab design note
- includes live Browser Run CDP trial evidence for navigate -> click -> extract over 10 trials
- recommends a provider-neutral explicit `nab browser` / `--render` / `--interactive` path, preserving HTTP-first defaults
- links public follow-up issue #93 for the implementation slice

## Live Trial Evidence
- Browser Run credentials were already present locally; no secret values were printed or committed
- task: connect over CDP, navigate to Browser Run docs, click Pricing, extract page metadata/text marker
- result: 10/10 successful trials, avg 707ms, p50 566ms, p95 1361ms
- measured local total: 7401ms; marginal browser-hour cost at Cloudflare listed $0.09/hour: about $0.000185

## Validation
- `git diff --check`
- `git diff --cached --check`
- `npx gitnexus analyze` + `npx gitnexus status` at commit `c9b61ec`

## Notes
- Docs-only change; no Rust code path changed, so cargo build/test was not rerun for this PR.
- GitNexus `detect_changes` is unavailable in this installed CLI (`unknown command 'detect_changes'` from prior checks), so diff scope + post-commit index status are the scope evidence.
