### PR TITLE
docs: add commercial license sponsor rail

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [MikkoParkkola]

--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,49 @@
+# Commercial Use
+
+`nab` is dual-licensed.
+
+- Core fetch, analyze, watch, MCP server, and public web-fetching code remains MIT-licensed.
+- Enterprise Edition files marked with `SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0` are licensed under PolyForm Noncommercial 1.0.0.
+- Releases before v0.9.0 remain entirely MIT-licensed and stay MIT forever.
+
+Commercial use of Enterprise Edition files requires a separate commercial license.
+
+Examples that require a commercial license:
+
+- A company uses Enterprise Edition modules internally for authenticated fetching, browser-cookie injection, anti-bot handling, WAF challenge handling, site-specific integrations, or secure ingestion.
+- Enterprise Edition code is forked, wrapped, modified, or copied into a business system.
+- Enterprise Edition code is run as a hosted, shared, or managed fetching service.
+- Enterprise Edition code powers a paid product, SaaS, agent platform, consulting deliverable, or internal platform.
+- Enterprise Edition capabilities materially improve a commercial workflow, product, or service.
+
+## Standard commercial license
+
+Companies can buy a standard commercial-use license through GitHub Sponsors:
+
+- EUR 500/month per named project.
+- Covers one company or organization using `nab` Enterprise Edition code while sponsorship remains active.
+- Covers routine internal business use, private forks, wrappers, private integrations, and shared internal services for that organization.
+- Requires the sponsoring company to identify the licensed project, such as `nab`, in the sponsor note or by email.
+- Does not include support, SLA, custom development, indemnity, trademark rights, sublicensing, resale, or the right to offer `nab` as a hosted or managed service to third parties unless separately agreed in writing.
+
+The standard license is intended to be simple enough for normal team, department, or manager-level purchasing. It is not a blanket license for all Mikko Parkkola projects.
+
+## Custom commercial terms
+
+Custom terms are available for larger or unusual deployments, including:
+
+- Multiple projects or portfolio-wide use.
+- External-facing SaaS, hosted, managed-service, or resale use.
+- Redistribution to customers, subsidiaries, contractors, or channel partners.
+- High-scale deployments, regulated environments, procurement-specific contract terms, indemnity, support, SLA, or custom development.
+- Strategic partnerships, revenue share, attribution plus upstream collaboration, or annual invoicing.
+
+## Future Enterprise Edition modules
+
+New features that are primarily valuable for authenticated access, anti-bot handling, WAF challenge handling, browser-cookie workflows, site-specific commercial integrations, secure ingestion, hosted operations, multi-tenant service operation, or commercial platform integration may be added as Enterprise Edition files under PolyForm Noncommercial 1.0.0.
+
+This does not change the MIT license for existing MIT releases or for core files that remain MIT.
+
+Sponsor link: https://github.com/sponsors/MikkoParkkola
+
+Annual invoicing, procurement terms, custom terms, or resale rights can be agreed by email: mikko.parkkola@iki.fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,4 +152,11 @@ nab is optimized for speed and token efficiency:
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree your contributions will be licensed under the license that applies to the files you modify:
+
+- MIT for core files.
+- PolyForm Noncommercial 1.0.0 for Enterprise Edition files marked with `SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0`.
+
+If a pull request adds a new Enterprise Edition file, include the PolyForm Noncommercial SPDX header. If it adds a new core file, use the MIT license boundary unless the maintainer explicitly marks the feature as Enterprise Edition.
+
+Maintainers may designate new files as Enterprise Edition when the feature is primarily valuable for authenticated access, anti-bot handling, WAF challenge handling, browser-cookie workflows, site-specific commercial integrations, secure ingestion, hosted operations, multi-tenant service operation, or commercial platform integration. Existing MIT releases and core files that remain MIT are not retroactively relicensed.

--- a/LICENSE-EE.md
+++ b/LICENSE-EE.md
@@ -34,7 +34,19 @@ Full license text reference: see polyformproject.org for the canonical license d
 
 ## Commercial licensing
 
-For commercial use of EE-designated files, contact: mikko.parkkola@iki.fi
+For commercial use of EE-designated files, companies can buy a standard commercial-use license through GitHub Sponsors:
+
+- EUR 500/month per named project.
+- Covers one company or organization using `nab` Enterprise Edition code while sponsorship remains active.
+- Covers routine internal business use, private forks, wrappers, private integrations, and shared internal services for that organization.
+- Requires the sponsoring company to identify the licensed project, such as `nab`, in the sponsor note or by email.
+- Does not include support, SLA, custom development, indemnity, trademark rights, sublicensing, resale, or the right to offer `nab` as a hosted or managed service to third parties unless separately agreed in writing.
+
+The standard license is not a blanket license for all Mikko Parkkola projects. Custom terms are available for multi-project, portfolio-wide, external-facing, resale, managed-service, high-scale, support, SLA, indemnity, or procurement-specific needs.
+
+Sponsor link: https://github.com/sponsors/MikkoParkkola
+
+Annual invoicing, procurement terms, custom terms, or resale rights can be agreed by email: mikko.parkkola@iki.fi
 
 ## Existing MIT-licensed releases
 

--- a/README.md
+++ b/README.md
@@ -504,5 +504,7 @@ EE-designated paths (every file carries `// SPDX-License-Identifier: PolyForm-No
 
 **What this means in practice**:
 - Free for noncommercial use, modification, redistribution.
-- Commercial use of EE modules requires a separate commercial license — contact `mikko.parkkola@iki.fi`.
+- Commercial use of EE modules requires a separate commercial license.
+- Companies can buy a standard commercial-use license via [GitHub Sponsors](https://github.com/sponsors/MikkoParkkola) at EUR 500/month per named project.
+- See [COMMERCIAL.md](COMMERCIAL.md) for business use, forks, wrappers, shared services, and managed-service deployments.
 - All releases prior to v0.9.0 remain entirely MIT and stay MIT forever.


### PR DESCRIPTION
## Summary

Adds GitHub Sponsors funding metadata and clarifies the standard commercial-license path for business use.

## Acceptance criteria

- AC-001: `.github/FUNDING.yml` points to `MikkoParkkola` so GitHub can show the Sponsor button after merge.
- AC-002: README/license docs describe the standard EUR 500/month per named project commercial-use path.
- AC-003: Annual invoicing and custom terms are clearly handled by email agreement.
- AC-004: Existing open-source license grants are preserved; Enterprise Edition/commercial boundaries are clarified where applicable.

## ROI

P1 / high leverage: makes the payment path visible at the point where companies evaluate the repo, while keeping normal noncommercial and core open-source use clear.

## Fail-fast

If GitHub does not render the Sponsor button after merge, verify the default-branch `.github/FUNDING.yml` path and GitHub Sponsors profile status before changing licensing text.

## Source

Requested by @MikkoParkkola to make Sponsor buttons appear where commercial licensing makes sense and to clarify per-project licensing terms.
