### PR TITLE
feat(linkedin): activity-feed support (MIK-3059)

### DIFF
--- a/src/site/linkedin/auth.rs
+++ b/src/site/linkedin/auth.rs
@@ -136,6 +136,11 @@ fn extract_code_json(document: &Html, url: &str, kind: LinkedInUrlKind) -> Optio
 
     let mut profile: Option<VoyagerProfileResponse> = None;
     let mut posts: Vec<String> = Vec::new();
+    // Rich structured activity-feed markdown extracted from an embedded Voyager
+    // feed envelope (`{data, included:[…]}`). Preferred over the text-only
+    // `posts` fallback because it carries author, urn, timestamp, and
+    // engagement per post. See `extract_activity_envelope`.
+    let mut activity_md: Option<String> = None;
     for element in document.select(&selector) {
         // scraper's .text() strips HTML comment nodes — use inner_html() which
         // preserves the raw "<!--{...}-->" content that LinkedIn embeds.
@@ -148,6 +153,15 @@ fn extract_code_json(document: &Html, url: &str, kind: LinkedInUrlKind) -> Optio
         let Ok(value) = serde_json::from_str::<serde_json::Value>(json_str) else {
             continue;
         };
+
+        // Priority for activity pages: a hidden <code> may carry the pre-fetched
+        // Voyager feed envelope LinkedIn would otherwise load over XHR. Route it
+        // through the shared rich walker so embedded and XHR paths agree.
+        if activity_md.is_none()
+            && let Some(md) = extract_activity_envelope(&value, json_str, profile.as_ref())
+        {
+            activity_md = Some(md);
+        }
 
         // Walk every JSON value recursively looking for profile and post data.
         scan_json_value(&value, &mut profile, &mut posts);
@@ -162,11 +176,55 @@ fn extract_code_json(document: &Html, url: &str, kind: LinkedInUrlKind) -> Optio
             && !body_str.is_empty()
             && let Ok(body_json) = serde_json::from_str::<serde_json::Value>(body_str)
         {
+            if activity_md.is_none()
+                && let Some(md) = extract_activity_envelope(&body_json, body_str, profile.as_ref())
+            {
+                activity_md = Some(md);
+            }
             scan_json_value(&body_json, &mut profile, &mut posts);
         }
     }
 
-    build_code_json_content(url, kind, profile.as_ref(), &posts)
+    build_code_json_content(url, kind, profile.as_ref(), &posts, activity_md.as_deref())
+}
+
+/// Detect and render a pre-fetched Voyager activity-feed envelope embedded in a
+/// hidden `<code>` element on `/recent-activity/all/`.
+///
+/// `LinkedIn`'s SPA inlines the first feed XHR response (`{data, included:[…]}`)
+/// into the SSR HTML to avoid a client round-trip. When that envelope is
+/// present, this routes the raw JSON through the shared
+/// [`super::voyager::render_voyager_body`] walker — the same code the live XHR
+/// path uses — so the embedded path yields fully structured posts (author,
+/// activity URN, snowflake-derived timestamp, engagement counts) instead of the
+/// text-only commentary fallback.
+///
+/// `value` is the parsed JSON; `raw` is the original string passed straight to
+/// the walker (which re-parses internally). `profile` supplies the expected
+/// author name used to flag reshares. Returns `None` when no `included[]` feed
+/// array with `feed.Update` entities is present.
+fn extract_activity_envelope(
+    value: &serde_json::Value,
+    raw: &str,
+    profile: Option<&VoyagerProfileResponse>,
+) -> Option<String> {
+    // Cheap structural gate before the expensive walker: must have an
+    // `included` array carrying at least one feed Update entity.
+    let included = value.get("included")?.as_array()?;
+    let has_update = included.iter().any(|e| {
+        e.get("$type").and_then(serde_json::Value::as_str)
+            == Some("com.linkedin.voyager.dash.feed.Update")
+    });
+    if !has_update {
+        return None;
+    }
+
+    let expected_actor = profile
+        .and_then(|p| build_full_name(p.first_name.as_deref(), p.last_name.as_deref()))
+        .unwrap_or_default();
+
+    let md = super::voyager::render_voyager_body(raw, &expected_actor);
+    if md.trim().is_empty() { None } else { Some(md) }
 }
 
 /// Recursively walk a JSON value tree looking for `LinkedIn` data objects.
@@ -336,12 +394,18 @@ pub(super) fn extract_post_text(
 
 /// Build `SiteContent` from extracted `<code>` JSON data.
 ///
-/// Returns `None` when neither a profile nor any posts were found.
+/// `activity_md`, when present, is the richly structured activity-feed markdown
+/// rendered from an embedded Voyager envelope (see `extract_activity_envelope`).
+/// It is preferred over the text-only `posts` fallback so activity pages surface
+/// author, urn, timestamp, and engagement per post.
+///
+/// Returns `None` when no profile, structured activity, or post text was found.
 fn build_code_json_content(
     url: &str,
     kind: LinkedInUrlKind,
     profile: Option<&VoyagerProfileResponse>,
     posts: &[String],
+    activity_md: Option<&str>,
 ) -> Option<SiteContent> {
     let mut md = String::new();
 
@@ -373,7 +437,12 @@ fn build_code_json_content(
         (None, None)
     };
 
-    if !posts.is_empty() {
+    // Prefer the structured activity envelope when present; otherwise fall back
+    // to the text-only commentary collection.
+    if let Some(activity) = activity_md.map(str::trim).filter(|s| !s.is_empty()) {
+        let _ = writeln!(md, "### Recent Activity\n");
+        let _ = writeln!(md, "{activity}");
+    } else if !posts.is_empty() {
         if profile.is_some() {
             let _ = writeln!(md, "### Recent Activity\n");
         }

--- a/src/site/linkedin/mod.rs
+++ b/src/site/linkedin/mod.rs
@@ -46,6 +46,8 @@ pub use types::{
     VoyagerActivityResponse, VoyagerCommentary, VoyagerFeedElement, VoyagerText, VoyagerUpdateValue,
 };
 pub use url::{LinkedInUrlKind, classify_linkedin_url};
+#[cfg(feature = "impersonate")]
+pub use voyager::timestamp_from_activity_urn;
 
 use anyhow::{Result, bail};
 use async_trait::async_trait;

--- a/src/site/linkedin/tests.rs
+++ b/src/site/linkedin/tests.rs
@@ -871,3 +871,143 @@ fn code_tag_profile_without_industry_still_renders() {
     assert!(content.markdown.contains("Engineer"));
     assert!(!content.markdown.contains("Industry:"));
 }
+
+// ── /recent-activity/all/ embedded <code> feed envelope ─────────────────────
+//
+// MIK-3059: LinkedIn's activity-feed SPA inlines the first Voyager feed XHR
+// response (`{data, included:[…]}`) inside a hidden `<code>` element on
+// `/recent-activity/all/`. These tests exercise the routing of that embedded
+// envelope through the shared rich walker, yielding structured posts with
+// author, activity URN, snowflake-derived timestamp, and engagement.
+//
+// The fixtures are synthetic but use LinkedIn's documented decorator-envelope
+// field shapes (`$type`, compound `entityUrn`, `SocialActivityCounts`) — the
+// same shapes the live XHR path in `voyager.rs` parses against captured data.
+
+#[cfg(feature = "impersonate")]
+#[test]
+fn activity_code_envelope_extracts_structured_post() {
+    use super::auth::parse_linkedin_html;
+
+    // GIVEN: an activity page whose <code> block carries a Voyager feed
+    // envelope with one Update + its engagement counts. The activity URN
+    // 7451014806356230146 decodes to 2026-04-17T21:12:42Z.
+    let envelope = r#"{"data":{},"included":[
+        {"$type":"com.linkedin.voyager.dash.feed.Update",
+         "entityUrn":"urn:li:fsd_update:(urn:li:activity:7451014806356230146,MEMBER_FEED,DEBUG_REASON,DEFAULT,false)",
+         "actor":{"name":{"text":"Mikko Parkkola"}},
+         "commentary":{"text":{"text":"Shipped the LinkedIn activity-feed parser."}}},
+        {"$type":"com.linkedin.voyager.dash.feed.SocialActivityCounts",
+         "urn":"urn:li:activity:7451014806356230146",
+         "numLikes":12,"numComments":3,"numShares":1,"numImpressions":1500}
+    ]}"#;
+    let html = format!(
+        r#"<!DOCTYPE html><html><head></head><body>
+        <code style="display:none" id="bpr-guid-1"><!--{envelope}--></code>
+        </body></html>"#
+    );
+
+    // WHEN
+    let content = parse_linkedin_html(
+        &html,
+        "https://www.linkedin.com/in/mikko-parkkola/recent-activity/all/",
+        LinkedInUrlKind::Activity,
+    )
+    .unwrap();
+    let md = &content.markdown;
+
+    // THEN: post text, URN-derived link, timestamp, and engagement all surface.
+    assert!(
+        md.contains("Shipped the LinkedIn activity-feed parser."),
+        "missing post text: {md}"
+    );
+    assert!(
+        md.contains("urn:li:activity:7451014806356230146"),
+        "missing activity URN / post URL: {md}"
+    );
+    assert!(
+        md.contains("2026-04-17T21:12:42Z"),
+        "missing snowflake timestamp: {md}"
+    );
+    assert!(md.contains("1500 impressions"), "missing impressions: {md}");
+    assert!(md.contains("12 reactions"), "missing reactions: {md}");
+    assert!(md.contains("[POST]"), "missing POST tag: {md}");
+    assert_eq!(content.metadata.platform, "LinkedIn (Activity)");
+}
+
+#[cfg(feature = "impersonate")]
+#[test]
+fn activity_code_envelope_via_prefetch_body_wrapper() {
+    use super::auth::parse_linkedin_html;
+
+    // GIVEN: the feed envelope wrapped in a pre-fetched API response shape
+    // ({status:200, body:"<json string>"}) — the Type-2 embedding LinkedIn
+    // also uses. The inner body must still be routed through the rich walker.
+    let inner = r#"{\"data\":{},\"included\":[{\"$type\":\"com.linkedin.voyager.dash.feed.Update\",\"entityUrn\":\"urn:li:fsd_update:(urn:li:activity:7451014806356230146,MEMBER_FEED,DEBUG_REASON,DEFAULT,false)\",\"actor\":{\"name\":{\"text\":\"Mikko Parkkola\"}},\"commentary\":{\"text\":{\"text\":\"Body-wrapped post.\"}}}]}"#;
+    let html = format!(
+        r#"<!DOCTYPE html><html><head></head><body>
+        <code><!--{{"status":200,"body":"{inner}"}}--></code>
+        </body></html>"#
+    );
+
+    // WHEN
+    let content = parse_linkedin_html(
+        &html,
+        "https://www.linkedin.com/in/mikko-parkkola/recent-activity/all/",
+        LinkedInUrlKind::Activity,
+    )
+    .unwrap();
+
+    // THEN: the wrapped envelope is rendered with timestamp + per-post URL.
+    assert!(
+        content.markdown.contains("Body-wrapped post."),
+        "missing body-wrapped post: {}",
+        content.markdown
+    );
+    assert!(
+        content.markdown.contains("2026-04-17T21:12:42Z"),
+        "missing timestamp from wrapped envelope: {}",
+        content.markdown
+    );
+}
+
+#[cfg(feature = "impersonate")]
+#[test]
+fn activity_code_envelope_does_not_leak_comment_entities() {
+    use super::auth::parse_linkedin_html;
+
+    // GIVEN: the envelope mixes a real Update with a Comment entity. Only the
+    // Update should surface as a post (structural filter, not text scraping).
+    let envelope = r#"{"data":{},"included":[
+        {"$type":"com.linkedin.voyager.dash.feed.Update",
+         "entityUrn":"urn:li:fsd_update:(urn:li:activity:7451014806356230146,MEMBER_FEED,DEBUG_REASON,DEFAULT,false)",
+         "actor":{"name":{"text":"Mikko Parkkola"}},
+         "commentary":{"text":{"text":"real post body"}}},
+        {"$type":"com.linkedin.voyager.dash.social.Comment",
+         "entityUrn":"urn:li:fsd_comment:(activity:7451014806356230146,1)",
+         "commentary":{"text":{"text":"a stray comment that must not appear"}}}
+    ]}"#;
+    let html = format!(
+        r"<!DOCTYPE html><html><head></head><body>
+        <code><!--{envelope}--></code>
+        </body></html>"
+    );
+
+    let content = parse_linkedin_html(
+        &html,
+        "https://www.linkedin.com/in/mikko-parkkola/recent-activity/all/",
+        LinkedInUrlKind::Activity,
+    )
+    .unwrap();
+
+    assert!(
+        content.markdown.contains("real post body"),
+        "missing real post: {}",
+        content.markdown
+    );
+    assert!(
+        !content.markdown.contains("stray comment"),
+        "leaked Comment entity into activity output: {}",
+        content.markdown
+    );
+}

--- a/src/site/linkedin/voyager.rs
+++ b/src/site/linkedin/voyager.rs
@@ -295,6 +295,51 @@ impl PostRecord {
     }
 }
 
+/// Bits the snowflake id is shifted right by to recover Unix-millisecond time.
+/// LinkedIn activity ids are Twitter-style snowflakes: the high 41 bits encode
+/// Unix milliseconds, the low 22 bits are worker id + sequence.
+const SNOWFLAKE_TIMESTAMP_SHIFT: u32 = 22;
+
+/// Lower sanity bound (2010-01-01T00:00:00Z) in Unix milliseconds.
+const SNOWFLAKE_MIN_MS: u64 = 1_262_304_000_000;
+
+/// Upper sanity bound (2100-01-01T00:00:00Z) in Unix milliseconds.
+const SNOWFLAKE_MAX_MS: u64 = 4_102_444_800_000;
+
+/// Derive the post creation time (RFC-3339 UTC, second precision) from a
+/// `urn:li:activity:NUMBER` URN.
+///
+/// LinkedIn activity ids are Twitter-style snowflakes whose high 41 bits encode
+/// Unix milliseconds. The timestamp is therefore intrinsic to the URN — no
+/// separate `createdAt` field is required, which is why this works on both the
+/// XHR and embedded-`<code>` paths.
+///
+/// Returns `None` when the URN is malformed, the numeric id does not parse, or
+/// the derived instant falls outside a sane window — guarding against non-
+/// snowflake ids leaking a 1970 / far-future date.
+///
+/// ```
+/// # use nab::site::linkedin::timestamp_from_activity_urn;
+/// let ts = timestamp_from_activity_urn("urn:li:activity:7451014806356230146");
+/// assert_eq!(ts.as_deref(), Some("2026-04-17T21:12:42Z"));
+/// assert!(timestamp_from_activity_urn("urn:li:activity:not-a-number").is_none());
+/// ```
+#[must_use]
+pub fn timestamp_from_activity_urn(activity_urn: &str) -> Option<String> {
+    let id: u64 = activity_urn
+        .strip_prefix("urn:li:activity:")?
+        .parse()
+        .ok()?;
+    let unix_ms = id >> SNOWFLAKE_TIMESTAMP_SHIFT;
+    if !(SNOWFLAKE_MIN_MS..SNOWFLAKE_MAX_MS).contains(&unix_ms) {
+        return None;
+    }
+    #[allow(clippy::cast_possible_wrap)]
+    let secs = (unix_ms / 1000) as i64;
+    chrono::DateTime::<chrono::Utc>::from_timestamp_secs(secs)
+        .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+}
+
 /// Extract `urn:li:activity:NUMBER` from `urn:li:fsd_update:(urn:li:activity:NUMBER,...)`.
 ///
 /// LinkedIn's compound URN syntax is `(child_urn,tag1,tag2,...)`; the activity
@@ -463,7 +508,13 @@ fn fmt_engagement(c: &SocialCounts) -> String {
 /// `expected_actor_name` flags posts whose author does not match the resolved
 /// profile name as reshares (defence in depth — `resharedUpdate` is the
 /// primary signal but is occasionally absent on quote-shares).
-fn render_voyager_body(body: &str, expected_actor_name: &str) -> String {
+///
+/// Exposed to the `<code>`-JSON path (`auth.rs`): when `/recent-activity/all/`
+/// embeds a pre-fetched Voyager feed envelope inside a hidden `<code>` element,
+/// that path routes the envelope body through this same walker so the embedded
+/// and XHR paths produce byte-identical structured output (author, urn,
+/// timestamp, engagement) instead of the text-only commentary fallback.
+pub(super) fn render_voyager_body(body: &str, expected_actor_name: &str) -> String {
     if let Ok(typed) = serde_json::from_str::<VoyagerActivityResponse>(body) {
         let md = parse_voyager_activity(&typed);
         if !md.trim().is_empty() {
@@ -506,6 +557,9 @@ fn render_voyager_body(body: &str, expected_actor_name: &str) -> String {
 
         let _ = writeln!(md, "---");
         let _ = writeln!(md, "**[{tag}]** · <{}>", post.url());
+        if let Some(ts) = timestamp_from_activity_urn(&post.activity_urn) {
+            let _ = writeln!(md, "_{ts}_");
+        }
         let engagement = fmt_engagement(&post.counts);
         if !engagement.is_empty() {
             let _ = writeln!(md, "_{engagement}_");
@@ -699,6 +753,45 @@ mod tests {
         let body = r#"{"elements":[]}"#;
         let md = render_voyager_body(body, "Mikko Parkkola");
         assert!(md.trim().is_empty());
+    }
+
+    #[test]
+    fn timestamp_from_known_activity_urn_decodes_snowflake() {
+        // GIVEN: a real-shaped activity URN whose snowflake decodes to 2026-04-17.
+        // WHEN / THEN: the high 41 bits yield the correct UTC instant.
+        assert_eq!(
+            timestamp_from_activity_urn("urn:li:activity:7451014806356230146").as_deref(),
+            Some("2026-04-17T21:12:42Z")
+        );
+    }
+
+    #[test]
+    fn timestamp_rejects_non_numeric_and_out_of_range_ids() {
+        // Malformed numeric component → None (no panic).
+        assert!(timestamp_from_activity_urn("urn:li:activity:not-a-number").is_none());
+        // Wrong prefix → None.
+        assert!(timestamp_from_activity_urn("urn:li:comment:7451014806356230146").is_none());
+        // A tiny id decodes to ~1970 (below the sanity window) → None rather
+        // than inventing a 1970 timestamp.
+        assert!(timestamp_from_activity_urn("urn:li:activity:1").is_none());
+    }
+
+    #[test]
+    fn render_includes_snowflake_timestamp_line() {
+        // GIVEN: a feed envelope with one Update whose URN decodes to 2026-04-17.
+        let body = r#"{"data":{},"included":[
+            {"$type":"com.linkedin.voyager.dash.feed.Update",
+             "entityUrn":"urn:li:fsd_update:(urn:li:activity:7451014806356230146,MEMBER_FEED,DEBUG_REASON,DEFAULT,false)",
+             "actor":{"name":{"text":"Mikko Parkkola"}},
+             "commentary":{"text":{"text":"timestamped post"}}}
+        ]}"#;
+        // WHEN
+        let md = render_voyager_body(body, "Mikko Parkkola");
+        // THEN: the derived timestamp is rendered.
+        assert!(
+            md.contains("2026-04-17T21:12:42Z"),
+            "missing snowflake timestamp: {md}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds structured rendering of the LinkedIn activity feed (`/in/{user}/recent-activity/all/`) (MIK-3059).

LinkedIn inlines the first Voyager feed XHR response (`{data, included:[…]}`) into a hidden `<code>` element of the SSR HTML. This change detects that embedded envelope and routes it through the shared `render_voyager_body` walker — the same code the live XHR path uses — so the embedded path yields fully structured posts (author, activity URN, post URL, timestamp, engagement counts) instead of the prior text-only commentary fallback.

## Changes

- `voyager.rs`: `timestamp_from_activity_urn()` decodes the Twitter-style snowflake activity URN to an RFC-3339 UTC instant, with sanity bounds at each end of the valid window so non-snowflake ids return `None` rather than inventing a 1970 or far-future date. The renderer emits a per-post timestamp line. `render_voyager_body` is widened to `pub(super)` so the `<code>` path can reuse it.
- `auth.rs`: `extract_activity_envelope()` applies a cheap structural gate (an `included[]` array carrying at least one `feed.Update` entity) before invoking the walker, and `build_code_json_content` prefers the structured activity markdown over the text-only `posts` fallback. Both the direct `<code>` JSON and the Type-2 pre-fetched API-response (`{status, body}`) embeddings are handled.
- `mod.rs`: re-exports `timestamp_from_activity_urn` (feature-gated on `impersonate`) so the documented public API path and its doctest resolve.
- `tests.rs`: new coverage for the activity path.

## Acceptance criteria

- MIK-3059.AC1 — Embedded activity envelope renders structured posts with author, activity URN / post URL, snowflake-derived timestamp, and engagement counts. Covered by `activity_code_envelope_extracts_structured_post`.
- MIK-3059.AC2 — The Type-2 status-plus-body pre-fetch wrapper is routed through the same walker. Covered by `activity_code_envelope_via_prefetch_body_wrapper`.
- MIK-3059.AC3 — Only `feed.Update` entities surface as posts; `Comment` entities are excluded by construction. Covered by `activity_code_envelope_does_not_leak_comment_entities`.
- MIK-3059.AC4 — Snowflake decode is correct and bounded; malformed, out-of-range, or wrong-prefix URNs return `None`. Covered by `timestamp_from_known_activity_urn_decodes_snowflake`, `timestamp_rejects_non_numeric_and_out_of_range_ids`, and the `timestamp_from_activity_urn` doctest.

## Test evidence

- `cargo fmt --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — no issues.
- `cargo test` — 1889 passed, 12 ignored, 0 failed (22 suites, lib + integration + doctests).
- `cargo check --no-default-features --features cli` — clean (confirms the feature-gated re-export does not break non-`impersonate` builds).
- Repo pre-push gate (fmt + clippy + lib tests) ran on push and passed.

Note: the local build was verified with `RUSTC_WRAPPER=""`, bypassing a broken sccache wrapper in the build environment; no cargo config change is included in this PR.