### PR TITLE
docs(contributing): document docs-aware CI gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,25 @@ Key modules:
 - **Breaking changes**: Clearly mark and explain in PR description
 - **Keep PRs focused**: One feature or fix per PR
 
+## Continuous integration
+
+CI is **docs-aware**. A `changes` job classifies each PR: when it touches a
+code path (`src/`, `crates/`, `Cargo.toml`, `Cargo.lock`, `build.rs`,
+`tests/`, `benches/`, `.github/workflows/`, `.cargo/`, `rust-toolchain*`)
+the full Rust matrix runs (format, clippy, tests, builds, package, audit).
+Documentation-only PRs (`*.md`, `docs/**`, licenses) **skip** that matrix and
+merge in seconds.
+
+Two checks are required by branch protection and always report:
+
+- **CI Gate** — aggregates the matrix; it passes when every upstream job
+  finished as success/skipped, and fails on any failure/cancellation.
+- **Secrets scan** — runs on every PR, including docs, since a doc can still
+  leak a credential.
+
+To force the full matrix for a new code path, extend the `code` filter in
+`.github/workflows/ci.yml`.
+
 ## Performance Considerations
 
 nab is optimized for speed and token efficiency:


### PR DESCRIPTION
Doc-only change (CONTRIBUTING.md). Validates the #136 docs-aware gate: the Rust matrix should skip; CI Gate + Secrets scan report green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)