### PR TITLE
style: cargo fmt — restore CI green

### DIFF
--- a/src/cmd/cookies.rs
+++ b/src/cmd/cookies.rs
@@ -83,9 +83,8 @@ fn cmd_cookies_export(domain: &str, browser: &str) -> Result<()> {
 /// residual case where cookies live on other subdomains the user must specify
 /// explicitly.
 fn bare_domain_thin_result_warning(domain: &str, cookie_count: usize) -> Option<String> {
-    let is_bare_domain = !domain.starts_with('.')
-        && !domain.starts_with("www.")
-        && domain.split('.').count() == 2;
+    let is_bare_domain =
+        !domain.starts_with('.') && !domain.starts_with("www.") && domain.split('.').count() == 2;
     if is_bare_domain && cookie_count < THIN_COOKIE_RESULT_THRESHOLD {
         Some(format!(
             "⚠️  Only {cookie_count} cookies found for bare domain '{domain}'. \

--- a/tests/yara_guard.rs
+++ b/tests/yara_guard.rs
@@ -336,9 +336,7 @@ fn materialize_sample(rule_id: &str, sample: &str) -> String {
             debug_assert_eq!(sample, "__NAB_FIXTURE_SLACK_BOT_TOKEN__");
             // Regex: xox[baprs]-[0-9]{10,}-[0-9]{10,}-[A-Za-z0-9]{20,}
             let prefix = ["xo", "xb"].concat();
-            format!(
-                "SLACK_BOT_TOKEN={prefix}-{zeros10}-{zeros10}-{marker_alnum}0"
-            )
+            format!("SLACK_BOT_TOKEN={prefix}-{zeros10}-{zeros10}-{marker_alnum}0")
         }
         "secret_openai_key" => {
             debug_assert_eq!(sample, "__NAB_FIXTURE_OPENAI_API_KEY__");


### PR DESCRIPTION
## Summary

`cargo fmt` on `src/cmd/cookies.rs:83` + `tests/yara_guard.rs:336`. Two whitespace deviations were failing the Format CI step in the last 3 runs on main.

## Scope clarification

This PR restores **Format** to green only. Other CI jobs:

- ✅ **Format** — fixed by this PR
- ✅ Build, Test, Security Audit, Secrets scan — green
- ❌ **Clippy** — failing pre-PR on main with `unresolved import nab_yara_engine` (verified locally). Pre-existing, NOT a regression of this PR. Tracked as MIK-4390 follow-up.
- ⏸ Test (ubuntu-default) — pending; orthogonal to this fix

Clippy root cause: `tests/yara_guard.rs` references workspace member crate without dev-dep declaration; `cargo clippy --all-targets` runs the test without the wiring. Naive dev-dep addition pulls encoding_rs transitive issues; needs proper feature-gated solution.

## Why
Public-repo health sweep (MIK-4390). nab is a load-bearing portfolio repo. This PR clears the cheapest red light; clippy fix scoped separately for a clean focused PR.

## Test plan
- [x] cargo fmt --check passes locally
- [x] Format CI step passes
- [ ] Clippy fix tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)