### PR TITLE
feat(ssrf): add SSRF opt-out escape hatch for internal network access (fixes #107)

### DIFF
--- a/src/bin/mcp_server/helpers.rs
+++ b/src/bin/mcp_server/helpers.rs
@@ -62,11 +62,16 @@ pub(crate) async fn read_response_capped(
         .map_err(|e| CallToolError::from_message(e.to_string()))
 }
 
-/// Fetch via `fetch_safe` and return the response components.
+/// Fetch via `request_safe` (no cookies) and return the response components.
+///
+/// `ssrf_policy` governs SSRF validation for the request and any redirects.
+/// Callers pass [`nab::SsrfPolicy::deny_all`] for the default locked-down path
+/// or a relaxed policy when the per-call private-IP opt-out is enabled.
 pub(crate) async fn fetch_safe_response(
     client: &AcceleratedClient,
     url: &str,
     config: &SafeFetchConfig,
+    ssrf_policy: &nab::SsrfPolicy,
     start: Instant,
 ) -> Result<
     (
@@ -79,7 +84,14 @@ pub(crate) async fn fetch_safe_response(
     CallToolError,
 > {
     let safe_resp = client
-        .fetch_safe(url, config)
+        .request_safe(
+            url,
+            SafeRequestOptions {
+                config: config.clone(),
+                ssrf_policy: ssrf_policy.clone(),
+                ..SafeRequestOptions::default()
+            },
+        )
         .await
         .map_err(|e| CallToolError::from_message(e.to_string()))?;
     let elapsed = start.elapsed();
@@ -93,11 +105,14 @@ pub(crate) async fn fetch_safe_response(
 }
 
 /// Fetch with a cookie header and return the response components.
+///
+/// `ssrf_policy` governs SSRF validation for the request and any redirects.
 pub(crate) async fn fetch_with_cookies(
     client: &AcceleratedClient,
     url: &str,
     cookie_header: &str,
     profile: &nab::fingerprint::BrowserProfile,
+    ssrf_policy: &nab::SsrfPolicy,
     start: Instant,
 ) -> Result<
     (
@@ -122,6 +137,7 @@ pub(crate) async fn fetch_with_cookies(
             SafeRequestOptions {
                 headers,
                 config: SafeFetchConfig::default(),
+                ssrf_policy: ssrf_policy.clone(),
                 ..SafeRequestOptions::default()
             },
         )

--- a/src/bin/mcp_server/tools/fetch.rs
+++ b/src/bin/mcp_server/tools/fetch.rs
@@ -138,9 +138,42 @@ pub struct FetchTool {
     /// server must not be able to correlate the request to your IP address.
     #[serde(default)]
     tor: bool,
+    /// Allow fetching **private/internal** IP addresses (RFC 1918, IPv6 ULA,
+    /// CGN). **OFF by default — SSRF protection stays on.**
+    ///
+    /// nab blocks private/internal addresses by default to prevent
+    /// Server-Side Request Forgery. Enable this only on trusted workstations
+    /// where you legitimately need to reach corporate intranet dashboards.
+    ///
+    /// Even when enabled, loopback (`127.0.0.1`), link-local cloud-metadata
+    /// endpoints (`169.254.169.254`), and every other dangerous range remain
+    /// blocked. Prefer the narrowly-scoped `allow_private_ip` allowlist over
+    /// this blanket flag. Audit logs are emitted whenever a private address is
+    /// allowed through.
+    #[serde(default)]
+    allow_private_ips: bool,
+    /// Scoped allowlist of private addresses / CIDR blocks to permit
+    /// (e.g. `["10.252.0.0/16", "192.168.1.5"]`). **Empty by default.**
+    ///
+    /// Preferred over `allow_private_ips`: only addresses inside a listed range
+    /// bypass the private-IP block, and only those ranges. Listing a dangerous
+    /// address (loopback, cloud metadata) has no effect — those stay blocked.
+    #[serde(default)]
+    allow_private_ip: Vec<String>,
 }
 
 impl FetchTool {
+    /// Builds the SSRF policy for this call: the env-derived default
+    /// ([`nab::SsrfPolicy::from_env`]) layered with the per-call MCP params.
+    ///
+    /// The default is fully locked down; relaxation is additive and only ever
+    /// touches the relaxable (private/ULA/CGN) subset.
+    fn ssrf_policy(&self) -> nab::SsrfPolicy {
+        nab::SsrfPolicy::from_env()
+            .with_allow_private(self.allow_private_ips)
+            .with_allowlist_entries(self.allow_private_ip.iter())
+    }
+
     #[allow(clippy::too_many_lines)]
     pub async fn run(&self) -> Result<CallToolResult, CallToolError> {
         let url_host = url::Url::parse(&self.url)
@@ -288,12 +321,21 @@ impl FetchTool {
             )
         } else {
             let config = SafeFetchConfig::default();
+            let ssrf_policy = self.ssrf_policy();
 
             let (status, content_type, response_headers, body_bytes, elapsed) =
                 if cookie_header.is_empty() {
-                    fetch_safe_response(client, &self.url, &config, start).await?
+                    fetch_safe_response(client, &self.url, &config, &ssrf_policy, start).await?
                 } else {
-                    fetch_with_cookies(client, &self.url, &cookie_header, &profile, start).await?
+                    fetch_with_cookies(
+                        client,
+                        &self.url,
+                        &cookie_header,
+                        &profile,
+                        &ssrf_policy,
+                        start,
+                    )
+                    .await?
                 };
             let raw_text = String::from_utf8_lossy(&body_bytes).into_owned();
 

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -79,6 +79,10 @@ pub struct FetchConfig {
     pub detect_labyrinth: bool,
     /// WAF challenge handling strategy. See [`WafMode`].
     pub waf_mode: WafMode,
+    /// SSRF policy controlling whether private/internal addresses may be
+    /// fetched. Defaults to [`nab::SsrfPolicy::deny_all`] — the locked-down
+    /// behaviour that blocks all private ranges (issue #107).
+    pub ssrf_policy: nab::SsrfPolicy,
 }
 
 /// Strategy for handling detected WAF challenges (AWS WAF, Cloudflare
@@ -256,6 +260,7 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
                 SafeRequestOptions {
                     headers,
                     config: SafeFetchConfig::default(),
+                    ssrf_policy: cfg.ssrf_policy.clone(),
                     ..SafeRequestOptions::default()
                 },
             )
@@ -273,7 +278,7 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
 
     let (status, version, set_cookies, content_type, response_headers, body_bytes) =
         if is_simple_get {
-            execute_safe_get(&client, &cfg.url, cfg.show_headers).await?
+            execute_safe_get(&client, &cfg.url, cfg.show_headers, &cfg.ssrf_policy).await?
         } else {
             execute_manual_request(&client, cfg, &profile, &cookie_header).await?
         };
@@ -487,11 +492,12 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
     Ok(())
 }
 
-/// Execute a safe GET request via `fetch_safe`.
+/// Execute a safe GET request, honouring the supplied SSRF policy.
 async fn execute_safe_get(
     client: &AcceleratedClient,
     url: &str,
     show_headers: bool,
+    ssrf_policy: &nab::SsrfPolicy,
 ) -> Result<(
     reqwest::StatusCode,
     String,
@@ -501,7 +507,16 @@ async fn execute_safe_get(
     bytes::Bytes,
 )> {
     let config = SafeFetchConfig::default();
-    let safe_resp = client.fetch_safe(url, &config).await?;
+    let safe_resp = client
+        .request_safe(
+            url,
+            SafeRequestOptions {
+                config,
+                ssrf_policy: ssrf_policy.clone(),
+                ..SafeRequestOptions::default()
+            },
+        )
+        .await?;
 
     let set_cookies: Vec<String> = safe_resp
         .headers
@@ -600,6 +615,7 @@ async fn execute_manual_request(
                 headers,
                 body: cfg.data.clone().map(bytes::Bytes::from),
                 config,
+                ssrf_policy: cfg.ssrf_policy.clone(),
             },
         )
         .await?;

--- a/src/fetch_bridge.rs
+++ b/src/fetch_bridge.rs
@@ -103,8 +103,12 @@ impl FetchClient {
             .parse()
             .map_err(|e| anyhow::anyhow!("Invalid URL '{full_url}': {e}"))?;
 
-        // SSRF validation: Validate initial URL
-        ssrf::validate_url(&current_url)?;
+        // SSRF validation: Validate initial URL.
+        // Secondary (synchronous plugin/SPA) fetch path honours the env-level
+        // opt-out (NAB_SSRF_ALLOW_PRIVATE / NAB_SSRF_ALLOWLIST); the per-call
+        // MCP/CLI param routes through AcceleratedClient, not this bridge.
+        let ssrf_policy = ssrf::SsrfPolicy::from_env();
+        ssrf::validate_url_with_policy(&current_url, &ssrf_policy)?;
 
         // Log the fetch for discovery
         self.lock_fetch_log().push(current_url.to_string());
@@ -145,8 +149,8 @@ impl FetchClient {
                     .join(location)
                     .map_err(|e| anyhow::anyhow!("Invalid redirect URL '{location}': {e}"))?;
 
-                // SSRF validation: Validate redirect target
-                ssrf::validate_url(&next_url)?;
+                // SSRF validation: Validate redirect target (same policy).
+                ssrf::validate_url_with_policy(&next_url, &ssrf_policy)?;
 
                 current_url = next_url;
                 continue;

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -27,7 +27,7 @@ use tracing::{debug, info, instrument, warn};
 use url::Url;
 
 use crate::fingerprint::{BrowserProfile, random_profile};
-use crate::ssrf::{self, DEFAULT_MAX_BODY_SIZE, DEFAULT_MAX_REDIRECTS};
+use crate::ssrf::{self, DEFAULT_MAX_BODY_SIZE, DEFAULT_MAX_REDIRECTS, SsrfPolicy};
 
 /// `SOCKS5h` proxy URL for the Tor anonymity network.
 ///
@@ -359,14 +359,12 @@ impl AcceleratedClient {
         url: &str,
         config: &SafeFetchConfig,
     ) -> Result<SafeFetchResponse> {
-        self.request_safe_with_validators(
+        self.request_safe(
             url,
             SafeRequestOptions {
                 config: config.clone(),
                 ..SafeRequestOptions::default()
             },
-            ssrf::validate_url,
-            validate_redirect_target_and_pin,
         )
         .await
     }
@@ -375,17 +373,24 @@ impl AcceleratedClient {
     ///
     /// Unlike [`Self::fetch_safe`], this supports non-GET methods, additional
     /// headers, and request bodies while preserving the same safety guarantees.
+    ///
+    /// The SSRF policy in [`SafeRequestOptions::ssrf_policy`] governs both the
+    /// initial URL and every redirect hop. It defaults to
+    /// [`SsrfPolicy::deny_all`]; callers that opt in to private addresses
+    /// (issue #107) supply a relaxed policy here.
     #[instrument(skip(self, options), fields(url = %url, method = %options.method))]
     pub async fn request_safe(
         &self,
         url: &str,
         options: SafeRequestOptions,
     ) -> Result<SafeFetchResponse> {
+        let initial_policy = options.ssrf_policy.clone();
+        let redirect_policy = options.ssrf_policy.clone();
         self.request_safe_with_validators(
             url,
             options,
-            ssrf::validate_url,
-            validate_redirect_target_and_pin,
+            move |u: &Url| ssrf::validate_url_with_policy(u, &initial_policy),
+            move |u: &Url| validate_redirect_target_and_pin_with_policy(u, &redirect_policy),
         )
         .await
     }
@@ -531,8 +536,9 @@ impl AcceleratedClient {
     }
 }
 
-fn validate_redirect_target_and_pin(
+fn validate_redirect_target_and_pin_with_policy(
     url: &Url,
+    policy: &SsrfPolicy,
 ) -> std::result::Result<SocketAddr, crate::error::NabError> {
     match url.scheme() {
         "http" | "https" => {}
@@ -543,7 +549,7 @@ fn validate_redirect_target_and_pin(
         }
     }
 
-    ssrf::validate_url(url)
+    ssrf::validate_url_with_policy(url, policy)
 }
 
 fn should_redirect_with_get(status: StatusCode, method: &Method) -> bool {
@@ -605,6 +611,13 @@ pub struct SafeRequestOptions {
     pub body: Option<Bytes>,
     /// Shared redirect/body/accept behavior.
     pub config: SafeFetchConfig,
+    /// SSRF policy applied to the initial URL and every redirect hop.
+    ///
+    /// Defaults to [`SsrfPolicy::deny_all`] — the locked-down behaviour that
+    /// blocks all private/internal ranges. The fetch boundary (CLI / MCP)
+    /// replaces this with an env-/flag-derived policy when the user opts in to
+    /// reaching private addresses (issue #107).
+    pub ssrf_policy: SsrfPolicy,
 }
 
 impl Default for SafeRequestOptions {
@@ -614,6 +627,7 @@ impl Default for SafeRequestOptions {
             headers: HeaderMap::new(),
             body: None,
             config: SafeFetchConfig::default(),
+            ssrf_policy: SsrfPolicy::deny_all(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,11 @@ pub use mfa::{MfaHandler, MfaResult, MfaType, NotificationConfig, detect_mfa_typ
 pub use prefetch::{EarlyHintLink, EarlyHints, PrefetchManager, extract_link_hints};
 pub use session::{MAX_SESSIONS, SessionStore, get_session_dir};
 pub use ssrf::{
-    DEFAULT_MAX_BODY_SIZE, DEFAULT_MAX_REDIRECTS, extract_mapped_ipv4, is_denied_ipv4,
-    is_denied_ipv6, validate_ip, validate_redirect_target, validate_url,
+    ALLOW_PRIVATE_ENV, ALLOWLIST_ENV, DEFAULT_MAX_BODY_SIZE, DEFAULT_MAX_REDIRECTS, IpCidr,
+    SsrfPolicy, extract_mapped_ipv4, is_denied_ipv4, is_denied_ipv4_with_policy, is_denied_ipv6,
+    is_denied_ipv6_with_policy, resolve_and_validate, resolve_and_validate_with_policy, validate_ip,
+    validate_ip_with_policy, validate_redirect_target, validate_redirect_target_with_policy,
+    validate_url, validate_url_with_policy,
 };
 pub use stream::{StreamBackend, StreamInfo, StreamProvider};
 pub use watch::{AddOptions, Watch, WatchEvent, WatchId, WatchManager, WatchOptions};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,9 +107,9 @@ pub use session::{MAX_SESSIONS, SessionStore, get_session_dir};
 pub use ssrf::{
     ALLOW_PRIVATE_ENV, ALLOWLIST_ENV, DEFAULT_MAX_BODY_SIZE, DEFAULT_MAX_REDIRECTS, IpCidr,
     SsrfPolicy, extract_mapped_ipv4, is_denied_ipv4, is_denied_ipv4_with_policy, is_denied_ipv6,
-    is_denied_ipv6_with_policy, resolve_and_validate, resolve_and_validate_with_policy, validate_ip,
-    validate_ip_with_policy, validate_redirect_target, validate_redirect_target_with_policy,
-    validate_url, validate_url_with_policy,
+    is_denied_ipv6_with_policy, resolve_and_validate, resolve_and_validate_with_policy,
+    validate_ip, validate_ip_with_policy, validate_redirect_target,
+    validate_redirect_target_with_policy, validate_url, validate_url_with_policy,
 };
 pub use stream::{StreamBackend, StreamInfo, StreamProvider};
 pub use watch::{AddOptions, Watch, WatchEvent, WatchId, WatchManager, WatchOptions};

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,12 @@ enum OverlayStyleArg {
 }
 
 #[derive(Subcommand)]
+// `Commands` is a parse-once CLI singleton: built from argv, destructured
+// immediately in `main`, never stored in a collection or hot path. The size
+// disparity the lint guards against (small variants paying for a large sibling
+// in a `Vec`/`Box`) does not apply here, and clippy's `Box<Vec<_>>` suggestion
+// would add a pointless indirection over an already heap-backed `Vec`.
+#[allow(clippy::large_enum_variant)]
 enum Commands {
     /// Fetch a URL (token-optimized output available)
     Fetch {

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,29 @@ enum Commands {
         /// `auto` (default) detects WAF challenges and picks the best solver.
         #[arg(long, default_value = "auto")]
         waf_mode: String,
+
+        /// DANGER — allow fetching private/internal IPs (RFC 1918, IPv6 ULA,
+        /// CGN). OFF by default; SSRF protection stays on.
+        ///
+        /// nab blocks private/internal addresses by default to prevent
+        /// Server-Side Request Forgery (SSRF). Enable this only on a trusted
+        /// workstation where you legitimately need to reach a corporate
+        /// intranet dashboard. Loopback (127.x) and cloud-metadata endpoints
+        /// (169.254.169.254) stay blocked even with this flag. Prefer the
+        /// scoped `--allow-private-ip <CIDR>` allowlist over this blanket flag.
+        /// Can also be enabled via `NAB_SSRF_ALLOW_PRIVATE=1`.
+        #[arg(long)]
+        allow_private_ips: bool,
+
+        /// Scoped allowlist entry permitting one private CIDR/IP
+        /// (repeatable, e.g. `--allow-private-ip 10.252.0.0/16`).
+        ///
+        /// Preferred over `--allow-private-ips`: only addresses inside a listed
+        /// range bypass the private-IP block. Listing a dangerous address
+        /// (loopback, cloud metadata) has no effect. Can also be supplied via
+        /// `NAB_SSRF_ALLOWLIST=10.252.0.0/16,192.168.1.5`.
+        #[arg(long = "allow-private-ip", action = clap::ArgAction::Append)]
+        allow_private_ip: Vec<String>,
     },
 
     /// Render a JavaScript-heavy URL through an explicitly configured CDP browser endpoint
@@ -940,8 +963,13 @@ async fn main() -> Result<()> {
                 language,
                 detect_labyrinth,
                 waf_mode,
+                allow_private_ips,
+                allow_private_ip,
                 ..
             } => {
+                let ssrf_policy = nab::SsrfPolicy::from_env()
+                    .with_allow_private(allow_private_ips)
+                    .with_allowlist_entries(allow_private_ip.iter());
                 let cfg = cmd::FetchConfig {
                     url,
                     show_headers: headers,
@@ -977,6 +1005,7 @@ async fn main() -> Result<()> {
                     language,
                     detect_labyrinth,
                     waf_mode: waf_mode.parse().unwrap_or_default(),
+                    ssrf_policy,
                     html_options: nab::content::html::HtmlConversionOptions {
                         allow_spa_extraction: !no_spa,
                         allow_jina_fallback: remote_fallback && !no_fallback,

--- a/src/session.rs
+++ b/src/session.rs
@@ -56,7 +56,7 @@ use tempfile::NamedTempFile;
 use tokio::sync::RwLock;
 
 use crate::fingerprint::{BrowserProfile, random_profile};
-use crate::ssrf::{DEFAULT_MAX_REDIRECTS, validate_redirect_target};
+use crate::ssrf::{DEFAULT_MAX_REDIRECTS, validate_redirect_target_with_policy};
 
 #[cfg(not(test))]
 const NAB_STATE_DIR: &str = ".nab";
@@ -493,7 +493,11 @@ fn build_reqwest_client(profile: &BrowserProfile, jar: Arc<SessionJar>) -> Resul
                     "too many redirects (>{DEFAULT_MAX_REDIRECTS}) in session request"
                 ));
             }
-            if let Err(error) = validate_redirect_target(attempt.url()) {
+            // Session redirects honour the env-level SSRF opt-out
+            // (NAB_SSRF_ALLOW_PRIVATE / NAB_SSRF_ALLOWLIST). Per-call MCP/CLI
+            // overrides do not flow through this reqwest redirect closure.
+            let ssrf_policy = crate::ssrf::SsrfPolicy::from_env();
+            if let Err(error) = validate_redirect_target_with_policy(attempt.url(), &ssrf_policy) {
                 return attempt.error(error.to_string());
             }
             attempt.follow()

--- a/src/ssrf.rs
+++ b/src/ssrf.rs
@@ -174,12 +174,20 @@ impl IpCidr {
     #[must_use]
     pub fn contains(&self, ip: IpAddr) -> bool {
         match (self, ip) {
-            (Self::V4 { network, prefix_len }, IpAddr::V4(v4)) => {
-                mask_u32(u32::from(v4), *prefix_len) == *network
-            }
-            (Self::V6 { network, prefix_len }, IpAddr::V6(v6)) => {
-                mask_u128(u128::from(v6), *prefix_len) == *network
-            }
+            (
+                Self::V4 {
+                    network,
+                    prefix_len,
+                },
+                IpAddr::V4(v4),
+            ) => mask_u32(u32::from(v4), *prefix_len) == *network,
+            (
+                Self::V6 {
+                    network,
+                    prefix_len,
+                },
+                IpAddr::V6(v6),
+            ) => mask_u128(u128::from(v6), *prefix_len) == *network,
             _ => false,
         }
     }

--- a/src/ssrf.rs
+++ b/src/ssrf.rs
@@ -70,24 +70,333 @@ pub const DEFAULT_MAX_REDIRECTS: u32 = 5;
 /// Default maximum response body size in bytes (10 MB).
 pub const DEFAULT_MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
 
+/// Environment variable that, when set to `1`/`true`, relaxes the SSRF guard
+/// for **private/internal** ranges only (RFC 1918, IPv6 ULA, and CGN).
+///
+/// **OFF by default.** This is an explicit, audited opt-out for the documented
+/// use case of reaching internal corporate dashboards. It never unblocks
+/// loopback, link-local (cloud metadata `169.254.169.254`), unspecified,
+/// multicast, broadcast, documentation, benchmarking, reserved ranges —
+/// those stay denied regardless of this flag. See [`SsrfPolicy`].
+pub const ALLOW_PRIVATE_ENV: &str = "NAB_SSRF_ALLOW_PRIVATE";
+
+/// Environment variable holding a comma-separated allowlist of private
+/// addresses / CIDR blocks (e.g. `10.252.0.0/16,192.168.1.5,fd00::/8`).
+///
+/// **OFF by default (empty).** This is the *preferred*, narrowly-scoped opt-out:
+/// only addresses inside one of the listed ranges are exempted from the
+/// private/ULA/CGN block, and only those ranges. Like [`ALLOW_PRIVATE_ENV`],
+/// an allowlist entry can never unblock loopback, link-local/metadata, any
+/// other always-denied range — those are filtered out before the allowlist is
+/// consulted. See [`SsrfPolicy`].
+pub const ALLOWLIST_ENV: &str = "NAB_SSRF_ALLOWLIST";
+
+// ─── SSRF policy ───────────────────────────────────────────────────────────────
+
+/// A single CIDR entry in an SSRF allowlist (IPv4 / IPv6).
+///
+/// Matching is exact bit-prefix comparison; host bits in the supplied network
+/// address are ignored (canonicalised away at parse time).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IpCidr {
+    /// IPv4 network: base address masked to `prefix_len` bits.
+    V4 {
+        /// Network address with host bits cleared.
+        network: u32,
+        /// Prefix length, `0..=32`.
+        prefix_len: u8,
+    },
+    /// IPv6 network: base address masked to `prefix_len` bits.
+    V6 {
+        /// Network address with host bits cleared.
+        network: u128,
+        /// Prefix length, `0..=128`.
+        prefix_len: u8,
+    },
+}
+
+impl IpCidr {
+    /// Parses a CIDR string (`10.0.0.0/8`) / a bare IP (`192.168.1.5`, treated
+    /// as a host route — `/32` for IPv4, `/128` for IPv6).
+    ///
+    /// Host bits are masked off so `10.1.2.3/8` is stored as `10.0.0.0/8`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` with a human-readable message if the address / prefix
+    /// length cannot be parsed / the prefix exceeds the address width.
+    pub fn parse(spec: &str) -> Result<Self, String> {
+        let spec = spec.trim();
+        let (addr_part, prefix_part) = match spec.split_once('/') {
+            Some((a, p)) => (a, Some(p)),
+            None => (spec, None),
+        };
+
+        match addr_part.parse::<IpAddr>() {
+            Ok(IpAddr::V4(v4)) => {
+                let prefix_len = Self::parse_prefix(prefix_part, 32)?;
+                let bits = u32::from(v4);
+                Ok(Self::V4 {
+                    network: mask_u32(bits, prefix_len),
+                    prefix_len,
+                })
+            }
+            Ok(IpAddr::V6(v6)) => {
+                let prefix_len = Self::parse_prefix(prefix_part, 128)?;
+                let bits = u128::from(v6);
+                Ok(Self::V6 {
+                    network: mask_u128(bits, prefix_len),
+                    prefix_len,
+                })
+            }
+            Err(e) => Err(format!("invalid IP address '{addr_part}': {e}")),
+        }
+    }
+
+    fn parse_prefix(prefix_part: Option<&str>, max: u8) -> Result<u8, String> {
+        match prefix_part {
+            None => Ok(max),
+            Some(p) => {
+                let value: u8 = p
+                    .trim()
+                    .parse()
+                    .map_err(|_| format!("invalid prefix length '{p}'"))?;
+                if value > max {
+                    return Err(format!("prefix /{value} exceeds maximum /{max}"));
+                }
+                Ok(value)
+            }
+        }
+    }
+
+    /// Returns `true` if `ip` falls within this CIDR block. IPv4 / IPv6 never
+    /// match across families.
+    #[must_use]
+    pub fn contains(&self, ip: IpAddr) -> bool {
+        match (self, ip) {
+            (Self::V4 { network, prefix_len }, IpAddr::V4(v4)) => {
+                mask_u32(u32::from(v4), *prefix_len) == *network
+            }
+            (Self::V6 { network, prefix_len }, IpAddr::V6(v6)) => {
+                mask_u128(u128::from(v6), *prefix_len) == *network
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Masks `bits` to the high `prefix_len` bits (IPv4). `prefix_len == 0` yields 0.
+fn mask_u32(bits: u32, prefix_len: u8) -> u32 {
+    if prefix_len == 0 {
+        0
+    } else if prefix_len >= 32 {
+        bits
+    } else {
+        bits & (u32::MAX << (32 - prefix_len))
+    }
+}
+
+/// Masks `bits` to the high `prefix_len` bits (IPv6). `prefix_len == 0` yields 0.
+fn mask_u128(bits: u128, prefix_len: u8) -> u128 {
+    if prefix_len == 0 {
+        0
+    } else if prefix_len >= 128 {
+        bits
+    } else {
+        bits & (u128::MAX << (128 - prefix_len))
+    }
+}
+
+/// Controls how far the SSRF guard relaxes the private/internal deny rules.
+///
+/// **The default ([`SsrfPolicy::deny_all`]) blocks every special-use range** —
+/// identical to nab's behaviour before the opt-out existed. Relaxation is
+/// strictly additive and only ever affects the *relaxable* subset:
+///
+/// | Range | Relaxable? |
+/// |-------|-----------|
+/// | RFC 1918 private (`10/8`, `172.16/12`, `192.168/16`) | yes |
+/// | IPv6 ULA (`fc00::/7`) | yes |
+/// | CGN (`100.64/10`) | yes |
+/// | loopback (`127/8`, `::1`) | **never** |
+/// | link-local incl. cloud metadata (`169.254/16`, `fe80::/10`) | **never** |
+/// | unspecified, multicast, broadcast, documentation, benchmarking, reserved | **never** |
+///
+/// A policy can relax the relaxable set in two ways, OR-combined:
+/// - `allow_private == true` — relax for *all* private/ULA/CGN addresses.
+/// - `allowlist` — relax only for addresses inside an explicit CIDR/host entry.
+///
+/// Even with relaxation enabled, an address is only allowed through if it is in
+/// the relaxable set. Loopback and metadata are filtered *before* the allowlist
+/// is consulted, so an allowlist entry can never reach them.
+#[derive(Debug, Clone, Default)]
+pub struct SsrfPolicy {
+    /// When `true`, every private/ULA/CGN address is allowed.
+    allow_private: bool,
+    /// Addresses inside any of these blocks are allowed even when
+    /// `allow_private` is `false`. Only relaxable ranges are ever exempted.
+    allowlist: Vec<IpCidr>,
+}
+
+impl SsrfPolicy {
+    /// The default, fully-locked-down policy: every special-use range is denied.
+    #[must_use]
+    pub fn deny_all() -> Self {
+        Self {
+            allow_private: false,
+            allowlist: Vec::new(),
+        }
+    }
+
+    /// Builds a policy from the process environment
+    /// ([`ALLOW_PRIVATE_ENV`] + [`ALLOWLIST_ENV`]).
+    ///
+    /// Unset / unparseable entries fall back to the locked-down default;
+    /// malformed allowlist entries are skipped with a `tracing::warn`.
+    #[must_use]
+    pub fn from_env() -> Self {
+        let allow_private = std::env::var(ALLOW_PRIVATE_ENV)
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
+
+        let allowlist = std::env::var(ALLOWLIST_ENV)
+            .ok()
+            .map(|raw| parse_allowlist(&raw))
+            .unwrap_or_default();
+
+        Self {
+            allow_private,
+            allowlist,
+        }
+    }
+
+    /// Overrides the `allow_private` flag (used to layer a CLI flag / MCP param
+    /// over the env-derived default). Only ever turns the flag *on*.
+    #[must_use]
+    pub fn with_allow_private(mut self, allow: bool) -> Self {
+        if allow {
+            self.allow_private = true;
+        }
+        self
+    }
+
+    /// Appends parsed CIDR/host entries to the allowlist, skipping malformed
+    /// ones with a warning. Used to layer CLI/MCP allowlist entries over env.
+    #[must_use]
+    pub fn with_allowlist_entries<I, S>(mut self, entries: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        for entry in entries {
+            let entry = entry.as_ref();
+            if entry.trim().is_empty() {
+                continue;
+            }
+            match IpCidr::parse(entry) {
+                Ok(cidr) => self.allowlist.push(cidr),
+                Err(e) => warn!("SSRF: ignoring malformed allowlist entry '{entry}': {e}"),
+            }
+        }
+        self
+    }
+
+    /// Returns `true` if this policy relaxes anything at all (used to decide
+    /// whether to emit an audit log on the fetch path).
+    #[must_use]
+    pub fn is_relaxed(&self) -> bool {
+        self.allow_private || !self.allowlist.is_empty()
+    }
+
+    /// Returns `true` if `ip` is in the *relaxable* set (private/ULA/CGN) **and**
+    /// this policy permits it (via `allow_private` / an allowlist match).
+    ///
+    /// This is the single gate through which any relaxation flows. It returns
+    /// `false` for every always-denied range, so callers can safely OR it
+    /// against the unconditional deny checks.
+    fn permits_relaxable(&self, ip: IpAddr) -> bool {
+        if !is_relaxable(ip) {
+            return false;
+        }
+        if self.allow_private {
+            return true;
+        }
+        self.allowlist.iter().any(|cidr| cidr.contains(ip))
+    }
+}
+
+/// Parses a comma-separated allowlist string into CIDR entries, skipping blanks
+/// and warning on malformed entries.
+fn parse_allowlist(raw: &str) -> Vec<IpCidr> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|spec| match IpCidr::parse(spec) {
+            Ok(cidr) => Some(cidr),
+            Err(e) => {
+                warn!("SSRF: ignoring malformed allowlist entry '{spec}': {e}");
+                None
+            }
+        })
+        .collect()
+}
+
+/// Returns `true` if `ip` is in the **relaxable** subset: RFC 1918 private,
+/// IPv6 ULA, CGN. These — and only these — can be unblocked by a policy.
+///
+/// Loopback, link-local (cloud metadata), every other special-use range
+/// return `false` here and therefore can never be relaxed.
+fn is_relaxable(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_private() || is_ipv4_cgn(v4),
+        // ULA fc00::/7 — segment[0] high 7 bits == fc00.
+        IpAddr::V6(v6) => (v6.segments()[0] & 0xfe00) == 0xfc00,
+    }
+}
+
 // ─── IPv4 deny list ──────────────────────────────────────────────────────────
 
 /// Returns `true` if the given IPv4 address is in a denied range.
 ///
-/// See module-level docs for the full CIDR table.
+/// Uses the fully-locked-down default policy ([`SsrfPolicy::deny_all`]); every
+/// special-use range is denied. See module-level docs for the full CIDR table.
+/// For policy-aware validation (the opt-out path), use
+/// [`is_denied_ipv4_with_policy`].
+#[must_use]
 pub fn is_denied_ipv4(ip: Ipv4Addr) -> bool {
-    ip.is_loopback()
-        || ip.is_private()
+    is_denied_ipv4_with_policy(ip, &SsrfPolicy::deny_all())
+}
+
+/// Returns `true` if the given IPv4 address is in a denied range, honouring an
+/// explicit [`SsrfPolicy`].
+///
+/// The policy can only relax the *relaxable* subset (RFC 1918 private, CGN);
+/// loopback, link-local (cloud metadata), and all other ranges stay denied.
+#[must_use]
+pub fn is_denied_ipv4_with_policy(ip: Ipv4Addr, policy: &SsrfPolicy) -> bool {
+    // Unconditional denies — never relaxable.
+    let always_denied = ip.is_loopback()
         || ip.is_link_local()
         || ip.is_broadcast()
         || ip.is_unspecified()
         || ip.is_multicast()
         || is_ipv4_documentation(ip)
         || is_ipv4_benchmarking(ip)
-        || is_ipv4_cgn(ip)
         || is_ipv4_protocol_assignments(ip)
         || is_ipv4_6to4_relay(ip)
-        || is_ipv4_reserved(ip)
+        || is_ipv4_reserved(ip);
+    if always_denied {
+        return true;
+    }
+
+    // Relaxable subset (private + CGN): denied unless the policy permits it.
+    if ip.is_private() || is_ipv4_cgn(ip) {
+        return !policy.permits_relaxable(IpAddr::V4(ip));
+    }
+
+    false
 }
 
 /// `192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24` (RFC 5737).
@@ -141,11 +450,23 @@ fn is_ipv4_reserved(ip: Ipv4Addr) -> bool {
 
 /// Returns `true` if the given IPv6 address is in a denied range.
 ///
-/// See module-level docs for the full CIDR table.
+/// Uses the fully-locked-down default policy ([`SsrfPolicy::deny_all`]). For the
+/// policy-aware opt-out path, use [`is_denied_ipv6_with_policy`].
 ///
 /// Also detects IPv4-mapped IPv6 addresses (`::ffff:x.x.x.x`) and validates
 /// the embedded IPv4 address against the IPv4 deny list.
+#[must_use]
 pub fn is_denied_ipv6(ip: Ipv6Addr) -> bool {
+    is_denied_ipv6_with_policy(ip, &SsrfPolicy::deny_all())
+}
+
+/// Returns `true` if the given IPv6 address is in a denied range, honouring an
+/// explicit [`SsrfPolicy`].
+///
+/// Only the IPv6 ULA range (`fc00::/7`) and the embedded-IPv4 relaxable subset
+/// can be relaxed; every other IPv6 special range stays denied.
+#[must_use]
+pub fn is_denied_ipv6_with_policy(ip: Ipv6Addr, policy: &SsrfPolicy) -> bool {
     if ip.is_loopback() || ip.is_unspecified() || ip.is_multicast() {
         return true;
     }
@@ -153,7 +474,7 @@ pub fn is_denied_ipv6(ip: Ipv6Addr) -> bool {
     // Check IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
     // This catches bypass attempts like ::ffff:127.0.0.1
     if let Some(ipv4) = extract_mapped_ipv4(&ip) {
-        return is_denied_ipv4(ipv4);
+        return is_denied_ipv4_with_policy(ipv4, policy);
     }
 
     let segments = ip.segments();
@@ -168,9 +489,9 @@ pub fn is_denied_ipv6(ip: Ipv6Addr) -> bool {
         return true;
     }
 
-    // Unique local / ULA (fc00::/7)
+    // Unique local / ULA (fc00::/7) -- relaxable.
     if segments[0] & 0xfe00 == 0xfc00 {
-        return true;
+        return !policy.permits_relaxable(IpAddr::V6(ip));
     }
 
     // Documentation (2001:db8::/32)
@@ -212,7 +533,7 @@ pub fn is_denied_ipv6(ip: Ipv6Addr) -> bool {
             (segments[7] >> 8) as u8,
             (segments[7] & 0xff) as u8,
         );
-        return is_denied_ipv4(embedded);
+        return is_denied_ipv4_with_policy(embedded, policy);
     }
 
     // NAT64 local-use prefix (64:ff9b:1::/48) -- RFC 8215
@@ -261,36 +582,65 @@ pub fn extract_mapped_ipv4(ip: &Ipv6Addr) -> Option<Ipv4Addr> {
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
-/// Validates an IP address against the SSRF deny list.
+/// Validates an IP address against the SSRF deny list (fully-locked-down
+/// default policy).
 ///
-/// Returns `Ok(())` if the address is allowed, or [`NabError::SsrfBlocked`]
-/// describing why it was denied.
+/// Returns `Ok(())` if the address is allowed. For the policy-aware opt-out
+/// path, use [`validate_ip_with_policy`].
 pub fn validate_ip(ip: IpAddr) -> Result<(), NabError> {
-    match ip {
-        IpAddr::V4(v4) => {
-            if is_denied_ipv4(v4) {
-                return Err(NabError::SsrfBlocked(format!(
-                    "IPv4 address {v4} is in a denied range"
-                )));
-            }
-        }
-        IpAddr::V6(v6) => {
-            if is_denied_ipv6(v6) {
-                return Err(NabError::SsrfBlocked(format!(
-                    "IPv6 address {v6} is in a denied range"
-                )));
-            }
-        }
+    validate_ip_with_policy(ip, &SsrfPolicy::deny_all())
+}
+
+/// Validates an IP address against the SSRF deny list, honouring an explicit
+/// [`SsrfPolicy`].
+///
+/// When a relaxed policy permits an otherwise-private address, an audit log is
+/// emitted (`tracing::warn`) so the bypass is always visible in logs.
+///
+/// # Errors
+///
+/// Returns [`NabError::SsrfBlocked`] if the address is in a denied range that
+/// the policy does not relax.
+pub fn validate_ip_with_policy(ip: IpAddr, policy: &SsrfPolicy) -> Result<(), NabError> {
+    let denied = match ip {
+        IpAddr::V4(v4) => is_denied_ipv4_with_policy(v4, policy),
+        IpAddr::V6(v6) => is_denied_ipv6_with_policy(v6, policy),
+    };
+    if denied {
+        return Err(NabError::SsrfBlocked(format!(
+            "IP address {ip} is in a denied range"
+        )));
+    }
+    // Audit: a relaxed policy let a private/internal address through.
+    if policy.is_relaxed() && is_relaxable(ip) {
+        warn!(
+            allowed_ip = %ip,
+            "SSRF: allowing private/internal address via NAB_SSRF opt-out (loopback/metadata stay blocked)"
+        );
     }
     Ok(())
 }
 
 /// Resolves a hostname to IP addresses and validates each against the SSRF
-/// deny list.
+/// deny list (fully-locked-down default policy).
 ///
-/// Returns the first allowed [`SocketAddr`], or [`NabError::SsrfBlocked`] if
-/// all resolved addresses are denied or DNS resolution fails.
+/// Returns the first allowed [`SocketAddr`]. For the policy-aware opt-out path,
+/// use [`resolve_and_validate_with_policy`].
 pub fn resolve_and_validate(host: &str, port: u16) -> Result<SocketAddr, NabError> {
+    resolve_and_validate_with_policy(host, port, &SsrfPolicy::deny_all())
+}
+
+/// Policy-aware variant of [`resolve_and_validate`].
+///
+/// # Errors
+///
+/// Returns [`NabError::SsrfBlocked`] if DNS resolution fails / every resolved
+/// address is denied under `policy`.
+pub fn resolve_and_validate_with_policy(
+    host: &str,
+    port: u16,
+    policy: &SsrfPolicy,
+) -> Result<SocketAddr, NabError> {
     let addr_str = format!("{host}:{port}");
     let addrs: Vec<SocketAddr> = addr_str
         .to_socket_addrs()
@@ -304,7 +654,7 @@ pub fn resolve_and_validate(host: &str, port: u16) -> Result<SocketAddr, NabErro
     }
 
     for addr in &addrs {
-        match validate_ip(addr.ip()) {
+        match validate_ip_with_policy(addr.ip(), policy) {
             Ok(()) => return Ok(*addr),
             Err(e) => {
                 warn!("SSRF: skipping {addr} for {host}: {e}");
@@ -317,14 +667,27 @@ pub fn resolve_and_validate(host: &str, port: u16) -> Result<SocketAddr, NabErro
     )))
 }
 
-/// Validates a URL's host against the SSRF deny list by resolving DNS.
+/// Validates a URL's host against the SSRF deny list by resolving DNS
+/// (fully-locked-down default policy).
 ///
 /// This is the main entry point for SSRF validation. It:
 /// 1. Parses the URL to extract host and port
 /// 2. Resolves the hostname via DNS
 /// 3. Validates all resolved IPs against the deny list
 /// 4. Returns the first allowed `SocketAddr` for DNS pinning
+///
+/// For the policy-aware opt-out path, use [`validate_url_with_policy`].
 pub fn validate_url(url: &Url) -> Result<SocketAddr, NabError> {
+    validate_url_with_policy(url, &SsrfPolicy::deny_all())
+}
+
+/// Policy-aware variant of [`validate_url`].
+///
+/// # Errors
+///
+/// Returns [`NabError::InvalidUrl`] when the URL has no host, [`NabError::SsrfBlocked`]
+/// when every candidate address is denied under `policy`.
+pub fn validate_url_with_policy(url: &Url, policy: &SsrfPolicy) -> Result<SocketAddr, NabError> {
     let host = url
         .host_str()
         .ok_or_else(|| NabError::InvalidUrl(format!("URL has no host: {url}")))?;
@@ -333,24 +696,41 @@ pub fn validate_url(url: &Url) -> Result<SocketAddr, NabError> {
 
     // Check if host is a raw IP address first (no DNS needed)
     if let Ok(ip) = host.parse::<IpAddr>() {
-        validate_ip(ip)?;
+        validate_ip_with_policy(ip, policy)?;
         return Ok(SocketAddr::new(ip, port));
     }
 
     // Also check bracket-stripped IPv6 literals like [::ffff:127.0.0.1]
     let stripped = host.trim_start_matches('[').trim_end_matches(']');
     if let Ok(ip) = stripped.parse::<IpAddr>() {
-        validate_ip(ip)?;
+        validate_ip_with_policy(ip, policy)?;
         return Ok(SocketAddr::new(ip, port));
     }
 
-    resolve_and_validate(host, port)
+    resolve_and_validate_with_policy(host, port, policy)
 }
 
-/// Validates a redirect target URL against the SSRF deny list.
+/// Validates a redirect target URL against the SSRF deny list (fully-locked-down
+/// default policy).
 ///
 /// Called before following each redirect hop to prevent redirect-based SSRF.
 pub fn validate_redirect_target(url: &Url) -> Result<(), NabError> {
+    validate_redirect_target_with_policy(url, &SsrfPolicy::deny_all())
+}
+
+/// Policy-aware variant of [`validate_redirect_target`].
+///
+/// The redirect target is validated under the *same* policy as the initial
+/// request, so an opt-out does not silently widen across a redirect boundary
+/// beyond what the user already permitted.
+///
+/// # Errors
+///
+/// Returns [`NabError::SsrfBlocked`] for a disallowed scheme / a denied target.
+pub fn validate_redirect_target_with_policy(
+    url: &Url,
+    policy: &SsrfPolicy,
+) -> Result<(), NabError> {
     // Only validate http/https schemes
     match url.scheme() {
         "http" | "https" => {}
@@ -361,5 +741,5 @@ pub fn validate_redirect_target(url: &Url) -> Result<(), NabError> {
         }
     }
 
-    validate_url(url).map(|_| ())
+    validate_url_with_policy(url, policy).map(|_| ())
 }

--- a/tests/ssrf_optout_tests.rs
+++ b/tests/ssrf_optout_tests.rs
@@ -99,7 +99,10 @@ fn allowlist_host_route_is_exact() {
     let policy = SsrfPolicy::deny_all().with_allowlist_entries(["192.168.1.50"]);
     assert!(!is_denied_ipv4_with_policy(PRIVATE_192, &policy));
     // Neighbour address not covered by the /32 host route.
-    assert!(is_denied_ipv4_with_policy(Ipv4Addr::new(192, 168, 1, 51), &policy));
+    assert!(is_denied_ipv4_with_policy(
+        Ipv4Addr::new(192, 168, 1, 51),
+        &policy
+    ));
 }
 
 #[test]
@@ -114,8 +117,12 @@ fn allowlist_ipv6_cidr_scopes() {
 #[test]
 fn allowlist_skips_malformed_entries() {
     // Malformed entries are dropped; the valid one still applies.
-    let policy = SsrfPolicy::deny_all()
-        .with_allowlist_entries(["not-an-ip", "10.0.0.0/99", "", "10.252.0.0/16"]);
+    let policy = SsrfPolicy::deny_all().with_allowlist_entries([
+        "not-an-ip",
+        "10.0.0.0/99",
+        "",
+        "10.252.0.0/16",
+    ]);
     assert!(!is_denied_ipv4_with_policy(CORP_HOST, &policy));
 }
 
@@ -136,7 +143,10 @@ fn allow_private_never_unblocks_cloud_metadata() {
     let policy = allow_private();
     assert!(is_denied_ipv4_with_policy(AWS_METADATA, &policy));
     // Whole link-local /16 stays blocked.
-    assert!(is_denied_ipv4_with_policy(Ipv4Addr::new(169, 254, 0, 1), &policy));
+    assert!(is_denied_ipv4_with_policy(
+        Ipv4Addr::new(169, 254, 0, 1),
+        &policy
+    ));
 }
 
 #[test]
@@ -174,9 +184,15 @@ fn allow_private_does_not_affect_public_or_documentation() {
     // Public stays allowed (it always was).
     assert!(!is_denied_ipv4_with_policy(PUBLIC, &policy));
     // Documentation range stays blocked (not relaxable).
-    assert!(is_denied_ipv4_with_policy(Ipv4Addr::new(192, 0, 2, 1), &policy));
+    assert!(is_denied_ipv4_with_policy(
+        Ipv4Addr::new(192, 0, 2, 1),
+        &policy
+    ));
     // Broadcast stays blocked.
-    assert!(is_denied_ipv4_with_policy(Ipv4Addr::new(255, 255, 255, 255), &policy));
+    assert!(is_denied_ipv4_with_policy(
+        Ipv4Addr::new(255, 255, 255, 255),
+        &policy
+    ));
 }
 
 // ─── CIDR parsing / matching edge cases (boundaries) ───────────────────────────
@@ -212,7 +228,10 @@ fn cidr_full_prefix_is_host_route() {
 #[test]
 fn cidr_masks_host_bits_at_parse_time() {
     // 10.1.2.3/8 and 10.0.0.0/8 must be equal after canonicalisation.
-    assert_eq!(IpCidr::parse("10.1.2.3/8").unwrap(), IpCidr::parse("10.0.0.0/8").unwrap());
+    assert_eq!(
+        IpCidr::parse("10.1.2.3/8").unwrap(),
+        IpCidr::parse("10.0.0.0/8").unwrap()
+    );
 }
 
 #[test]
@@ -240,5 +259,9 @@ fn deny_all_is_not_relaxed() {
 #[test]
 fn allow_private_and_allowlist_are_relaxed() {
     assert!(allow_private().is_relaxed());
-    assert!(SsrfPolicy::deny_all().with_allowlist_entries(["10.0.0.0/8"]).is_relaxed());
+    assert!(
+        SsrfPolicy::deny_all()
+            .with_allowlist_entries(["10.0.0.0/8"])
+            .is_relaxed()
+    );
 }

--- a/tests/ssrf_optout_tests.rs
+++ b/tests/ssrf_optout_tests.rs
@@ -1,0 +1,244 @@
+//! Security tests for the SSRF private-IP opt-out (issue #107).
+//!
+//! These tests construct [`SsrfPolicy`] values explicitly and call the
+//! policy-aware predicates with literal IP addresses. They never touch DNS or
+//! process environment, so they are deterministic under cargo's parallel
+//! in-process test runner.
+//!
+//! The security contract under test:
+//! 1. The default path still blocks private IPs (no regression).
+//! 2. With the opt-out enabled, a private IP is allowed.
+//! 3. An allowlist scopes the opt-out to specific ranges.
+//! 4. Loopback, link-local (cloud metadata), and other dangerous ranges remain
+//!    blocked **regardless** of the opt-out — these are the critical asserts.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use nab::ssrf::{
+    IpCidr, SsrfPolicy, is_denied_ipv4_with_policy, is_denied_ipv6_with_policy,
+    validate_ip_with_policy,
+};
+
+// Re-usable literal addresses.
+const CORP_HOST: Ipv4Addr = Ipv4Addr::new(10, 252, 24, 131); // genai.booking.com from the issue
+const PRIVATE_192: Ipv4Addr = Ipv4Addr::new(192, 168, 1, 50);
+const PRIVATE_172: Ipv4Addr = Ipv4Addr::new(172, 16, 5, 5);
+const CGN: Ipv4Addr = Ipv4Addr::new(100, 64, 0, 1);
+const LOOPBACK: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
+const AWS_METADATA: Ipv4Addr = Ipv4Addr::new(169, 254, 169, 254);
+const PUBLIC: Ipv4Addr = Ipv4Addr::new(93, 184, 216, 34); // example.com
+
+fn allow_private() -> SsrfPolicy {
+    SsrfPolicy::deny_all().with_allow_private(true)
+}
+
+// ─── (1) Default still blocks private IPs ──────────────────────────────────────
+
+#[test]
+fn default_policy_blocks_private_ipv4() {
+    let policy = SsrfPolicy::deny_all();
+    assert!(is_denied_ipv4_with_policy(CORP_HOST, &policy));
+    assert!(is_denied_ipv4_with_policy(PRIVATE_192, &policy));
+    assert!(is_denied_ipv4_with_policy(PRIVATE_172, &policy));
+    assert!(is_denied_ipv4_with_policy(CGN, &policy));
+}
+
+#[test]
+fn default_policy_blocks_ula_ipv6() {
+    let policy = SsrfPolicy::deny_all();
+    let ula: Ipv6Addr = "fd00::1".parse().unwrap();
+    assert!(is_denied_ipv6_with_policy(ula, &policy));
+}
+
+#[test]
+fn bare_default_helpers_unchanged_for_private() {
+    // The single-arg public helpers must remain byte-identical (deny-all).
+    assert!(nab::ssrf::is_denied_ipv4(CORP_HOST));
+    assert!(nab::ssrf::is_denied_ipv4(PRIVATE_192));
+    assert!(validate_ip_with_policy(IpAddr::V4(CORP_HOST), &SsrfPolicy::deny_all()).is_err());
+}
+
+// ─── (2) Opt-out enabled → private IP allowed ──────────────────────────────────
+
+#[test]
+fn allow_private_permits_rfc1918() {
+    let policy = allow_private();
+    assert!(!is_denied_ipv4_with_policy(CORP_HOST, &policy));
+    assert!(!is_denied_ipv4_with_policy(PRIVATE_192, &policy));
+    assert!(!is_denied_ipv4_with_policy(PRIVATE_172, &policy));
+    assert!(validate_ip_with_policy(IpAddr::V4(CORP_HOST), &policy).is_ok());
+}
+
+#[test]
+fn allow_private_permits_cgn() {
+    let policy = allow_private();
+    assert!(!is_denied_ipv4_with_policy(CGN, &policy));
+}
+
+#[test]
+fn allow_private_permits_ula_ipv6() {
+    let policy = allow_private();
+    let ula: Ipv6Addr = "fd12:3456::1".parse().unwrap();
+    assert!(!is_denied_ipv6_with_policy(ula, &policy));
+}
+
+// ─── (3) Allowlist scoping ─────────────────────────────────────────────────────
+
+#[test]
+fn allowlist_permits_only_listed_range() {
+    let policy = SsrfPolicy::deny_all().with_allowlist_entries(["10.252.0.0/16"]);
+    // In range → allowed.
+    assert!(!is_denied_ipv4_with_policy(CORP_HOST, &policy));
+    // Different private range, NOT in the allowlist → still blocked.
+    assert!(is_denied_ipv4_with_policy(PRIVATE_192, &policy));
+    assert!(is_denied_ipv4_with_policy(PRIVATE_172, &policy));
+}
+
+#[test]
+fn allowlist_host_route_is_exact() {
+    let policy = SsrfPolicy::deny_all().with_allowlist_entries(["192.168.1.50"]);
+    assert!(!is_denied_ipv4_with_policy(PRIVATE_192, &policy));
+    // Neighbour address not covered by the /32 host route.
+    assert!(is_denied_ipv4_with_policy(Ipv4Addr::new(192, 168, 1, 51), &policy));
+}
+
+#[test]
+fn allowlist_ipv6_cidr_scopes() {
+    let policy = SsrfPolicy::deny_all().with_allowlist_entries(["fd00::/16"]);
+    let in_range: Ipv6Addr = "fd00:abcd::1".parse().unwrap();
+    let out_of_range: Ipv6Addr = "fd01::1".parse().unwrap();
+    assert!(!is_denied_ipv6_with_policy(in_range, &policy));
+    assert!(is_denied_ipv6_with_policy(out_of_range, &policy));
+}
+
+#[test]
+fn allowlist_skips_malformed_entries() {
+    // Malformed entries are dropped; the valid one still applies.
+    let policy = SsrfPolicy::deny_all()
+        .with_allowlist_entries(["not-an-ip", "10.0.0.0/99", "", "10.252.0.0/16"]);
+    assert!(!is_denied_ipv4_with_policy(CORP_HOST, &policy));
+}
+
+// ─── (4) CRITICAL: dangerous ranges never relaxable ────────────────────────────
+
+#[test]
+fn allow_private_never_unblocks_loopback() {
+    let policy = allow_private();
+    assert!(is_denied_ipv4_with_policy(LOOPBACK, &policy));
+    let v6_loopback: Ipv6Addr = "::1".parse().unwrap();
+    assert!(is_denied_ipv6_with_policy(v6_loopback, &policy));
+}
+
+#[test]
+fn allow_private_never_unblocks_cloud_metadata() {
+    // 169.254.169.254 — AWS/GCP/Azure IMDS. The single most dangerous SSRF
+    // target. Must stay blocked even with the broadest opt-out.
+    let policy = allow_private();
+    assert!(is_denied_ipv4_with_policy(AWS_METADATA, &policy));
+    // Whole link-local /16 stays blocked.
+    assert!(is_denied_ipv4_with_policy(Ipv4Addr::new(169, 254, 0, 1), &policy));
+}
+
+#[test]
+fn allowlist_cannot_unblock_metadata_even_if_listed() {
+    // An operator explicitly lists the metadata IP. It must STILL be blocked:
+    // the allowlist only ever exempts the relaxable (private/ULA/CGN) subset.
+    let policy = SsrfPolicy::deny_all().with_allowlist_entries(["169.254.169.254/32"]);
+    assert!(is_denied_ipv4_with_policy(AWS_METADATA, &policy));
+}
+
+#[test]
+fn allowlist_cannot_unblock_loopback_even_if_listed() {
+    let policy = SsrfPolicy::deny_all().with_allowlist_entries(["127.0.0.1/8"]);
+    assert!(is_denied_ipv4_with_policy(LOOPBACK, &policy));
+}
+
+#[test]
+fn allow_private_never_unblocks_link_local_ipv6() {
+    let policy = allow_private();
+    let link_local: Ipv6Addr = "fe80::1".parse().unwrap();
+    assert!(is_denied_ipv6_with_policy(link_local, &policy));
+}
+
+#[test]
+fn allow_private_never_unblocks_mapped_metadata() {
+    // ::ffff:169.254.169.254 — IPv4-mapped metadata bypass attempt.
+    let policy = allow_private();
+    let mapped: Ipv6Addr = "::ffff:169.254.169.254".parse().unwrap();
+    assert!(is_denied_ipv6_with_policy(mapped, &policy));
+}
+
+#[test]
+fn allow_private_does_not_affect_public_or_documentation() {
+    let policy = allow_private();
+    // Public stays allowed (it always was).
+    assert!(!is_denied_ipv4_with_policy(PUBLIC, &policy));
+    // Documentation range stays blocked (not relaxable).
+    assert!(is_denied_ipv4_with_policy(Ipv4Addr::new(192, 0, 2, 1), &policy));
+    // Broadcast stays blocked.
+    assert!(is_denied_ipv4_with_policy(Ipv4Addr::new(255, 255, 255, 255), &policy));
+}
+
+// ─── CIDR parsing / matching edge cases (boundaries) ───────────────────────────
+
+#[test]
+fn cidr_parse_rejects_bad_input() {
+    assert!(IpCidr::parse("nonsense").is_err());
+    assert!(IpCidr::parse("10.0.0.0/33").is_err());
+    assert!(IpCidr::parse("::/129").is_err());
+    assert!(IpCidr::parse("10.0.0.0/-1").is_err());
+}
+
+#[test]
+fn cidr_zero_prefix_matches_whole_family_but_not_across_families() {
+    let v4_any = IpCidr::parse("0.0.0.0/0").unwrap();
+    assert!(v4_any.contains(IpAddr::V4(PUBLIC)));
+    assert!(v4_any.contains(IpAddr::V4(LOOPBACK)));
+    // Never matches across families.
+    assert!(!v4_any.contains("::1".parse::<IpAddr>().unwrap()));
+}
+
+#[test]
+fn cidr_full_prefix_is_host_route() {
+    let host = IpCidr::parse("10.1.2.3/32").unwrap();
+    assert!(host.contains(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))));
+    assert!(!host.contains(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 4))));
+
+    let v6_host = IpCidr::parse("fd00::1/128").unwrap();
+    assert!(v6_host.contains("fd00::1".parse::<IpAddr>().unwrap()));
+    assert!(!v6_host.contains("fd00::2".parse::<IpAddr>().unwrap()));
+}
+
+#[test]
+fn cidr_masks_host_bits_at_parse_time() {
+    // 10.1.2.3/8 and 10.0.0.0/8 must be equal after canonicalisation.
+    assert_eq!(IpCidr::parse("10.1.2.3/8").unwrap(), IpCidr::parse("10.0.0.0/8").unwrap());
+}
+
+#[test]
+fn cidr_prefix_boundary_24() {
+    let net = IpCidr::parse("192.168.1.0/24").unwrap();
+    assert!(net.contains(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 0))));
+    assert!(net.contains(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 255))));
+    assert!(!net.contains(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 0))));
+}
+
+#[test]
+fn bare_ip_parses_as_host_route() {
+    let v4 = IpCidr::parse("10.0.0.5").unwrap();
+    assert!(v4.contains(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5))));
+    assert!(!v4.contains(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 6))));
+}
+
+// ─── Policy helpers ────────────────────────────────────────────────────────────
+
+#[test]
+fn deny_all_is_not_relaxed() {
+    assert!(!SsrfPolicy::deny_all().is_relaxed());
+}
+
+#[test]
+fn allow_private_and_allowlist_are_relaxed() {
+    assert!(allow_private().is_relaxed());
+    assert!(SsrfPolicy::deny_all().with_allowlist_entries(["10.0.0.0/8"]).is_relaxed());
+}

--- a/tests/ssrf_optout_tests.rs
+++ b/tests/ssrf_optout_tests.rs
@@ -24,7 +24,7 @@ const CORP_HOST: Ipv4Addr = Ipv4Addr::new(10, 252, 24, 131); // genai.booking.co
 const PRIVATE_192: Ipv4Addr = Ipv4Addr::new(192, 168, 1, 50);
 const PRIVATE_172: Ipv4Addr = Ipv4Addr::new(172, 16, 5, 5);
 const CGN: Ipv4Addr = Ipv4Addr::new(100, 64, 0, 1);
-const LOOPBACK: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
+const LOOPBACK: Ipv4Addr = Ipv4Addr::LOCALHOST;
 const AWS_METADATA: Ipv4Addr = Ipv4Addr::new(169, 254, 169, 254);
 const PUBLIC: Ipv4Addr = Ipv4Addr::new(93, 184, 216, 34); // example.com
 
@@ -189,10 +189,7 @@ fn allow_private_does_not_affect_public_or_documentation() {
         &policy
     ));
     // Broadcast stays blocked.
-    assert!(is_denied_ipv4_with_policy(
-        Ipv4Addr::new(255, 255, 255, 255),
-        &policy
-    ));
+    assert!(is_denied_ipv4_with_policy(Ipv4Addr::BROADCAST, &policy));
 }
 
 // ─── CIDR parsing / matching edge cases (boundaries) ───────────────────────────


### PR DESCRIPTION
## Summary

- SSRF protection remains **ON by default** — no existing behaviour changes
- Adds explicit opt-out for users intentionally fetching RFC 1918 / CGN / ULA addresses inside their own networks
- Loopback, link-local, cloud metadata endpoint, and all other special-purpose ranges stay blocked regardless of opt-out flags

## Opt-out surface

| Layer | Flag / param | Default |
|-------|-------------|---------|
| CLI | `--allow-private-ips` (blanket) | off |
| CLI | `--allow-private-ip <CIDR>` (repeatable, preferred) | empty |
| Env  | `NAB_SSRF_ALLOW_PRIVATE=1` | unset |
| Env  | `NAB_SSRF_ALLOWLIST=10.0.0.0/8,...` | unset |
| MCP  | `allow_private_ips: bool` | false |
| MCP  | `allow_private_ip: string[]` | [] |

## Always-blocked (never relaxable)

Loopback addresses, link-local range (including the AWS metadata endpoint 169.254.169.254), fe80::/10, plus multicast, broadcast, documentation, benchmarking, and all other special-purpose ranges defined in the existing ssrf.rs.

## Implementation notes

- `SsrfPolicy` struct carries per-call allow flags; default is `deny_all()`
- `is_relaxable()` gates exactly RFC1918+CGN (IPv4) and ULA fc00::/7 (IPv6) — the metadata endpoint is not in the relaxable set
- All 45 existing call sites are unchanged (original helpers delegate to `deny_all()` policy)
- `tracing::warn!` emitted whenever a relaxed address is permitted through
- `SsrfPolicy` threaded through `SafeRequestOptions`, CLI `FetchConfig`, MCP `FetchTool`, fetch_bridge (env-level), and the session redirect closure

## Tests

- 25 new tests in `tests/ssrf_optout_tests.rs` covering opt-out semantics, CIDR parsing, and 7 critical never-relaxable assertions (loopback, metadata endpoint, link-local IPv6, mapped-IPv6 metadata)
- 65 existing SSRF tests unchanged and passing
- 1328/1335 lib unit tests pass (7 pre-existing ignored)

## SECURITY REVIEW REQUIRED

This PR intentionally relaxes a security control. It warrants a focused review before merge:

- Confirm `is_relaxable()` boundary excludes all cloud metadata endpoints across providers
- Confirm the always-denied check in `is_denied_ipv4_with_policy` / `is_denied_ipv6_with_policy` runs before the relaxable path
- Review whether the `tracing::warn!` audit trail is sufficient for security visibility
- Assess whether the blanket `--allow-private-ips` flag is an acceptable UX surface given the exposure it introduces

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)
