### PR TITLE
fix(fetch): browser-profile fallback for --cookies auto on Cloudflare challenge (#117)

### DIFF
--- a/src/auth/cookies/fallback.rs
+++ b/src/auth/cookies/fallback.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+//! Browser-profile fallback for `--cookies auto`.
+//!
+//! When `auto` picks a single browser profile and the resulting response is a
+//! bot / Cloudflare challenge (the chosen profile lacks valid clearance cookies
+//! for the target domain), nab retries with the remaining available browser
+//! profiles in a deterministic order and returns the first non-challenge
+//! response.
+//!
+//! The core loop ([`fallback_over_profiles`]) is generic over an injected
+//! "attempt" closure so it can be unit-tested with canned responses — no
+//! network and no real browser cookie store required. Production wires the
+//! closure to the live HTTP path; tests wire it to a lookup table.
+//!
+//! Challenge detection reuses the shared
+//! [`crate::content::response_classifier::classify_http_response`] classifier
+//! (the same one the CLI fetch diagnostics use), so the fallback fires on
+//! exactly the markers the issue describes (`cf-chl-`, `"just a moment..."`,
+//! `cf-browser-verification`, …) without a second bespoke detector.
+
+use std::future::Future;
+
+use super::CookieSource;
+use crate::content::response_classifier::{ResponseDiagnosticKind, classify_http_response};
+
+/// Deterministic order in which `auto` fallback considers browser profiles.
+///
+/// Edge and Dia collapse onto [`CookieSource::Chrome`] (they share the Chromium
+/// cookie store), so the list is intentionally de-duplicated by *cookie source*
+/// rather than by browser name.
+pub const FALLBACK_ORDER: [CookieSource; 4] = [
+    CookieSource::Brave,
+    CookieSource::Chrome,
+    CookieSource::Firefox,
+    CookieSource::Safari,
+];
+
+/// Build the ordered list of fallback candidates, excluding the profile that
+/// `auto` already tried.
+///
+/// The result preserves [`FALLBACK_ORDER`] and drops `already_tried` so each
+/// remaining profile is attempted at most once.
+#[must_use]
+pub fn fallback_candidates(already_tried: CookieSource) -> Vec<CookieSource> {
+    FALLBACK_ORDER
+        .iter()
+        .copied()
+        .filter(|source| *source != already_tried)
+        .collect()
+}
+
+/// Whether a `(status, body)` pair is a bot / browser challenge that should
+/// trigger profile fallback.
+///
+/// Returns `true` only for [`ResponseDiagnosticKind::BrowserChallenge`] classes
+/// (Cloudflare, Turnstile, CAPTCHA interstitial, AWS WAF, …). Auth walls, rate
+/// limits, and clean responses do **not** trigger fallback — a different
+/// cookie profile cannot fix those.
+#[must_use]
+pub fn is_challenge(status: u16, body: &str) -> bool {
+    matches!(
+        classify_http_response(status, body).map(|d| d.kind),
+        Some(ResponseDiagnosticKind::BrowserChallenge(_))
+    )
+}
+
+/// Outcome of the per-profile attempt closure.
+///
+/// `Available` carries the `(status, body)` the profile produced. `Unavailable`
+/// means the profile had no usable cookies for the domain (empty cookie store
+/// or no cookies for the target) and therefore does not count as an attempt.
+pub enum AttemptOutcome {
+    /// The profile produced a response.
+    Available { status: u16, body: String },
+    /// The profile had no cookies for the domain; skip without counting it.
+    Unavailable,
+}
+
+/// Result of running the fallback loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FallbackResult {
+    /// A profile produced a non-challenge response. Carries the winning
+    /// profile so the caller can re-resolve cookies / log it.
+    Resolved {
+        source: CookieSource,
+        status: u16,
+        body: String,
+    },
+    /// Every available profile still returned a challenge (or none were
+    /// available). The caller should keep its original response (AC NAB.COOKIE.3).
+    Exhausted { tried: Vec<CookieSource> },
+}
+
+/// Iterate `candidates`, calling `attempt` for each, and return the first
+/// profile whose response is **not** a challenge.
+///
+/// * Profiles reported [`AttemptOutcome::Unavailable`] are skipped and not
+///   recorded as "tried" (they were never actually fetched with).
+/// * The loop is bounded: each candidate is attempted at most once.
+/// * On exhaustion, returns [`FallbackResult::Exhausted`] listing the profiles
+///   that were actually attempted, so the caller can warn and keep the original
+///   response instead of erroring.
+///
+/// The closure is async and fallible-free by construction: it maps a
+/// [`CookieSource`] to an [`AttemptOutcome`]. Production resolves cookies and
+/// performs the HTTP request inside it; tests return canned outcomes.
+pub async fn fallback_over_profiles<F, Fut>(
+    candidates: Vec<CookieSource>,
+    mut attempt: F,
+) -> FallbackResult
+where
+    F: FnMut(CookieSource) -> Fut,
+    Fut: Future<Output = AttemptOutcome>,
+{
+    let mut tried = Vec::new();
+    for source in candidates {
+        match attempt(source).await {
+            AttemptOutcome::Unavailable => {}
+            AttemptOutcome::Available { status, body } => {
+                tried.push(source);
+                if !is_challenge(status, &body) {
+                    return FallbackResult::Resolved {
+                        source,
+                        status,
+                        body,
+                    };
+                }
+            }
+        }
+    }
+    FallbackResult::Exhausted { tried }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::{
+        AttemptOutcome, CookieSource, FallbackResult, fallback_candidates, fallback_over_profiles,
+        is_challenge,
+    };
+
+    const CHALLENGE_BODY: &str = "<html><head><title>Just a moment...</title></head><body>\
+         <div id='challenge-error-text'>Enable JavaScript and cookies to continue</div>\
+         <div id='cf-chl-widget'></div></body></html>";
+    const CLEAN_BODY: &str =
+        "<html><body><article><h1>Real Article</h1><p>Lots of words.</p></article></body></html>";
+
+    #[test]
+    fn challenge_body_with_cloudflare_markers_is_detected() {
+        // GIVEN a 403 Cloudflare interstitial — WHEN classified — THEN it is a challenge.
+        assert!(is_challenge(403, CHALLENGE_BODY));
+    }
+
+    #[test]
+    fn clean_article_is_not_a_challenge() {
+        // GIVEN a normal 200 article — WHEN classified — THEN no fallback triggers.
+        assert!(!is_challenge(200, CLEAN_BODY));
+    }
+
+    #[test]
+    fn fallback_candidates_excludes_already_tried_and_keeps_order() {
+        // GIVEN auto picked Brave — WHEN building candidates — THEN Brave is dropped, order preserved.
+        let candidates = fallback_candidates(CookieSource::Brave);
+        assert_eq!(
+            candidates,
+            vec![
+                CookieSource::Chrome,
+                CookieSource::Firefox,
+                CookieSource::Safari
+            ]
+        );
+    }
+
+    /// AC NAB.COOKIE.4 — mock a 403-challenge from profile A and 200 from
+    /// profile B; assert auto returns B's body.
+    #[tokio::test]
+    async fn fallback_returns_first_clean_profile_body() {
+        // GIVEN Chrome challenges and Firefox returns clean content.
+        let mut table: HashMap<CookieSource, (u16, &str)> = HashMap::new();
+        table.insert(CookieSource::Chrome, (403, CHALLENGE_BODY));
+        table.insert(CookieSource::Firefox, (200, CLEAN_BODY));
+        table.insert(CookieSource::Safari, (200, CLEAN_BODY));
+
+        // WHEN we fall back over Brave's siblings.
+        let result = fallback_over_profiles(fallback_candidates(CookieSource::Brave), |source| {
+            let entry = table.get(&source).copied();
+            async move {
+                match entry {
+                    Some((status, body)) => AttemptOutcome::Available {
+                        status,
+                        body: body.to_string(),
+                    },
+                    None => AttemptOutcome::Unavailable,
+                }
+            }
+        })
+        .await;
+
+        // THEN Firefox (first clean profile in order) wins.
+        match result {
+            FallbackResult::Resolved { source, body, .. } => {
+                assert_eq!(source, CookieSource::Firefox);
+                assert_eq!(body, CLEAN_BODY);
+            }
+            FallbackResult::Exhausted { .. } => panic!("expected a clean profile to resolve"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unavailable_profiles_are_skipped_not_counted() {
+        // GIVEN Chrome/Safari have no cookies and Firefox is clean.
+        let result = fallback_over_profiles(fallback_candidates(CookieSource::Brave), |source| {
+            let outcome = match source {
+                CookieSource::Firefox => AttemptOutcome::Available {
+                    status: 200,
+                    body: CLEAN_BODY.to_string(),
+                },
+                _ => AttemptOutcome::Unavailable,
+            };
+            async move { outcome }
+        })
+        .await;
+
+        // THEN Firefox resolves and the empty profiles were never tried.
+        assert_eq!(
+            result,
+            FallbackResult::Resolved {
+                source: CookieSource::Firefox,
+                status: 200,
+                body: CLEAN_BODY.to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn all_profiles_challenged_returns_exhausted_with_tried_list() {
+        // GIVEN every available profile still returns a challenge.
+        let result = fallback_over_profiles(fallback_candidates(CookieSource::Brave), |source| {
+            let outcome = match source {
+                CookieSource::Safari => AttemptOutcome::Unavailable,
+                _ => AttemptOutcome::Available {
+                    status: 403,
+                    body: CHALLENGE_BODY.to_string(),
+                },
+            };
+            async move { outcome }
+        })
+        .await;
+
+        // THEN the loop reports exhaustion naming exactly the attempted profiles.
+        assert_eq!(
+            result,
+            FallbackResult::Exhausted {
+                tried: vec![CookieSource::Chrome, CookieSource::Firefox],
+            }
+        );
+    }
+}

--- a/src/auth/cookies/mod.rs
+++ b/src/auth/cookies/mod.rs
@@ -15,6 +15,7 @@ pub use crypto::{decrypt_cookie_value, derive_cookie_key};
 
 mod crypto;
 mod db;
+pub mod fallback;
 #[cfg(test)]
 mod tests;
 
@@ -30,7 +31,7 @@ use db::{copy_db_to_temp, decrypt_rows, domain_candidates, has_domain_tag, query
 // ─── CookieSource ─────────────────────────────────────────────────────────────
 
 /// Cookie source for browser cookie extraction.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CookieSource {
     Brave,
     Chrome,

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -278,6 +278,28 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
             execute_manual_request(&client, cfg, &profile, &cookie_header).await?
         };
 
+    // ── `--cookies auto` browser-profile fallback (issue #117) ────────────
+    // When `auto` picked one browser whose cookies were absent/stale for this
+    // domain, the response may be a Cloudflare/bot challenge. Retry with the
+    // remaining available browser profiles and adopt the first clean response.
+    // No-op for explicit `--cookies <browser>` and for non-challenge responses.
+    let (status, version, set_cookies, content_type, response_headers, body_bytes) =
+        maybe_fallback_cookie_profiles(
+            &client,
+            cfg,
+            &profile,
+            &domain,
+            (
+                status,
+                version,
+                set_cookies,
+                content_type,
+                response_headers,
+                body_bytes,
+            ),
+        )
+        .await?;
+
     let elapsed = start.elapsed();
     let raw_text = String::from_utf8_lossy(&body_bytes).to_string();
 
@@ -625,6 +647,124 @@ async fn execute_manual_request(
         resp_headers,
         safe_resp.body,
     ))
+}
+
+/// The six-field response payload threaded through the fetch pipeline.
+type FetchResponseTuple = (
+    reqwest::StatusCode,
+    String,
+    Vec<String>,
+    String,
+    Vec<(String, String)>,
+    bytes::Bytes,
+);
+
+/// Browser-profile fallback for `--cookies auto` (issue #117).
+///
+/// When `auto` selects a single browser profile and the resulting response is
+/// a bot / Cloudflare challenge, retry with the remaining available browser
+/// profiles (Brave → Chrome → Firefox → Safari, minus the auto-picked one) and
+/// return the first non-challenge response.
+///
+/// Bounded: each remaining profile is attempted at most once, and only when it
+/// actually holds cookies for the domain. Cheap: the loop never runs on a clean
+/// initial response, nor for explicit `--cookies <browser>`. On exhaustion the
+/// original response is returned unchanged with a warning naming the profiles
+/// tried (AC NAB.COOKIE.3).
+async fn maybe_fallback_cookie_profiles(
+    client: &AcceleratedClient,
+    cfg: &FetchConfig,
+    profile: &nab::fingerprint::BrowserProfile,
+    domain: &str,
+    initial: FetchResponseTuple,
+) -> Result<FetchResponseTuple> {
+    use nab::auth::cookies::fallback::{
+        AttemptOutcome, FallbackResult, fallback_candidates, fallback_over_profiles, is_challenge,
+    };
+
+    // Gate 1: only the `auto` default escalates. Explicit profiles are honoured.
+    if !cfg.cookies.eq_ignore_ascii_case("auto") {
+        return Ok(initial);
+    }
+    // Gate 2: only escalate on a detected challenge.
+    let initial_is_challenge =
+        is_challenge(initial.0.as_u16(), &String::from_utf8_lossy(&initial.5));
+    if !initial_is_challenge {
+        return Ok(initial);
+    }
+
+    // The profile `auto` already used — exclude it from the candidate set so it
+    // is not re-attempted.
+    let auto_source = nab::detect_default_browser().map_or(nab::CookieSource::Chrome, |b| {
+        nab::CookieSource::from_browser_name(b.as_str())
+    });
+    let candidates = fallback_candidates(auto_source);
+
+    tracing::info!(
+        domain = %domain,
+        ?candidates,
+        "cookies=auto profile returned a challenge; trying fallback browser profiles"
+    );
+
+    // Capture each attempt's full response so the winning profile does not need
+    // a second network round-trip. The loop awaits attempts sequentially, so the
+    // `RefCell` is never borrowed concurrently.
+    let last_response: std::cell::RefCell<Option<FetchResponseTuple>> =
+        std::cell::RefCell::new(None);
+
+    let outcome = fallback_over_profiles(candidates, |source| {
+        // Per-profile attempt: resolve that profile's cookies and, if present,
+        // re-issue the request with them. Empty cookies ⇒ profile unavailable.
+        let cookie_header = source.get_cookie_header(domain).unwrap_or_default();
+        let last_response = &last_response;
+        async move {
+            if cookie_header.is_empty() {
+                return AttemptOutcome::Unavailable;
+            }
+            tracing::info!(?source, "retrying fetch with fallback browser cookies");
+            match execute_manual_request(client, cfg, profile, &cookie_header).await {
+                Ok(resp) => {
+                    let status = resp.0.as_u16();
+                    let body = String::from_utf8_lossy(&resp.5).to_string();
+                    *last_response.borrow_mut() = Some(resp);
+                    AttemptOutcome::Available { status, body }
+                }
+                Err(e) => {
+                    tracing::warn!(?source, error = %e, "fallback profile request failed");
+                    AttemptOutcome::Unavailable
+                }
+            }
+        }
+    })
+    .await;
+
+    match outcome {
+        FallbackResult::Resolved { source, .. } => {
+            tracing::info!(?source, "fallback browser profile cleared the challenge");
+            // The winning response was captured during the attempt; reuse it
+            // rather than issuing a redundant request.
+            last_response.into_inner().map_or_else(|| Ok(initial), Ok)
+        }
+        FallbackResult::Exhausted { tried } => {
+            let names: Vec<&str> = tried.iter().copied().map(cookie_source_name).collect();
+            tracing::warn!(
+                tried = ?names,
+                "all fallback browser profiles still returned a challenge; \
+                 returning the original response"
+            );
+            Ok(initial)
+        }
+    }
+}
+
+/// Human-readable name for a [`nab::CookieSource`], used in fallback warnings.
+fn cookie_source_name(source: nab::CookieSource) -> &'static str {
+    match source {
+        nab::CookieSource::Brave => "brave",
+        nab::CookieSource::Chrome => "chrome",
+        nab::CookieSource::Firefox => "firefox",
+        nab::CookieSource::Safari => "safari",
+    }
 }
 
 /// Attempt to recover article content from Next.js webpack content chunks.

--- a/src/content/response_classifier.rs
+++ b/src/content/response_classifier.rs
@@ -506,6 +506,13 @@ fn looks_like_cloudflare_challenge(body_lower: &str) -> bool {
             "cf-browser-verification",
             "cf-chl-",
             "cf-challenge",
+            // Cloudflare "managed challenge" interstitials center on this DOM
+            // hook plus the "enable javascript and cookies" copy rather than the
+            // legacy `cf-browser-verification` / "just a moment" markup. Issue
+            // #117: a Brave profile with no clearance cookie hit exactly this
+            // page, so the auto-fallback must recognise it.
+            "challenge-error-text",
+            "enable javascript and cookies to continue",
             "checking your browser before accessing",
             "just a moment...",
             "cloudflare ray id",
@@ -686,6 +693,39 @@ mod tests {
     fn classify_http_response_detects_cloudflare_challenge() {
         let body = "<div id='cf-browser-verification'>Please wait...</div>";
         let diagnostic = classify_http_response(403, body).expect("cloudflare classification");
+        assert_eq!(
+            diagnostic.kind,
+            ResponseDiagnosticKind::BrowserChallenge(BrowserChallengeKind::Cloudflare)
+        );
+    }
+
+    /// Issue #117 — the repro Medium URL returns a Cloudflare *managed
+    /// challenge* whose body carries `challenge-error-text` and the "enable
+    /// javascript and cookies" copy rather than the legacy
+    /// `cf-browser-verification` markup. The `--cookies auto` fallback hinges on
+    /// this 403 being classified as a `BrowserChallenge`, so lock the
+    /// real-world marker text into the regression suite.
+    #[test]
+    fn classify_http_response_detects_cloudflare_managed_challenge_from_issue_117() {
+        let body = "<!DOCTYPE html><html><head><title>Just a moment...</title></head>\
+             <body><div id=\"challenge-error-text\">\
+             Enable JavaScript and cookies to continue</div></body></html>";
+        let diagnostic =
+            classify_http_response(403, body).expect("managed-challenge classification");
+        assert_eq!(
+            diagnostic.kind,
+            ResponseDiagnosticKind::BrowserChallenge(BrowserChallengeKind::Cloudflare)
+        );
+    }
+
+    /// The same marker text, stripped of `Just a moment`, still classifies —
+    /// proving the fix does not lean on the legacy title string.
+    #[test]
+    fn classify_http_response_detects_challenge_error_text_without_legacy_markers() {
+        let body = "<html><body><div id=\"challenge-error-text\">\
+             Enable JavaScript and cookies to continue</div></body></html>";
+        let diagnostic =
+            classify_http_response(403, body).expect("challenge-error-text classification");
         assert_eq!(
             diagnostic.kind,
             ResponseDiagnosticKind::BrowserChallenge(BrowserChallengeKind::Cloudflare)


### PR DESCRIPTION
Closes #117.

## Problem

With `--cookies auto` (the default), nab selects one browser profile (e.g. Brave). When that profile lacks a valid Cloudflare clearance cookie for the target domain, the server returns a managed-challenge page and `auto` returned the challenge HTML instead of trying another available profile. The same URL succeeded with explicit `--cookies safari`/`chrome`/`firefox`.

## Change

- Adds a deterministic browser-profile fallback for `--cookies auto`: Brave -> Chrome -> Firefox -> Safari, excluding the profile `auto` already picked. On a detected challenge, each remaining profile that actually holds cookies for the domain is retried at most once; the first non-challenge body is returned. Order is logged at INFO.
- On exhaustion (all available profiles still challenged), the original response is kept and a warning names the profiles tried.
- Reuses the existing `response_classifier` rather than adding a new detector. The Cloudflare matcher is extended to recognise modern managed-challenge markup (`challenge-error-text`, "enable javascript and cookies to continue") that the repro URL returns; the legacy `cf-browser-verification` / "just a moment" strings are not always present on those pages.
- Explicit `--cookies <browser>` keeps current single-profile behaviour (no fallback). Additive change, no schema change.

## Acceptance criteria

- NAB.COOKIE.1 — challenge response under `auto` triggers retry with the next available profile (challenge detection via shared classifier).
- NAB.COOKIE.2 — fallback order is deterministic (`FALLBACK_ORDER`) and logged at INFO.
- NAB.COOKIE.3 — all profiles exhausted returns the prior response with a warning naming profiles tried.
- NAB.COOKIE.4 — regression test mocks a 403-challenge from one profile and 200 from another; asserts the clean body is returned.

## Tests

The fallback loop is generic over an injected async attempt closure, so it is unit-tested with canned responses (no network, no real cookie store).

- `cookies::fallback`: candidate ordering, unavailable-profile skipping, first-clean-profile wins (NAB.COOKIE.4), all-challenged -> Exhausted. 6 passed.
- `response_classifier`: the issue managed-challenge body classifies as `BrowserChallenge(Cloudflare)`; `challenge-error-text` classifies without legacy markers. 16 passed.
- content (392) and auth (39) module suites pass; `cargo build` and scoped `cargo clippy` clean on touched files.

## Impact (gitnexus)

- `looks_like_cloudflare_challenge`: LOW risk (additive markers only).
- `classify_http_response`: medium by caller count, but signature and logic unchanged.
- `cmd_fetch`: LOW (single caller). `CookieSource`: re-exported at crate root, but the change is an additive `#[derive(PartialEq, Eq, Hash)]` (no break). No high-risk symbols affected.

## Rollback

Revert the commit; `auto` reverts to single-profile behaviour. Additive, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)