### PR TITLE
ci: docs-aware aggregate gate so doc-only PRs skip the Rust matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,47 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
 
 jobs:
+  # Decide whether this change touches code. Documentation-only changes
+  # (README, docs/**, licenses) skip the heavy Rust matrix; the CI Gate job
+  # below still reports success so branch protection is satisfied instantly.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'crates/**'
+              - 'benches/**'
+              - 'tests/**'
+              - 'build.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain*'
+              - '.cargo/**'
+              - '.github/workflows/**'
+
   fmt:
     name: Format
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -23,6 +57,8 @@ jobs:
 
   clippy:
     name: Clippy
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -34,6 +70,8 @@ jobs:
 
   test:
     name: Test (${{ matrix.name }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -61,6 +99,8 @@ jobs:
 
   build:
     name: Build (${{ matrix.name }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -80,6 +120,8 @@ jobs:
 
   package:
     name: Package
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -87,6 +129,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo publish --locked --dry-run
 
+  # Secret scanning always runs — a documentation change can still leak a key.
   secrets-scan:
     name: Secrets scan
     runs-on: ubuntu-latest
@@ -100,6 +143,8 @@ jobs:
 
   audit:
     name: Security Audit
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -109,3 +154,27 @@ jobs:
         run: cargo install cargo-audit --locked --version 0.22.0
       - name: Run cargo audit
         run: cargo audit
+
+  # Single required status check. Passes when every upstream job either
+  # succeeded or was skipped (documentation-only change); fails if any
+  # upstream job failed or was cancelled. Make THIS the required check in
+  # branch protection instead of the individual matrix jobs.
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs: [changes, fmt, clippy, test, build, package, secrets-scan, audit]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no required job failed
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "Upstream job results: ${results}"
+          for r in ${results}; do
+            case "${r}" in
+              failure|cancelled)
+                echo "::error::A CI job reported '${r}' — gate fails."
+                exit 1
+                ;;
+            esac
+          done
+          echo "CI Gate passed (all jobs succeeded or were skipped)."


### PR DESCRIPTION
## Problem
`ci.yml` ran the full matrix (Format, Clippy, 3× Test, 3× Build, Package, Secrets, Security Audit — ~10 min) on **every** PR, including one-line README edits. A naive `paths-ignore` would deadlock doc PRs because 7 of those jobs are branch-protection-required (`Build`×3, `Test`×3, `Clippy`) — they'd never report and the PR could never merge.

## Fix — aggregate gate
- **`changes`** job (`dorny/paths-filter`, SHA-pinned) sets `code=true` only when a real code path changed (`src`, `crates`, `Cargo.*`, `build.rs`, `tests`, `benches`, `.github/workflows`, `.cargo`, `rust-toolchain`).
- The Rust matrix (`fmt`/`clippy`/`test`/`build`/`package`/`audit`) is now `if: needs.changes.outputs.code == 'true'` — **skipped on doc-only PRs**.
- **`secrets-scan`** always runs (a doc can still leak a key).
- **`CI Gate`** (`if: always()`, `needs:` all upstream) passes when every job **succeeded or was skipped**, fails on any `failure`/`cancelled`.

## Required follow-up (after this lands on `main`)
Branch protection required checks must change from the 7 matrix contexts to **`CI Gate`** + **`Secrets scan`**. Until then this PR runs the full matrix (it touches `.github/workflows/**`) and merges under existing rules. Doc-only PRs only get fast once the required-check swap is done.

## Validation
- YAML parses; `CI Gate` `needs:` all 8 upstream jobs; gate logic fails on `failure`/`cancelled`, passes on `success`/`skipped`.
- This PR exercises the **code=true** path (full matrix). The **skip path** will be validated by the first doc-only PR after the branch-protection swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)