### PR TITLE
docs(notice): reference LICENSE, not the nonexistent LICENSE-MIT

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,7 +3,7 @@ nab attribution notice
 Copyright (c) 2026 Mikko Parkkola.
 
 nab is a mixed-license project. MIT-licensed files are covered by
-LICENSE-MIT. Enterprise Edition files are covered by LICENSE-EE.md.
+LICENSE. Enterprise Edition files are covered by LICENSE-EE.md.
 
 Required Notice: Includes nab Enterprise Edition components by Mikko Parkkola, https://github.com/MikkoParkkola/nab. Commercial use requires a separate license.
 


### PR DESCRIPTION
Follow-up to #141. The salvaged NOTICE referenced `LICENSE-MIT` (only on a stale branch); main's MIT text is `LICENSE`. One-line fix to the dangling reference. Docs-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)