### PR TITLE
feat(session): cookie and storage-state export for MIK-5359 Phase 1

### DIFF
--- a/docs/design/2026-06-01-nab-task-engine-browser-modes.md
+++ b/docs/design/2026-06-01-nab-task-engine-browser-modes.md
@@ -1,0 +1,115 @@
+# ADR: nab Task Engine — Browser-Mode Dimensions for Rung-3 Execution
+
+**Date:** 2026-06-01
+**Ticket:** MIK-5359 (Phase 1)
+**Status:** Accepted
+**Author:** MikkoParkkola / claude-elite session
+
+## Context
+
+The nab task engine (design: `2026-05-31-nab-task-engine.md`) escalates to an
+external browser at rung 3 via the opt-in `chromiumoxide` CDP feature. Before
+rung-3 work begins, the operator ratified three orthogonal configuration
+dimensions that any rung-3 browser launch must model. This ADR records those
+decisions, their CLI/MCP surface, the mapping to `chromiumoxide` primitives, and
+the auth-seeding contract from `export.1`.
+
+## Decision
+
+### Dimension 1 — Visibility (`headless` vs `headed`)
+
+| | Detail |
+|---|---|
+| **Default** | Headless (`--headless` in CDP / `BrowserConfig::builder().headless(true)`) |
+| **Override flag** | `--headed` CLI flag; `headed: bool` MCP param (default `false`) |
+| **Auto-engage** | Test-mode detection (`NAB_TEST=1` or `--test` flag) and interactive chat-portal sessions engage `--headed` automatically so the operator can observe, solve CAPTCHAs, and approve 2FA |
+| **Rationale** | Headless is the default for unattended agents; headed is the safety net for human-in-the-loop flows. Automat detection prevents agents from silently skipping CAPTCHA prompts in CI |
+
+### Dimension 2 — Persistence/Isolation (`persistent` vs `incognito`)
+
+| | Detail |
+|---|---|
+| **Default** | Persistent — the browser launches with the user's existing Chrome/Brave profile directory (same as today's `--remote-debugging-port=9222` flow) |
+| **Override flag** | `--incognito` CLI flag; `incognito: bool` MCP param (default `false`) |
+| **Per-site policy** | A TOML list `incognito_sites = ["example.com", …]` in `~/.config/nab/task.toml` forces incognito for those domains regardless of the flag, so operators need not remember to pass `--incognito` for sensitive or third-party domains |
+| **chromiumoxide mapping** | Incognito → `BrowserConfig::builder().user_data_dir(tempdir())` for a throwaway profile **or** `Browser::new_incognito_context()` if the CDP target is already running. Nothing is written back to the normal browser profile: no history entry, no cookie persistence, no `localStorage`/`IndexedDB` visible in later sessions |
+| **Rationale** | Operator-defined incognito prevents accidental persistent side-effects (logins to third-party services, history pollution) on automation tasks the user did not intend to be durable |
+
+### Dimension 3 — Auth Seeding (`cookieless` vs `seeded-from-export`)
+
+| | Detail |
+|---|---|
+| **Default** | Cookieless (incognito context starts with an empty cookie jar) |
+| **Seeded mode** | Pass a `storage_state` JSON path via `--storage-state <path>` CLI or `storage_state_path: Option<PathBuf>` MCP param. nab injects the cookies (and optionally `localStorage` entries) into the CDP session at launch via `Network.setCookies` + `Runtime.evaluate(localStorage.setItem…)` |
+| **Export source** | `nab cookies export --format playwright [--output path]` (MIK-5359 `export.1`, shipped in this PR) produces the seed artifact |
+| **Auth-seeded incognito** | The primary use case: `--incognito --storage-state auth.json`. The context starts logged-in (real session cookies injected), but nothing persists after the browser closes. Session is discarded on context teardown |
+| **Live-chat pattern** | `--headed --incognito --storage-state auth.json` — logged-in, visible to the operator, fully isolated. This is the canonical configuration for interactive sessions on third-party portals |
+| **Rationale** | Separates "what credentials does the agent start with" from "what isolation model does the session use". An incognito context without seeding is a clean anonymous session; with seeding it is a logged-in throwaway session |
+
+## Combined CLI/MCP Surface
+
+```
+# CLI
+nab task "<goal>" <url> [--headed] [--incognito] [--storage-state path/to/auth.json]
+
+# MCP (nab-mcp tool schema fragment)
+{
+  "headed":        { "type": "boolean", "default": false },
+  "incognito":     { "type": "boolean", "default": false },
+  "storage_state": { "type": "string",  "description": "Path to Playwright storage_state JSON" }
+}
+```
+
+Defaults (`headed=false`, `incognito=false`, no `storage_state`) reproduce the
+current `nab login --browser` behavior exactly — no behavior change to existing
+callers.
+
+## chromiumoxide Mapping
+
+| Mode | chromiumoxide config |
+|---|---|
+| Headless (default) | `BrowserConfig::builder().headless(true).build()` |
+| Headed | `BrowserConfig::builder().headless(false).build()` |
+| Persistent (default) | existing user-data-dir (Chrome/Brave profile path) |
+| Incognito (temp dir) | `BrowserConfig::builder().user_data_dir(tempdir()).build()` |
+| Incognito (already-running Chrome) | `Browser::new_incognito_context()` CDP call |
+| Seeded auth | After context open: `Network.setCookies(cookies)` from storage_state |
+
+## Firefox/Safari Fidelity Note (Best-Effort)
+
+`nab cookies export --format playwright` produces faithful metadata for
+Chromium-family browsers (Brave/Chrome/Edge): real `domain`, `path`, `expires`,
+`httpOnly`, `secure`, and `sameSite` are read from the `SQLite` cookie database.
+
+For Firefox/Safari/Python-fallback extraction, only `name`/`value` are currently
+available. The exported storage_state for these sources synthesizes safe defaults
+(`domain` = queried domain, `path = "/"`, session expiry, `secure=true`,
+`sameSite="Lax"`). The storage_state is schema-valid and will authenticate on
+the queried domain, but may miss cookies on sub-domains not covered by the
+synthesized domain. Users on Firefox/Safari should prefer `--cookies brave` or
+`--cookies chrome` when exporting for rung-3 seeding.
+
+This limitation is Phase-1 only. Phase 2 will extend `browser_cookie3`-backed
+extraction to emit full metadata.
+
+## Consequences
+
+- `nab cookies export --format playwright` (shipped in this PR) is the only
+  authoritative way to produce a seed artifact. Do not hand-craft storage_state
+  JSON — the Chromium epoch conversion and `samesite` integer mapping are
+  non-obvious and are handled automatically by the exporter.
+- Per-site `incognito_sites` config is the right place for operator policy;
+  ad-hoc `--incognito` flags are for one-off overrides.
+- Rung 3 requires the `browser` cargo feature. The default build (`--features
+  default`) never compiles or links `chromiumoxide`. All three dimensions are
+  no-ops on the default build and return a `delegate_to_browser` response.
+- The `storage_state` seed path is passed through nab's `ssrf::validate_url`
+  equivalent for the file path (path traversal guard) before being read.
+
+## References
+
+- Design doc: `docs/design/2026-05-31-nab-task-engine.md`
+- Cookie export implementation: `src/auth/cookies/storage_state.rs`
+- MIK-5359 (Linear)
+- Playwright `storageState` schema: https://playwright.dev/docs/api/class-browsercontext#browser-context-storage-state
+- chromiumoxide: https://github.com/mattsse/chromiumoxide

--- a/src/auth/cookies/db.rs
+++ b/src/auth/cookies/db.rs
@@ -24,6 +24,27 @@ pub(super) struct CookieRow {
     pub(super) encrypted_bytes: Vec<u8>,
 }
 
+/// A cookie row enriched with the metadata a Playwright `storage_state` needs.
+///
+/// Distinct from [`CookieRow`] because the storage-state export must keep every
+/// cookie individually (a `Vec`), never collapse by name like the fetch hot path
+/// does: the same cookie name commonly appears on multiple host keys / paths and
+/// each is a separate credential.
+pub(super) struct RichCookieRow {
+    pub(super) name: String,
+    pub(super) value: String,
+    pub(super) encrypted_bytes: Vec<u8>,
+    /// Real Chromium `host_key` (e.g. `.github.com`) — load-bearing for auth.
+    pub(super) host_key: String,
+    pub(super) path: String,
+    /// Chromium `expires_utc`: microseconds since 1601-01-01, `0` for session.
+    pub(super) expires_utc: i64,
+    pub(super) is_httponly: bool,
+    pub(super) is_secure: bool,
+    /// Chromium `samesite`: `-1` unspecified, `0` None, `1` Lax, `2` Strict.
+    pub(super) samesite: i64,
+}
+
 // ─── DB interaction ───────────────────────────────────────────────────────────
 
 /// Copy the browser cookie database to a temp directory (avoids locking issues).
@@ -91,6 +112,41 @@ pub(super) fn query_cookie_db(temp_db: &std::path::Path, domain: &str) -> Result
     Ok(parse_cookie_rows(&stdout))
 }
 
+/// Like [`query_cookie_db`] but selects the full metadata each cookie carries,
+/// for a faithful Playwright `storage_state` export.
+///
+/// Returns one [`RichCookieRow`] per database row (never collapsed by name).
+pub(super) fn query_cookie_db_rich(
+    temp_db: &std::path::Path,
+    domain: &str,
+) -> Result<Vec<RichCookieRow>> {
+    let conditions = build_domain_conditions(domain);
+    let where_clause = conditions.join(" OR ");
+    // Order matters: parse_rich_cookie_rows reads columns positionally.
+    let query = format!(
+        "SELECT name, value, hex(encrypted_value), host_key, path, expires_utc, \
+         is_httponly, is_secure, samesite FROM cookies WHERE {where_clause}"
+    );
+    debug!("Rich cookie SQL query for '{}': WHERE {}", domain, where_clause);
+
+    let temp_db_str = temp_db
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("Invalid temp database path"))?;
+    let output = Command::new("sqlite3")
+        .args(["-separator", "\t", temp_db_str, &query])
+        .output()
+        .context("Failed to query cookie database")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        warn!("SQLite rich query failed: {}", stderr);
+        return Ok(Vec::new());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(parse_rich_cookie_rows(&stdout))
+}
+
 // ─── Parsing ──────────────────────────────────────────────────────────────────
 
 /// Build SQL `host_key` conditions for `domain` and its parent domains.
@@ -154,6 +210,40 @@ pub(super) fn parse_cookie_rows(stdout: &str) -> Vec<CookieRow> {
     rows
 }
 
+/// Parse tab-separated rich-query output into [`RichCookieRow`] structs.
+///
+/// Expects nine tab-separated columns in the order emitted by
+/// [`query_cookie_db_rich`]: `name, value, hex(encrypted_value), host_key, path,
+/// expires_utc, is_httponly, is_secure, samesite`. The first three use
+/// `splitn(3,…)` semantics historically, but here every field after the hex blob
+/// is a fixed integer/short string, so a positional `splitn(9, …)` is unambiguous.
+pub(super) fn parse_rich_cookie_rows(stdout: &str) -> Vec<RichCookieRow> {
+    let mut rows = Vec::new();
+    for line in stdout.lines() {
+        let parts: Vec<&str> = line.splitn(9, '\t').collect();
+        if parts.len() < 9 {
+            continue;
+        }
+        let encrypted_bytes = if parts[2].is_empty() {
+            Vec::new()
+        } else {
+            hex::decode(parts[2]).unwrap_or_default()
+        };
+        rows.push(RichCookieRow {
+            name: parts[0].to_string(),
+            value: parts[1].to_string(),
+            encrypted_bytes,
+            host_key: parts[3].to_string(),
+            path: parts[4].to_string(),
+            expires_utc: parts[5].parse().unwrap_or(0),
+            is_httponly: parts[6] == "1",
+            is_secure: parts[7] == "1",
+            samesite: parts[8].trim().parse().unwrap_or(-1),
+        });
+    }
+    rows
+}
+
 // ─── Decryption orchestration ────────────────────────────────────────────────
 
 /// Decrypt cookie rows into a map of `name -> plaintext value`.
@@ -201,9 +291,158 @@ pub(super) fn decrypt_rows(
     cookies
 }
 
+/// Decrypt rich cookie rows into faithful Playwright cookies.
+///
+/// Mirrors [`decrypt_rows`] (plaintext as-is, encrypted requires `key`, domain
+/// tag stripped when present) but preserves per-row metadata and never collapses
+/// by name — so two same-named cookies on different hosts both survive.
+pub(super) fn decrypt_rich_rows(
+    rows: Vec<RichCookieRow>,
+    key: Option<&[u8]>,
+    has_domain_tag: bool,
+) -> Vec<crate::auth::cookies::storage_state::PlaywrightCookie> {
+    use crate::auth::cookies::storage_state::{
+        PlaywrightCookie, chromium_expiry_to_unix, chromium_samesite_to_playwright,
+    };
+
+    let mut cookies = Vec::with_capacity(rows.len());
+    for row in rows {
+        let value = if !row.value.is_empty() {
+            row.value
+        } else if row.encrypted_bytes.is_empty() {
+            continue;
+        } else if let Some(k) = key {
+            match decrypt_cookie_value(&row.encrypted_bytes, k, has_domain_tag) {
+                Ok(plain) => plain,
+                Err(e) => {
+                    warn!("Cookie decryption failed for '{}': {}", row.name, e);
+                    continue;
+                }
+            }
+        } else {
+            debug!(
+                "Skipping encrypted cookie '{}' — no key available",
+                row.name
+            );
+            continue;
+        };
+
+        cookies.push(PlaywrightCookie {
+            name: row.name,
+            value,
+            domain: row.host_key,
+            path: row.path,
+            expires: chromium_expiry_to_unix(row.expires_utc),
+            http_only: row.is_httponly,
+            secure: row.is_secure,
+            same_site: chromium_samesite_to_playwright(row.samesite),
+        });
+    }
+    cookies
+}
 /// Query the schema version of `temp_db` and return whether domain tags are present.
 pub(super) fn has_domain_tag(temp_db: &std::path::Path) -> bool {
     let version = query_db_schema_version(temp_db);
     debug!("Cookie DB schema v{version}");
     version >= SCHEMA_VERSION_WITH_DOMAIN_TAG
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_rich_rows_reads_all_metadata_columns_positionally() {
+        // GIVEN tab-separated rich-query output with two rows (one plaintext,
+        // one with an encrypted hex blob) covering distinct samesite values.
+        // WHEN parsed
+        // THEN every metadata column is read into the right field.
+        let stdout = "sess\tplain\t\t.github.com\t/\t13437022686718487\t1\t1\t2\n\
+                      tok\t\t763130\tapi.github.com\t/v3\t0\t0\t0\t-1\n";
+        let rows = parse_rich_cookie_rows(stdout);
+        assert_eq!(rows.len(), 2);
+
+        let a = &rows[0];
+        assert_eq!(a.name, "sess");
+        assert_eq!(a.value, "plain");
+        assert!(a.encrypted_bytes.is_empty());
+        assert_eq!(a.host_key, ".github.com");
+        assert_eq!(a.path, "/");
+        assert_eq!(a.expires_utc, 13_437_022_686_718_487);
+        assert!(a.is_httponly);
+        assert!(a.is_secure);
+        assert_eq!(a.samesite, 2);
+
+        let b = &rows[1];
+        assert_eq!(b.name, "tok");
+        assert!(b.value.is_empty());
+        assert_eq!(b.encrypted_bytes, hex::decode("763130").unwrap());
+        assert_eq!(b.host_key, "api.github.com");
+        assert_eq!(b.path, "/v3");
+        assert_eq!(b.expires_utc, 0);
+        assert!(!b.is_httponly);
+        assert!(!b.is_secure);
+        assert_eq!(b.samesite, -1);
+    }
+
+    #[test]
+    fn parse_rich_rows_skips_short_lines() {
+        // Fewer than nine columns → not a valid cookie row, skipped.
+        let rows = parse_rich_cookie_rows("only\ttwo\tcols\n");
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn decrypt_rich_rows_preserves_same_name_on_different_hosts() {
+        // GIVEN two plaintext cookies sharing a name on different host keys
+        // WHEN decrypted
+        // THEN both survive as distinct entries (no name-collapse), proving the
+        // storage_state path keeps every credential.
+        let rows = vec![
+            RichCookieRow {
+                name: "s".into(),
+                value: "1".into(),
+                encrypted_bytes: Vec::new(),
+                host_key: ".github.com".into(),
+                path: "/".into(),
+                expires_utc: 0,
+                is_httponly: true,
+                is_secure: true,
+                samesite: 1,
+            },
+            RichCookieRow {
+                name: "s".into(),
+                value: "2".into(),
+                encrypted_bytes: Vec::new(),
+                host_key: "api.github.com".into(),
+                path: "/".into(),
+                expires_utc: 0,
+                is_httponly: false,
+                is_secure: false,
+                samesite: 0,
+            },
+        ];
+        let out = decrypt_rich_rows(rows, None, false);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].domain, ".github.com");
+        assert_eq!(out[1].domain, "api.github.com");
+        assert_eq!(out[1].value, "2");
+    }
+
+    #[test]
+    fn decrypt_rich_rows_skips_encrypted_without_key() {
+        // An encrypted row with no key available is dropped, not surfaced empty.
+        let rows = vec![RichCookieRow {
+            name: "enc".into(),
+            value: String::new(),
+            encrypted_bytes: vec![1, 2, 3],
+            host_key: ".x.com".into(),
+            path: "/".into(),
+            expires_utc: 0,
+            is_httponly: false,
+            is_secure: true,
+            samesite: 1,
+        }];
+        assert!(decrypt_rich_rows(rows, None, false).is_empty());
+    }
 }

--- a/src/auth/cookies/db.rs
+++ b/src/auth/cookies/db.rs
@@ -127,7 +127,10 @@ pub(super) fn query_cookie_db_rich(
         "SELECT name, value, hex(encrypted_value), host_key, path, expires_utc, \
          is_httponly, is_secure, samesite FROM cookies WHERE {where_clause}"
     );
-    debug!("Rich cookie SQL query for '{}': WHERE {}", domain, where_clause);
+    debug!(
+        "Rich cookie SQL query for '{}': WHERE {}",
+        domain, where_clause
+    );
 
     let temp_db_str = temp_db
         .to_str()

--- a/src/auth/cookies/mod.rs
+++ b/src/auth/cookies/mod.rs
@@ -15,6 +15,7 @@ pub use crypto::{decrypt_cookie_value, derive_cookie_key};
 
 mod crypto;
 mod db;
+pub mod storage_state;
 #[cfg(test)]
 mod tests;
 
@@ -26,6 +27,8 @@ use tracing::{debug, info, warn};
 
 use super::{Credential, OnePasswordAuth};
 use db::{copy_db_to_temp, decrypt_rows, domain_candidates, has_domain_tag, query_cookie_db};
+use db::{decrypt_rich_rows, query_cookie_db_rich};
+use storage_state::{PlaywrightCookie, SameSite};
 
 // ─── CookieSource ─────────────────────────────────────────────────────────────
 
@@ -230,6 +233,83 @@ except Exception as e:
             .collect::<Vec<_>>()
             .join("; ");
         Ok(header)
+    }
+
+    /// Extract cookies for a domain as faithful Playwright `storage_state`
+    /// cookies — with real `domain`/`path`/`expires`/`httpOnly`/`secure`/
+    /// `sameSite` metadata.
+    ///
+    /// Chromium-family browsers (Brave/Chrome/Edge/…) get full fidelity from the
+    /// native `SQLite` path: every row is preserved individually, so two same-named
+    /// cookies on different host keys both survive (unlike [`Self::get_cookies`],
+    /// which collapses by name for the fetch hot path).
+    ///
+    /// Firefox/Safari and the Python fallback currently surface only name/value;
+    /// those are returned with safe defaults (`domain` = the queried domain,
+    /// `path` = `/`, session expiry, `secure`, `Lax`) — best-effort, as recorded
+    /// in `docs/design/2026-06-01-nab-task-engine-browser-modes.md`.
+    ///
+    /// # Errors
+    /// Propagates filesystem/Keychain errors from the native extraction path.
+    pub fn get_cookies_rich(&self, domain: &str) -> Result<Vec<PlaywrightCookie>> {
+        debug!("Getting rich cookies for {} from {:?}", domain, self);
+
+        match self.get_cookies_rich_native(domain) {
+            Ok(cookies) if !cookies.is_empty() => {
+                info!("Native rich extraction: {} cookies", cookies.len());
+                return Ok(cookies);
+            }
+            Ok(_) => debug!("Native rich extraction empty, falling back to name/value"),
+            Err(e) => debug!("Native rich extraction failed: {e}, falling back to name/value"),
+        }
+
+        // Fallback: name/value only (Firefox/Safari/Python). Synthesize safe
+        // metadata defaults so the storage_state is still schema-valid.
+        let flat = self.get_cookies(domain)?;
+        Ok(flat
+            .into_iter()
+            .map(|(name, value)| synthesize_cookie(name, value, domain))
+            .collect())
+    }
+
+    /// Native Rust rich extraction from the Chromium `SQLite` database.
+    fn get_cookies_rich_native(self, domain: &str) -> Result<Vec<PlaywrightCookie>> {
+        let cookie_path = self
+            .cookie_path()
+            .context("Could not determine cookie path")?;
+        if !cookie_path.exists() {
+            warn!("Cookie database not found: {:?}", cookie_path);
+            return Ok(Vec::new());
+        }
+
+        let temp_db = copy_db_to_temp(&cookie_path)?;
+        let domain_tag = has_domain_tag(&temp_db);
+        let rows = query_cookie_db_rich(&temp_db, domain)?;
+        if let Some(parent) = temp_db.parent() {
+            let _ = std::fs::remove_dir_all(parent);
+        }
+
+        let key = self.get_keychain_key().ok();
+        Ok(decrypt_rich_rows(rows, key.as_deref(), domain_tag))
+    }
+}
+
+/// Build a best-effort Playwright cookie from a bare name/value pair.
+///
+/// Used for sources that surface only name/value (Firefox, Safari, the Python
+/// `browser_cookie3` fallback). Defaults are conservative: the queried `domain`
+/// (leading dot preserved if present), root `path`, session expiry, `secure`,
+/// and `Lax` sameSite. Documented as best-effort in the browser-modes ADR.
+fn synthesize_cookie(name: String, value: String, domain: &str) -> PlaywrightCookie {
+    PlaywrightCookie {
+        name,
+        value,
+        domain: domain.to_string(),
+        path: "/".to_string(),
+        expires: -1.0,
+        http_only: false,
+        secure: true,
+        same_site: SameSite::Lax,
     }
 }
 

--- a/src/auth/cookies/storage_state.rs
+++ b/src/auth/cookies/storage_state.rs
@@ -124,7 +124,11 @@ pub fn chromium_expiry_to_unix(expires_utc: i64) -> f64 {
     // Integer-divide microseconds → seconds before the epoch shift to avoid
     // float precision loss on the ~13-quadrillion magnitude.
     let unix_secs = expires_utc / 1_000_000 - WINDOWS_TO_UNIX_EPOCH_SECS;
-    if unix_secs <= 0 { -1.0 } else { unix_secs as f64 }
+    if unix_secs <= 0 {
+        -1.0
+    } else {
+        unix_secs as f64
+    }
 }
 
 /// Map a Chromium `samesite` integer to the Playwright [`SameSite`] enum.
@@ -166,7 +170,10 @@ mod tests {
         // THEN the result is the exact Unix-seconds value, not an approximation.
         // 13_437_022_686_718_487 / 1_000_000 = 13_437_022_686
         // 13_437_022_686 - 11_644_473_600 = 1_792_549_086
-        assert_eq!(chromium_expiry_to_unix(13_437_022_686_718_487), 1_792_549_086.0);
+        assert_eq!(
+            chromium_expiry_to_unix(13_437_022_686_718_487),
+            1_792_549_086.0
+        );
     }
 
     #[test]
@@ -184,7 +191,10 @@ mod tests {
     fn samesite_serializes_to_playwright_enum_strings() {
         // Playwright rejects anything other than Strict/Lax/None — assert the
         // exact JSON spellings.
-        assert_eq!(serde_json::to_string(&SameSite::Strict).unwrap(), "\"Strict\"");
+        assert_eq!(
+            serde_json::to_string(&SameSite::Strict).unwrap(),
+            "\"Strict\""
+        );
         assert_eq!(serde_json::to_string(&SameSite::Lax).unwrap(), "\"Lax\"");
         assert_eq!(serde_json::to_string(&SameSite::None).unwrap(), "\"None\"");
     }

--- a/src/auth/cookies/storage_state.rs
+++ b/src/auth/cookies/storage_state.rs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+
+//! Playwright / CDP `storage_state` export (`nab cookies export --format playwright`).
+//!
+//! Implements MIK-5359 acceptance criterion `export.1`: convert the user's
+//! browser cookies into a schema-valid Playwright [`StorageState`] JSON document
+//! that can seed a logged-in browser context later (rung 3 of the task engine —
+//! see `docs/design/2026-06-01-nab-task-engine-browser-modes.md`).
+//!
+//! The export is intentionally **faithful** for Chromium-family browsers: real
+//! `domain`, `path`, `expires`, `httpOnly`, `secure`, and `sameSite` are pulled
+//! from the cookie database so the seeded context authenticates correctly. A
+//! storage-state with synthesized defaults would pass a shape check yet silently
+//! fail to authenticate (wrong `domain` → the browser never sends the cookie).
+//!
+//! Firefox / Safari / Python-fallback extraction currently surface only
+//! `name`/`value` (see [`super::CookieSource::get_cookies`]); for those sources
+//! the metadata is best-effort with safe defaults, documented in the ADR.
+//!
+//! `origins[]` (localStorage) is always emitted empty: per `export.1` that is
+//! acceptable, and nab never reads page-local web storage from disk.
+
+use serde::{Deserialize, Serialize};
+
+/// Chromium stores timestamps as microseconds since 1601-01-01 (the Windows
+/// FILETIME epoch). Playwright/Unix expect seconds since 1970-01-01. This is the
+/// offset in seconds between the two epochs.
+const WINDOWS_TO_UNIX_EPOCH_SECS: i64 = 11_644_473_600;
+
+/// A single cookie in Playwright `storage_state` form.
+///
+/// Field names match the Playwright [`storageState`] schema exactly (camelCase),
+/// so the serialized JSON is consumed without a translation layer.
+///
+/// [`storageState`]: https://playwright.dev/docs/api/class-browsercontext#browser-context-storage-state
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PlaywrightCookie {
+    pub name: String,
+    pub value: String,
+    /// Cookie host key, e.g. `.github.com` or `api.github.com`. Load-bearing for
+    /// authentication — must be the real `host_key`, never synthesized.
+    pub domain: String,
+    pub path: String,
+    /// Unix seconds; `-1` denotes a session cookie (Playwright convention).
+    pub expires: f64,
+    #[serde(rename = "httpOnly")]
+    pub http_only: bool,
+    pub secure: bool,
+    /// One of `"Strict"`, `"Lax"`, `"None"` — the only values Playwright accepts.
+    #[serde(rename = "sameSite")]
+    pub same_site: SameSite,
+}
+
+/// Playwright-accepted `sameSite` enum. Chromium persists an integer; Playwright
+/// rejects anything outside these three string variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SameSite {
+    Strict,
+    Lax,
+    None,
+}
+
+/// An origin's local storage. Always emitted empty for `export.1` (`origins: []`),
+/// but typed so a future phase can populate it without a wire-format change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OriginState {
+    pub origin: String,
+    #[serde(rename = "localStorage")]
+    pub local_storage: Vec<LocalStorageEntry>,
+}
+
+/// A single `localStorage` key/value pair.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocalStorageEntry {
+    pub name: String,
+    pub value: String,
+}
+
+/// A complete Playwright / CDP `storage_state` document.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StorageState {
+    pub cookies: Vec<PlaywrightCookie>,
+    pub origins: Vec<OriginState>,
+}
+
+impl StorageState {
+    /// Build a `storage_state` from cookies, with an empty `origins` list.
+    #[must_use]
+    pub fn from_cookies(cookies: Vec<PlaywrightCookie>) -> Self {
+        Self {
+            cookies,
+            origins: Vec::new(),
+        }
+    }
+
+    /// Serialize to pretty JSON (the on-disk / stdout form).
+    ///
+    /// # Errors
+    /// Returns an error only if serde fails to serialize, which cannot happen for
+    /// this fully-owned, string-keyed structure.
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+}
+
+/// Convert a Chromium `expires_utc` value to a Playwright `expires` field.
+///
+/// Chromium stores microseconds since 1601-01-01; `0` means a session cookie.
+/// Playwright wants Unix seconds, with `-1` for session cookies.
+///
+/// # Examples
+/// ```
+/// use nab::auth::cookies::storage_state::chromium_expiry_to_unix;
+/// // Session cookie.
+/// assert_eq!(chromium_expiry_to_unix(0), -1.0);
+/// // 13_437_022_686_718_487 µs since 1601 → 2026-10-21T... Unix seconds.
+/// assert_eq!(chromium_expiry_to_unix(13_437_022_686_718_487), 1_792_549_086.0);
+/// ```
+#[must_use]
+pub fn chromium_expiry_to_unix(expires_utc: i64) -> f64 {
+    if expires_utc <= 0 {
+        return -1.0;
+    }
+    // Integer-divide microseconds → seconds before the epoch shift to avoid
+    // float precision loss on the ~13-quadrillion magnitude.
+    let unix_secs = expires_utc / 1_000_000 - WINDOWS_TO_UNIX_EPOCH_SECS;
+    if unix_secs <= 0 { -1.0 } else { unix_secs as f64 }
+}
+
+/// Map a Chromium `samesite` integer to the Playwright [`SameSite`] enum.
+///
+/// Chromium values: `-1` unspecified, `0` None, `1` Lax, `2` Strict. Playwright
+/// accepts only `Strict`/`Lax`/`None`, so "unspecified" maps to the browser
+/// default (`Lax`) — a valid enum string, never an empty/invalid one.
+#[must_use]
+pub fn chromium_samesite_to_playwright(samesite: i64) -> SameSite {
+    match samesite {
+        0 => SameSite::None,
+        2 => SameSite::Strict,
+        // 1 (Lax) and -1 (unspecified → browser default Lax) and any unknown.
+        _ => SameSite::Lax,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chromium_session_expiry_maps_to_minus_one() {
+        // GIVEN a Chromium session cookie (expires_utc == 0)
+        // WHEN converted
+        // THEN Playwright sees the session sentinel -1.
+        assert_eq!(chromium_expiry_to_unix(0), -1.0);
+    }
+
+    #[test]
+    fn chromium_negative_expiry_maps_to_minus_one() {
+        assert_eq!(chromium_expiry_to_unix(-5), -1.0);
+    }
+
+    #[test]
+    fn chromium_real_expiry_uses_exact_epoch_formula() {
+        // GIVEN a real expires_utc read from a live Brave cookie DB
+        // WHEN converted with the FILETIME→Unix formula
+        // THEN the result is the exact Unix-seconds value, not an approximation.
+        // 13_437_022_686_718_487 / 1_000_000 = 13_437_022_686
+        // 13_437_022_686 - 11_644_473_600 = 1_792_549_086
+        assert_eq!(chromium_expiry_to_unix(13_437_022_686_718_487), 1_792_549_086.0);
+    }
+
+    #[test]
+    fn chromium_samesite_integers_map_to_exact_playwright_strings() {
+        // GIVEN each distinct samesite int observed in a real cookie DB (-1,0,1,2)
+        // WHEN mapped
+        // THEN each lands on a Playwright-valid enum variant.
+        assert_eq!(chromium_samesite_to_playwright(-1), SameSite::Lax); // unspecified
+        assert_eq!(chromium_samesite_to_playwright(0), SameSite::None);
+        assert_eq!(chromium_samesite_to_playwright(1), SameSite::Lax);
+        assert_eq!(chromium_samesite_to_playwright(2), SameSite::Strict);
+    }
+
+    #[test]
+    fn samesite_serializes_to_playwright_enum_strings() {
+        // Playwright rejects anything other than Strict/Lax/None — assert the
+        // exact JSON spellings.
+        assert_eq!(serde_json::to_string(&SameSite::Strict).unwrap(), "\"Strict\"");
+        assert_eq!(serde_json::to_string(&SameSite::Lax).unwrap(), "\"Lax\"");
+        assert_eq!(serde_json::to_string(&SameSite::None).unwrap(), "\"None\"");
+    }
+
+    #[test]
+    fn storage_state_serializes_with_camelcase_playwright_fields() {
+        // GIVEN a storage_state with one cookie
+        // WHEN serialized
+        // THEN field names match Playwright's camelCase schema (httpOnly, sameSite)
+        // and origins is an empty array.
+        let state = StorageState::from_cookies(vec![PlaywrightCookie {
+            name: "session".into(),
+            value: "abc".into(),
+            domain: ".example.com".into(),
+            path: "/".into(),
+            expires: -1.0,
+            http_only: true,
+            secure: true,
+            same_site: SameSite::Lax,
+        }]);
+        let json = state.to_json().unwrap();
+        assert!(json.contains("\"httpOnly\": true"), "json: {json}");
+        assert!(json.contains("\"sameSite\": \"Lax\""), "json: {json}");
+        assert!(json.contains("\"origins\": []"), "json: {json}");
+    }
+
+    #[test]
+    fn storage_state_round_trips_through_json() {
+        // GIVEN a storage_state
+        // WHEN serialized and parsed back
+        // THEN the parsed value equals the original (schema-valid round trip).
+        let original = StorageState::from_cookies(vec![
+            PlaywrightCookie {
+                name: "a".into(),
+                value: "1".into(),
+                domain: ".github.com".into(),
+                path: "/".into(),
+                expires: 1_792_549_086.0,
+                http_only: false,
+                secure: true,
+                same_site: SameSite::Strict,
+            },
+            PlaywrightCookie {
+                name: "a".into(), // same name, different host — must NOT collapse.
+                value: "2".into(),
+                domain: "api.github.com".into(),
+                path: "/v3".into(),
+                expires: -1.0,
+                http_only: true,
+                secure: false,
+                same_site: SameSite::None,
+            },
+        ]);
+        let json = original.to_json().unwrap();
+        let parsed: StorageState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, original);
+        // Same-name cookies on different hosts are preserved as distinct entries.
+        assert_eq!(parsed.cookies.len(), 2);
+    }
+}

--- a/src/cmd/cookies.rs
+++ b/src/cmd/cookies.rs
@@ -1,4 +1,6 @@
-use anyhow::Result;
+use std::path::Path;
+
+use anyhow::{Context, Result};
 
 use super::{resolve_browser_name, resolve_cookie_source};
 
@@ -6,18 +8,81 @@ use super::{resolve_browser_name, resolve_cookie_source};
 /// likely to be missing auth cookies that live on a sibling subdomain.
 const THIN_COOKIE_RESULT_THRESHOLD: usize = 5;
 
-pub async fn cmd_cookies(subcommand: &str, domain: &str, browser: &str) -> Result<()> {
-    match subcommand {
-        "export" => cmd_cookies_export(domain, browser),
-        _ => anyhow::bail!("Unknown cookies subcommand: {subcommand}. Use 'export'."),
+/// Entry point for `nab cookies export`.
+///
+/// Dispatches on `format` (`"netscape"` | `"playwright"`) and writes either to
+/// `output` (when `Some`) or stdout. Reuses the same `--cookies` browser
+/// selection as the rest of nab via [`resolve_browser_name`].
+///
+/// # Errors
+/// Fails on unrecognised formats, missing browser selection, or I/O errors
+/// writing the chosen output path.
+pub async fn cmd_cookies_export(
+    domain: &str,
+    browser: &str,
+    format: &str,
+    output: Option<&Path>,
+) -> Result<()> {
+    match format.to_lowercase().as_str() {
+        "netscape" => cmd_cookies_export_netscape(domain, browser, output),
+        "playwright" | "storage_state" | "storage-state" => {
+            cmd_cookies_export_playwright(domain, browser, output)
+        }
+        other => anyhow::bail!(
+            "Unrecognised cookies export format: '{other}'. Use 'netscape' or 'playwright'."
+        ),
     }
 }
 
-/// Export cookies for a domain in Netscape format
-fn cmd_cookies_export(domain: &str, browser: &str) -> Result<()> {
-    let browser_name = resolve_browser_name(browser)
-        .ok_or_else(|| anyhow::anyhow!("No browser specified. Use --cookies to select one."))?;
+/// Resolve the selected browser name, erroring when cookies are disabled.
+fn resolve_export_browser(browser: &str) -> Result<String> {
+    resolve_browser_name(browser)
+        .ok_or_else(|| anyhow::anyhow!("No browser specified. Use --cookies to select one."))
+}
 
+/// Write `content` to `output` (file) or stdout, with a success note on stderr.
+fn emit(content: &str, output: Option<&Path>, count: usize) -> Result<()> {
+    if let Some(path) = output {
+        std::fs::write(path, content)
+            .with_context(|| format!("Failed to write export to {}", path.display()))?;
+        eprintln!("\n✅ Exported {count} cookies to {}", path.display());
+    } else {
+        println!("{content}");
+        eprintln!("\n✅ Exported {count} cookies");
+    }
+    Ok(())
+}
+
+/// Export cookies for a domain as a Playwright/CDP `storage_state` JSON document.
+///
+/// Implements MIK-5359 `export.1`. The artifact seeds a logged-in browser
+/// context later (see the nab task-engine browser-modes ADR).
+fn cmd_cookies_export_playwright(domain: &str, browser: &str, output: Option<&Path>) -> Result<()> {
+    let browser_name = resolve_export_browser(browser)?;
+    let source = resolve_cookie_source(&browser_name);
+
+    eprintln!("🍪 Exporting Playwright storage_state for '{domain}' from {browser_name}");
+
+    let cookies = source.get_cookies_rich(domain)?;
+    if cookies.is_empty() {
+        eprintln!("No cookies found for domain: {domain}");
+    }
+    if let Some(msg) = bare_domain_thin_result_warning(domain, cookies.len()) {
+        eprintln!("{msg}");
+    }
+
+    let count = cookies.len();
+    let state = nab::auth::cookies::storage_state::StorageState::from_cookies(cookies);
+    let json = state
+        .to_json()
+        .context("Failed to serialize storage_state JSON")?;
+
+    emit(&json, output, count)
+}
+
+/// Export cookies for a domain in Netscape format.
+fn cmd_cookies_export_netscape(domain: &str, browser: &str, output: Option<&Path>) -> Result<()> {
+    let browser_name = resolve_export_browser(browser)?;
     let source = resolve_cookie_source(&browser_name);
 
     eprintln!("🍪 Exporting cookies for '{domain}' from {browser_name}");
@@ -36,39 +101,46 @@ fn cmd_cookies_export(domain: &str, browser: &str) -> Result<()> {
         eprintln!("{msg}");
     }
 
-    // Output in Netscape cookie format
-    // Format: domain\tinclude_subdomains\tpath\tsecure\texpiry\tname\tvalue
-    println!("# Netscape HTTP Cookie File");
-    println!("# Exported by nab from {browser_name}");
-    println!("# Domain: {domain}");
-    println!();
+    let body = render_netscape(domain, &browser_name, &cookies);
+    emit(&body, output, cookies.len())
+}
 
-    for (name, value) in &cookies {
-        let include_subdomains = if domain.starts_with('.') {
-            "TRUE"
-        } else {
-            "FALSE"
-        };
-        // Use a far-future expiry for session cookies (we don't have the actual expiry)
-        let expiry = "0";
-        let secure = "FALSE";
-        let path = "/";
+/// Render a Netscape cookie file body for the given cookies.
+///
+/// Format: `domain\tinclude_subdomains\tpath\tsecure\texpiry\tname\tvalue`.
+fn render_netscape(
+    domain: &str,
+    browser_name: &str,
+    cookies: &std::collections::HashMap<String, String>,
+) -> String {
+    use std::fmt::Write as _;
 
-        // Ensure domain starts with . for subdomain matching (Netscape convention)
-        let cookie_domain = if domain.starts_with('.') {
-            domain.to_string()
-        } else {
-            format!(".{domain}")
-        };
+    let mut out = String::new();
+    let _ = writeln!(out, "# Netscape HTTP Cookie File");
+    let _ = writeln!(out, "# Exported by nab from {browser_name}");
+    let _ = writeln!(out, "# Domain: {domain}");
+    let _ = writeln!(out);
 
-        println!(
-            "{cookie_domain}\t{include_subdomains}\t{path}\t{secure}\t{expiry}\t{name}\t{value}"
+    let include_subdomains = if domain.starts_with('.') {
+        "TRUE"
+    } else {
+        "FALSE"
+    };
+    // Ensure domain starts with . for subdomain matching (Netscape convention).
+    let cookie_domain = if domain.starts_with('.') {
+        domain.to_string()
+    } else {
+        format!(".{domain}")
+    };
+
+    for (name, value) in cookies {
+        // Far-future expiry sentinel for session cookies (no real expiry known).
+        let _ = writeln!(
+            out,
+            "{cookie_domain}\t{include_subdomains}\t/\tFALSE\t0\t{name}\t{value}"
         );
     }
-
-    eprintln!("\n✅ Exported {} cookies", cookies.len());
-
-    Ok(())
+    out
 }
 
 /// Return a warning string when a bare-domain export looks thin, else `None`.
@@ -128,5 +200,35 @@ mod tests {
     #[test]
     fn warning_silent_on_dotted_leading_domain() {
         assert!(bare_domain_thin_result_warning(".linkedin.com", 1).is_none());
+    }
+
+    #[test]
+    fn render_netscape_emits_header_and_tab_rows() {
+        // GIVEN one cookie for a bare domain
+        // WHEN rendered to Netscape format
+        // THEN the header lines and a tab-separated row are present.
+        let mut cookies = std::collections::HashMap::new();
+        cookies.insert("session".to_string(), "abc123".to_string());
+        let out = render_netscape("example.com", "brave", &cookies);
+        assert!(out.contains("# Netscape HTTP Cookie File"));
+        assert!(out.contains(".example.com\tFALSE\t/\tFALSE\t0\tsession\tabc123"));
+    }
+
+    #[test]
+    fn unrecognised_format_is_rejected() {
+        // GIVEN an unsupported export format
+        // WHEN dispatched
+        // THEN the command errors rather than silently defaulting.
+        let err = tokio_test_block(cmd_cookies_export("example.com", "none", "yaml", None));
+        assert!(err.is_err());
+    }
+
+    /// Minimal blocking executor for the single async-fn error-path test, so the
+    /// crate's existing tokio dev-dependency configuration is not assumed here.
+    fn tokio_test_block<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("failed to build current-thread runtime")
+            .block_on(fut)
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -30,7 +30,7 @@ pub use auth::cmd_auth;
 pub use bench::cmd_bench;
 pub use browser::{BrowserConfig, cmd_browser};
 pub use context::cmd_context;
-pub use cookies::cmd_cookies;
+pub use cookies::cmd_cookies_export;
 pub use doctor::cmd_doctor;
 pub use export_rules::{cmd_export_rules, cmd_list_rules};
 pub use fetch::{FetchConfig, cmd_fetch};

--- a/src/main.rs
+++ b/src/main.rs
@@ -755,7 +755,7 @@ enum McpAction {
 
 #[derive(Subcommand)]
 enum CookiesAction {
-    /// Export cookies for a domain in Netscape format
+    /// Export cookies for a domain (Netscape by default; Playwright `storage_state` with --format)
     Export {
         /// Domain to export cookies for (e.g., "github.com"). Bare domains also include www. variants.
         domain: String,
@@ -763,6 +763,14 @@ enum CookiesAction {
         /// Browser to export from (auto, brave, chrome, firefox, safari, edge)
         #[arg(short, long, default_value = "auto")]
         cookies: String,
+
+        /// Output format: "netscape" (default) or "playwright" (CDP `storage_state` JSON)
+        #[arg(long, default_value = "netscape")]
+        format: String,
+
+        /// Write to this path instead of stdout
+        #[arg(short, long)]
+        output: Option<std::path::PathBuf>,
     },
 }
 
@@ -1195,8 +1203,13 @@ async fn main() -> Result<()> {
                 cmd::cmd_context(&urls, &cookies, max_tokens).await?;
             }
             Commands::Cookies { action } => match action {
-                CookiesAction::Export { domain, cookies } => {
-                    cmd::cmd_cookies("export", &domain, &cookies).await?;
+                CookiesAction::Export {
+                    domain,
+                    cookies,
+                    format,
+                    output,
+                } => {
+                    cmd::cmd_cookies_export(&domain, &cookies, &format, output.as_deref()).await?;
                 }
             },
             Commands::Rules { action } => match action {


### PR DESCRIPTION
## Summary

MIK-5359 Phase 1: adds cookie and session export in Playwright storage_state format so a logged-in browser session can seed downstream automation (Playwright/CDP).

## What it does

- nab cookies export --format playwright (aliases storage_state, storage-state) emits a Playwright-schema storage_state JSON document for a domain.
- --output path writes to a file; otherwise writes to stdout.
- Reuses the existing --cookies browser selection (Brave, Chrome, Firefox, Safari) used by nab fetch.
- The existing netscape format is preserved and refactored alongside the new path.

New modules:
- src/auth/cookies/storage_state.rs — Playwright storage_state types and serialization (camelCase schema, Strict/Lax/None SameSite enum, Chromium FILETIME to Unix expiry conversion, session-cookie sentinel -1).
- src/auth/cookies/db.rs — cookie DB row retrieval feeding the export.

## Scope

Phase 1 only — cookie and session export. The included design ADR (docs/design/2026-06-01-nab-task-engine-browser-modes.md) documents the Phase 2 plus task-engine browser modes; it is design-only and ships no Phase-2 code.

## Acceptance criteria

- MIK-5359.export.1: playwright export produces a Playwright-valid storage_state JSON document. Met.
- Chromium expiry and SameSite values map exactly to Playwright equivalents. Met.
- camelCase field names (httpOnly, sameSite) and empty origins array per Playwright schema. Met.
- Same-name cookies on different hosts are preserved as distinct entries. Met.

## Test evidence

- cargo test: 1863 passed, 12 ignored.
- cargo fmt --all --check: clean.
- cargo clippy --lib --no-deps -- -D warnings: no issues.
- Targeted: storage_state 7 tests; cookie command and export 47 tests passing.
- Coverage includes FILETIME to Unix expiry, session sentinel, SameSite int to enum mapping, camelCase serialization, JSON round-trip, multi-host cookie distinctness.

## Note on src/cmd/task.rs

An untracked src/cmd/task.rs (task-engine skeleton) was present in the worktree. Its own module docs mark it as MIK-5359 Phase 2 plus; it is gated behind a task feature that does not exist in Cargo.toml and is not wired into src/cmd/mod.rs or main.rs. It was moved aside (not committed) to keep this PR scoped to Phase 1. It will land with the Phase 2 task-engine work.

## Notes

- Branch base (origin main) is 2 commits ahead; a rebase may be requested before merge.

Generated with Claude Code