### PR TITLE
ci(pre-push): docs-aware gate + stable TMPDIR (sccache resilience)

### DIFF
--- a/scripts/dev/pre-push.sh
+++ b/scripts/dev/pre-push.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # pre-push gate — local fmt + lint + lib-test parity with CI.
+# Documentation-only pushes skip the Rust gate, matching the docs-aware
+# `changes` filter in .github/workflows/ci.yml so local and CI agree.
 # Bypass: SKIP_PREPUSH=1 (logged, audit-only).
 # Wall-clock budget on warm cache: <60s.
 set -euo pipefail
@@ -12,7 +14,36 @@ fi
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-if [[ -f Cargo.toml ]]; then
+# rustc/sccache write per-compile temp files under $TMPDIR. Some sandboxes
+# wipe /tmp mid-build, which breaks the compiler cache with errors like
+# "error writing dependencies to .../deps.d: No such file or directory".
+# Pin a stable, repo-local temp dir so the gate is hermetic.
+STABLE_TMP="${REPO_ROOT}/target/.prepush-tmp"
+mkdir -p "$STABLE_TMP"
+export TMPDIR="$STABLE_TMP"
+
+# Decide whether code changed, relative to the integration base (origin/main).
+# Mirrors the `code` filter in .github/workflows/ci.yml.
+base="origin/main"
+git rev-parse --verify --quiet "${base}" >/dev/null 2>&1 || base="$(git rev-parse HEAD)"
+changed="$(git diff --name-only "${base}"...HEAD 2>/dev/null || true)"
+
+code_changed=0
+if [[ -z "${changed}" ]]; then
+  code_changed=1   # cannot classify — run the gate to stay safe
+else
+  while IFS= read -r f; do
+    [[ -z "${f}" ]] && continue
+    case "${f}" in
+      src/*|crates/*|tests/*|benches/*|build.rs|Cargo.toml|Cargo.lock|rust-toolchain*|.cargo/*|.github/workflows/*)
+        code_changed=1
+        break
+        ;;
+    esac
+  done <<< "${changed}"
+fi
+
+if [[ -f Cargo.toml && "${code_changed}" == "1" ]]; then
   echo "[pre-push] cargo fmt --check"
   cargo fmt --all --check 2>&1 | tail -20 || { echo "FAIL: cargo fmt"; exit 1; }
 
@@ -21,12 +52,16 @@ if [[ -f Cargo.toml ]]; then
 
   echo "[pre-push] cargo test --lib"
   cargo test --lib --quiet 2>&1 | tail -10 || { echo "FAIL: cargo test --lib"; exit 1; }
+  gate_result="cargo fmt+clippy+test green"
+else
+  echo "[pre-push] docs-only change — skipping Rust gate (parity with CI)"
+  gate_result="docs-only, Rust gate skipped"
 fi
 
 tip="$(git rev-parse HEAD)"
 if ! git log -1 --pretty=%B | grep -q '^Local-Tested: '; then
   git -c trailer.ifexists=replace commit --amend --no-edit \
-    --trailer "Local-Tested: cargo fmt+clippy+test green @ ${tip}" >/dev/null || true
+    --trailer "Local-Tested: ${gate_result} @ ${tip}" >/dev/null || true
 fi
 
 echo "[pre-push] OK"


### PR DESCRIPTION
## Why
Two local-dev papercuts hit repeatedly:
1. `scripts/dev/pre-push.sh` ran the full Rust gate (fmt/clippy/lib-test) on **every** push, including one-line README edits — minutes of build for a docs change.
2. rustc/sccache write per-compile temp under `$TMPDIR`; a sandbox wiping `/tmp` mid-build broke pushes with `error writing dependencies to .../deps.d: No such file or directory`.

## Fix
- **Docs-aware**: classify pushed changes vs `origin/main` with the same code-path filter as `.github/workflows/ci.yml`. Docs/scripts-only pushes skip the gate; code pushes run it.
- **sccache resilience**: pin `TMPDIR=target/.prepush-tmp` (gitignored) so the gate is hermetic against `/tmp` wipes.
- `Local-Tested` trailer now states whether the gate ran or was skipped.

## Validation
This PR's own push (`scripts/`-only) **skipped the gate and completed instantly** — `[pre-push] OK` with no cargo invocation. The code path (`Cargo.lock` change) is exercised by the dependency-audit PR that follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)