### PR TITLE
Security: patch Dependabot alerts + surface prompt-injection defense

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,7 +1794,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.3",
  "siphasher 1.0.2",
 ]
 
@@ -3766,7 +3766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3776,7 +3776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4122,7 +4122,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -4178,9 +4178,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4189,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -5239,9 +5239,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -5707,7 +5707,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
@@ -5724,7 +5724,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls",
  "rustls-pki-types",
  "sha1 0.10.6",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ nab treats every fetched page as hostile input and runs two local, non-networked
 
 The net effect: hidden instructions become **visible to you, not executed by your model**. That is the single biggest reason to point your agent at `nab fetch` instead of a built-in web-fetch tool.
 
+> **Licensing:** both guards are Enterprise Edition modules — **free for personal and non-commercial use** under [PolyForm Noncommercial 1.0.0](LICENSE-EE.md); **commercial / business use requires a commercial license** (see [COMMERCIAL.md](COMMERCIAL.md) and the [License](#license) section).
+
 ## Quick start
 
 **Tell your AI assistant** (recommended):
@@ -67,29 +69,44 @@ brew tap MikkoParkkola/tap
 brew install nab
 ```
 
-### From crates.io
+### Pre-built binary (no Rust toolchain required)
 
-```bash
-cargo install nab
-```
+**Most users want this path** — these are ready-to-run binaries; nothing is compiled on your machine.
 
-Requires Rust 1.95 or newer.
-
-### Pre-built binary
+If you have `cargo-binstall`, it fetches the right pre-built binary automatically:
 
 ```bash
 cargo binstall nab
 ```
 
-Or download directly from [GitHub Releases](https://github.com/MikkoParkkola/nab/releases):
+Otherwise download directly from [GitHub Releases](https://github.com/MikkoParkkola/nab/releases/latest). Both the `nab` CLI and the `nab-mcp` server ship for every platform below, alongside `checksums-sha256.txt`:
 
-| Platform | Binary |
-|----------|--------|
-| macOS Apple Silicon | `nab-aarch64-apple-darwin` |
-| macOS Intel | `nab-x86_64-apple-darwin` |
-| Linux x86_64 | `nab-x86_64-unknown-linux-gnu` |
-| Linux ARM64 | `nab-aarch64-unknown-linux-gnu` |
-| Windows x64 | `nab-x86_64-pc-windows-msvc.exe` |
+| Platform | CLI binary | MCP server binary |
+|----------|------------|-------------------|
+| macOS Apple Silicon | `nab-aarch64-apple-darwin` | `nab-mcp-aarch64-apple-darwin` |
+| macOS Intel | `nab-x86_64-apple-darwin` | `nab-mcp-x86_64-apple-darwin` |
+| Linux x86_64 (glibc) | `nab-x86_64-unknown-linux-gnu` | `nab-mcp-x86_64-unknown-linux-gnu` |
+| Linux x86_64 (static musl) | `nab-x86_64-unknown-linux-musl` | `nab-mcp-x86_64-unknown-linux-musl` |
+| Linux ARM64 (glibc) | `nab-aarch64-unknown-linux-gnu` | `nab-mcp-aarch64-unknown-linux-gnu` |
+| Linux ARM64 (static musl) | `nab-aarch64-unknown-linux-musl` | `nab-mcp-aarch64-unknown-linux-musl` |
+| Windows x64 | `nab-x86_64-pc-windows-msvc.exe` | `nab-mcp-x86_64-pc-windows-msvc.exe` |
+
+Example install for macOS Apple Silicon (substitute the filename for your platform):
+
+```bash
+shasum -a 256 -c checksums-sha256.txt --ignore-missing
+chmod +x nab-aarch64-apple-darwin
+mv nab-aarch64-apple-darwin /usr/local/bin/nab
+xattr -d com.apple.quarantine /usr/local/bin/nab 2>/dev/null || true
+```
+
+### From crates.io (compiles from source)
+
+Builds nab locally — requires the Rust toolchain (1.95 or newer) and takes a few minutes:
+
+```bash
+cargo install nab
+```
 
 ### From source
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ Token-optimized web fetcher + multilingual ASR + URL watcher. MCP 2025-11-25 com
 
 nab is a single Rust binary that does three things very well: it **fetches** any URL as clean markdown (with your real browser cookies and anti-bot evasion), it **analyzes** any audio or video file with on-device multilingual ASR and speaker diarization, and it **watches** any URL for changes and pushes notifications when content moves. Everything runs locally. There are no API keys to set up by default. The output is shaped for LLM context windows.
 
+## Prompt-injection defense (on by default)
+
+Web pages increasingly carry instructions written **for the AI, not for you** — concealed in HTML comments, `display:none` / `aria-hidden` text, `data-ai` / `data-mcp` / `data-agent` attribute payloads, or WebMCP manifests. Fetch such a page with a naive tool and those hidden instructions land straight in your model's context, where they can be acted on. This is the [prompt-injection-as-phishing](https://www.theregister.com/research/2026/05/29/chatgpt-prompt-injection-turns-web-pages-into-phishing-lures/5248137) class of attack.
+
+nab treats every fetched page as hostile input and runs two local, non-networked guards **before any content reaches your agent** — no flag, no setup:
+
+- **Secure Ingestion guard** — detects and strips machine-targeted markup that is invisible to humans (AI-addressed comments, hidden `display:none` / `aria-hidden` text, agent-only `data-*` payloads, WebMCP advertisements) and **reports** each detection at `Info` / `Warn` / `Block` severity, so you see what a page *tried* to tell your agent instead of it being silently executed.
+- **YARA-X signature guard** — scans every returned body for prompt-injection, exfiltration, secret-leak, and obfuscation signatures, redacting matched sections by default. Set `NAB_YARA_ACTION=refuse` to block the fetch outright (or `NAB_YARA_BYPASS=1` as an audited emergency opt-out).
+
+The net effect: hidden instructions become **visible to you, not executed by your model**. That is the single biggest reason to point your agent at `nab fetch` instead of a built-in web-fetch tool.
+
 ## Quick start
 
 **Tell your AI assistant** (recommended):


### PR DESCRIPTION
## Why
The Register feature (2026-05-29) on prompt-injection-as-phishing drove security-conscious traffic to nab. This PR (1) clears the visible Dependabot alerts and (2) makes nab's existing, default-on injection defense legible to that audience.

## Security: dependency bumps (lockfile-only, no source changes)
| Alert | Sev | Fix |
|---|---|---|
| `tar` ≤0.4.45 → 0.4.46 (GHSA-3pv8-6f4r-ffg2) | medium | bumped |
| `rand` 0.8.5 → 0.8.6 (GHSA-cq8v-f236-94qc) | low | bumped |
| `rand` 0.9.2 → 0.9.3 (GHSA-cq8v-f236-94qc) | low | bumped |
| `lru` 0.13 → 0.16.3 (GHSA-rhfx-m35p-ff5j) | low | transitive via `wreq 5.3` (`lru = "^0.13"`); only fix is `wreq 6.0.0-rc.29` (pre-release). Dismissed as tolerable_risk, tracked. |

`cargo check` + full pre-push test suite (1336 passed) green.

## Docs
- **Headline "Prompt-injection defense (on by default)"** section: describes the two existing guards accurately — Secure Ingestion guard (strip + surface machine-targeted markup at Info/Warn/Block) and YARA-X signature guard (redact by default, `NAB_YARA_ACTION=refuse` to block). States the EE licensing boundary at the point of pitch.
- **Installation reordered** so the no-toolchain path leads: Homebrew → pre-built binary (binstall + direct release download for `nab` and `nab-mcp`, all 7 targets incl. static musl, checksum verify) → crates.io (labelled "compiles from source") → from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)