### PR TITLE
feat(fingerprint): self-updating browser fingerprint (MIK-3058)

### DIFF
--- a/.github/workflows/bump-fingerprint.yml
+++ b/.github/workflows/bump-fingerprint.yml
@@ -1,0 +1,156 @@
+name: bump-fingerprint
+
+# Automatically refreshes the bundled browser-version fallback in
+# src/fingerprint/autoupdate.rs so the Default impl never drifts more than
+# ~4 weeks behind the live stable channel.
+#
+# How it works:
+#   1. Fetch current stable Chrome + Firefox versions from their official APIs.
+#   2. Patch the Default impl in-place via a Python script passed the JSON as files.
+#   3. If anything changed, open a PR labelled auto-merge-ok so it lands without
+#      manual review once CI passes.
+#
+# No cloud dependency is added to the runtime or build path — the fetch runs
+# only inside this CI job and writes static string literals into source code.
+# The runtime auto-updater (load_or_update) remains the primary mechanism;
+# these defaults are the offline / first-boot fallback only.
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC — Chrome releases typically ship on Tuesdays.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Refresh bundled browser-version defaults
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Fetch latest browser versions
+        run: |
+          curl -sf \
+            'https://versionhistory.googleapis.com/v1/chrome/platforms/all/channels/stable/versions' \
+            > /tmp/chrome.json || echo '{"versions":[]}' > /tmp/chrome.json
+          curl -sf \
+            'https://product-details.mozilla.org/1.0/firefox_versions.json' \
+            > /tmp/firefox.json || echo '{"LATEST_FIREFOX_VERSION":"0.0"}' > /tmp/firefox.json
+
+      - name: Patch autoupdate.rs
+        run: |
+          python3 - src/fingerprint/autoupdate.rs /tmp/chrome.json /tmp/firefox.json <<'PYEOF'
+          import json, re, sys
+          from datetime import datetime, timezone
+
+          source_path, chrome_path, ff_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+          chrome_data = json.loads(open(chrome_path).read())
+          ff_data = json.loads(open(ff_path).read())
+          today = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+
+          # Build Chrome tuples: top-5 unique majors, newest first
+          seen: dict = {}
+          for v in chrome_data.get("versions", []):
+              full = v.get("version", "")
+              major = full.split(".")[0]
+              if major and major not in seen:
+                  seen[major] = full
+          majors = sorted(seen, key=int, reverse=True)[:5]
+          if not majors:
+              print("WARNING: no Chrome versions found, skipping patch")
+              sys.exit(0)
+          chrome_block = "\n".join(
+              f'                ("{m}".into(), "{seen[m]}".into()),'
+              for m in majors
+          )
+
+          # Build Firefox lines: latest 4 major versions
+          latest_str = ff_data.get("LATEST_FIREFOX_VERSION", "0.0")
+          latest = int(latest_str.split(".")[0])
+          if latest == 0:
+              print("WARNING: no Firefox version found, skipping patch")
+              sys.exit(0)
+          ff_block = "\n".join(
+              f'                "{latest - i}.0".into(),'
+              for i in range(4)
+          )
+
+          src = open(source_path).read()
+
+          # Update the "Last refreshed" date in the comment
+          src = re.sub(
+              r'(// Last refreshed: )\d{4}-\d{2}-\d{2}',
+              rf'\g<1>{today}',
+              src,
+          )
+
+          # Replace chrome vec! body — match lines between vec![ and the closing ],
+          # anchored so we only touch the chrome field inside the Default impl.
+          def replace_chrome(m):
+              return f'{m.group(1)}\n{chrome_block}\n{m.group(2)}'
+
+          def replace_ff(m):
+              return f'{m.group(1)}\n{ff_block}\n{m.group(2)}'
+
+          src = re.sub(
+              r'(            chrome: vec!\[)\n(?:[ \t]+[^\n]+\n)+(            \],)',
+              replace_chrome,
+              src,
+          )
+          src = re.sub(
+              r'(            firefox: vec!\[)\n(?:[ \t]+[^\n]+\n)+(            \],)',
+              replace_ff,
+              src,
+          )
+
+          open(source_path, "w").write(src)
+          print(f"Patched {source_path} — Chrome {majors[0]}, Firefox {latest}, date {today}")
+          PYEOF
+
+      - name: Check for changes
+        id: check
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          echo "today=$TODAY" >> "$GITHUB_OUTPUT"
+          if git diff --quiet src/fingerprint/autoupdate.rs; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Bundled defaults are already current — no PR needed."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff src/fingerprint/autoupdate.rs
+          fi
+
+      - name: Commit and open PR
+        if: steps.check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TODAY: ${{ steps.check.outputs.today }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="chore/bump-fingerprint-${TODAY}"
+          git checkout -b "$BRANCH"
+          git add src/fingerprint/autoupdate.rs
+          git commit -m "chore(fingerprint): refresh bundled browser-version defaults ${TODAY}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore(fingerprint): refresh bundled browser-version defaults ${TODAY}" \
+            --body "Automated weekly refresh of the bundled fallback in \`src/fingerprint/autoupdate.rs\`.
+
+          The runtime auto-updater handles live refresh from Google's API; this PR keeps the static offline fallback current so \`bundled_chrome_default_is_not_stale\` and \`bundled_firefox_default_is_not_stale\` remain green between releases.
+
+          Sources:
+          - Chrome: \`versionhistory.googleapis.com\` (official Google API, no key required)
+          - Firefox: \`product-details.mozilla.org\` (official Mozilla API, no key required)
+
+          🤖 Generated by [bump-fingerprint workflow](../.github/workflows/bump-fingerprint.yml)" \
+            --label "auto-merge-ok" \
+            --base main \
+            --head "$BRANCH"

--- a/src/fingerprint/autoupdate.rs
+++ b/src/fingerprint/autoupdate.rs
@@ -319,24 +319,29 @@ impl Default for BrowserVersions {
         BrowserVersions {
             last_updated: now,
             safari_last_checked: now,
+            // Bundled fallback used only when offline / before the first
+            // successful API refresh. Kept fresh automatically by the
+            // `bump-fingerprint` CI workflow (see .github/workflows/) so the
+            // defaults never drift far from the live stable channel between
+            // releases. Last refreshed: 2026-06-02.
             chrome: vec![
-                ("131".into(), "131.0.0.0".into()),
-                ("130".into(), "130.0.0.0".into()),
-                ("129".into(), "129.0.0.0".into()),
-                ("128".into(), "128.0.0.0".into()),
-                ("127".into(), "127.0.0.0".into()),
+                ("149".into(), "149.0.7827.48".into()),
+                ("148".into(), "148.0.7778.216".into()),
+                ("147".into(), "147.0.7727.138".into()),
+                ("146".into(), "146.0.7680.178".into()),
+                ("145".into(), "145.0.7632.161".into()),
             ],
             firefox: vec![
-                "134.0".into(),
-                "133.0".into(),
-                "132.0".into(),
-                "131.0".into(),
+                "151.0".into(),
+                "150.0".into(),
+                "149.0".into(),
+                "148.0".into(),
             ],
             safari: vec![
+                ("18.5".into(), "620.1.16".into()),
+                ("18.4".into(), "620.1.16".into()),
+                ("18.3".into(), "619.1.26".into()),
                 ("18.2".into(), "619.1.15".into()),
-                ("18.1".into(), "619.1.15".into()),
-                ("18.0".into(), "618.1.15".into()),
-                ("17.6".into(), "605.1.15".into()),
             ],
         }
     }
@@ -346,6 +351,74 @@ impl Default for BrowserVersions {
 mod tests {
     use super::*;
     use chrono::Duration;
+
+    /// Floor for the bundled-default Chrome major version.
+    ///
+    /// The runtime auto-updater refreshes versions from Google's API, but when
+    /// nab runs fully offline (or before the first successful fetch) the
+    /// `Default` impl is the only fingerprint source. A bundled major that lags
+    /// the real stable channel by many releases is a detection signal, so this
+    /// floor guards against the defaults silently rotting between manual bumps.
+    ///
+    /// Keep this in lockstep with the `bump-fingerprint` CI workflow, which
+    /// refreshes the defaults and is the mechanism that keeps this test passing
+    /// without hand edits.
+    const MIN_BUNDLED_CHROME_MAJOR: u32 = 140;
+    const MIN_BUNDLED_FIREFOX_MAJOR: u32 = 140;
+
+    fn highest_major<'a>(versions: impl IntoIterator<Item = &'a str>) -> u32 {
+        versions
+            .into_iter()
+            .filter_map(|v| v.split('.').next())
+            .filter_map(|m| m.parse::<u32>().ok())
+            .max()
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn bundled_chrome_default_is_not_stale() {
+        let defaults = BrowserVersions::default();
+        let newest = highest_major(defaults.chrome.iter().map(|(major, _)| major.as_str()));
+        assert!(
+            newest >= MIN_BUNDLED_CHROME_MAJOR,
+            "bundled Chrome default major {newest} is below floor {MIN_BUNDLED_CHROME_MAJOR}; \
+             refresh src/fingerprint/autoupdate.rs Default impl (the bump-fingerprint workflow does this automatically)"
+        );
+    }
+
+    #[test]
+    fn bundled_firefox_default_is_not_stale() {
+        let defaults = BrowserVersions::default();
+        let newest = highest_major(defaults.firefox.iter().map(String::as_str));
+        assert!(
+            newest >= MIN_BUNDLED_FIREFOX_MAJOR,
+            "bundled Firefox default major {newest} is below floor {MIN_BUNDLED_FIREFOX_MAJOR}; \
+             refresh src/fingerprint/autoupdate.rs Default impl"
+        );
+    }
+
+    #[test]
+    fn bundled_defaults_are_internally_consistent() {
+        let defaults = BrowserVersions::default();
+        // Chrome: every full version string starts with its declared major.
+        for (major, full) in &defaults.chrome {
+            assert!(
+                full.starts_with(major),
+                "Chrome full version {full} should start with major {major}"
+            );
+        }
+        // Chrome majors are strictly descending (newest first, no duplicates).
+        let majors: Vec<u32> = defaults
+            .chrome
+            .iter()
+            .filter_map(|(m, _)| m.parse::<u32>().ok())
+            .collect();
+        assert_eq!(majors.len(), defaults.chrome.len(), "all majors parse");
+        assert!(
+            majors.windows(2).all(|w| w[0] > w[1]),
+            "Chrome majors must be strictly descending and unique: {majors:?}"
+        );
+    }
 
     #[test]
     fn test_staleness() {


### PR DESCRIPTION
## Summary

Completes the self-updating browser fingerprint feature (MIK-3058) by closing the remaining gap: the offline fallback that ships in the binary.

The runtime auto-updater (`load_or_update` + `fetch_and_update` in `src/fingerprint/autoupdate.rs`) was already in place and fetches current stable versions from Google's and Mozilla's official APIs. This change addresses the bundled `Default` fallback used when no runtime cache exists and no network is available.

## Changes

- Refresh bundled `Default` fallback to current stable channels: Chrome 131 to 149 (real patch versions, not `.0.0.0` placeholders), Firefox 134 to 151, Safari 18.2 to 18.5.
- Add three regression tests guarding against future fallback rot:
  - `bundled_chrome_default_is_not_stale`
  - `bundled_firefox_default_is_not_stale`
  - `bundled_defaults_are_internally_consistent` (floor: major version at least 140)
- Add `.github/workflows/bump-fingerprint.yml` — a scheduled (Monday) CI job that queries the official browser version APIs (no auth, no cloud dependency on the default path) and opens a PR when the bundled fallback is stale, removing the need for manual version bumps.

## Acceptance criteria

- MIK-3058.FP.1 — Bundled fallback reflects a current stable channel, not a stale placeholder. Met: Chrome 149 / Firefox 151 / Safari 18.5.
- MIK-3058.FP.2 — Tests guard the fallback against silent staleness. Met: 3 new guard tests added and passing.
- MIK-3058.FP.3 — Future bumps are automated rather than manual. Met: scheduled workflow added.

## Test evidence

- `cargo build --locked` — success.
- `cargo build --locked --bin nab --no-default-features --features cli,http3` — success.
- `cargo test --locked` — 1885 passed, 0 failed, 12 ignored (22 suites).
- New fingerprint guard tests run directly — 3 passed, 0 failed.
- `fingerprint::autoupdate` module — 7 passed, 2 ignored (live-network tests, gated).
- `cargo fmt --all --check` — clean.
- `cargo clippy --locked --all-targets -- -D warnings` — no issues.
- `actionlint .github/workflows/bump-fingerprint.yml` — no findings.

Refs MIK-3058.
