### PR TITLE
chore(audit): acknowledge unfixable transitive advisories (#134)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,12 @@
+# cargo-audit configuration (read by `cargo audit` in CI and locally).
+# These advisories are acknowledged and tracked in GitHub issue #134.
+# Neither is fixable by a lockfile bump today; both are transitive.
+[advisories]
+ignore = [
+    # bincode 2.x is unmaintained. Transitive dependency; no drop-in
+    # maintained replacement wired yet. Tracked in #134.
+    "RUSTSEC-2025-0141",
+    # lru 0.13 `IterMut` unsoundness. Pinned by wreq 5.3 (`lru = "^0.13"`);
+    # the only fix is wreq 6.0.0-rc (pre-release we will not ship). #134.
+    "RUSTSEC-2026-0002",
+]


### PR DESCRIPTION
## What
Adds `.cargo/audit.toml` to acknowledge two advisory-class `cargo audit` warnings that cannot be cleared by a lockfile bump, each documented with rationale + issue tracking.

| Advisory | Crate | Why ignored |
|---|---|---|
| RUSTSEC-2025-0141 | `bincode` (unmaintained) | transitive; no maintained drop-in wired |
| RUSTSEC-2026-0002 | `lru` (IterMut unsound) | pinned by `wreq 5.3` (`lru ^0.13`); fix only in `wreq 6.0-rc` |

## Result
`cargo audit` drops from **4 warnings → 2**. Remaining are `aes 0.8.4` / `gimli 0.32.3` (yanked) — pinned transitively with no non-yanked release in range (`cargo update` locked 0 packages). Tracked in #134, no advisory ID so not ignorable.

No code/lockfile change. Refs #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)