### PR TITLE
chore(license): enforce MIT/PolyForm-NC boundary; mark EE files; gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,17 @@ jobs:
       - name: Run cargo audit
         run: cargo audit
 
+  # License-boundary enforcement always runs: a PR can add a new EE file
+  # needing the PolyForm-NC SPDX header without changing any Rust code.
+  # Fast, no build.
+  license-boundary:
+    name: License boundary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Validate MIT / PolyForm-NC boundary
+        run: python3 scripts/check_license_boundary.py
+
   # Single required status check. Passes when every upstream job either
   # succeeded or was skipped (documentation-only change); fails if any
   # upstream job failed or was cancelled. Make THIS the required check in
@@ -162,7 +173,7 @@ jobs:
   ci-gate:
     name: CI Gate
     if: always()
-    needs: [changes, fmt, clippy, test, build, package, secrets-scan, audit]
+    needs: [changes, fmt, clippy, test, build, package, secrets-scan, audit, license-boundary]
     runs-on: ubuntu-latest
     steps:
       - name: Verify no required job failed

--- a/LICENSE-EE.md
+++ b/LICENSE-EE.md
@@ -4,6 +4,12 @@
 
 This file describes the license terms that apply to designated **Enterprise Edition (EE)** files within the `nab` repository. The Path C dual-license refactor landed in v0.9.0.
 
+## Required Notice
+
+Distributions, modified versions, forks, and derivative works that include Enterprise Edition components must preserve the following attribution (see `NOTICE`):
+
+> Required Notice: Includes nab Enterprise Edition components by Mikko Parkkola, https://github.com/MikkoParkkola/nab. Commercial use requires a separate license.
+
 ## Scope
 
 Files marked with the SPDX header

--- a/crates/nab-yara-engine/Cargo.toml
+++ b/crates/nab-yara-engine/Cargo.toml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 [package]
 name = "nab-yara-engine"
 version = "0.1.0"

--- a/crates/nab-yara-engine/tests/yara_guard.rs
+++ b/crates/nab-yara-engine/tests/yara_guard.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Instant;
 

--- a/scripts/check_license_boundary.py
+++ b/scripts/check_license_boundary.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Validate nab's mixed MIT / PolyForm Noncommercial licensing boundary."""
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SPDX = "SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0"
+
+EE_PATHS = (
+    Path("src/auth"),
+    Path("src/fingerprint"),
+    Path("src/waf"),
+    Path("src/site"),
+    Path("src/security"),
+    Path("crates/nab-yara-engine"),
+)
+
+EE_FILES = (Path("examples/scan_html.rs"),)
+
+COMMENTABLE_EXTENSIONS = {".rs", ".toml", ".yar"}
+NON_COMMENTABLE_EXTENSIONS = {".json"}
+
+
+def rel(path: Path) -> Path:
+    return path.relative_to(ROOT)
+
+
+def is_under(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def first_text(path: Path, max_lines: int = 8) -> str:
+    lines: list[str] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for _ in range(max_lines):
+            line = handle.readline()
+            if not line:
+                break
+            lines.append(line)
+    return "".join(lines)
+
+
+def check_required_files(errors: list[str]) -> None:
+    # nab keeps the MIT text in LICENSE (GitHub-detectable) rather than a
+    # separate LICENSE-MIT; the mixed-licensing boundary is explained in
+    # LICENSE-EE.md, NOTICE, CONTRIBUTING.md, and the README.
+    required = [
+        "LICENSE",
+        "LICENSE-EE.md",
+        "NOTICE",
+        "CITATION.cff",
+        "CONTRIBUTING.md",
+    ]
+    for name in required:
+        if not (ROOT / name).is_file():
+            errors.append(f"missing required licensing file: {name}")
+
+    checks = {
+        "LICENSE": "MIT License",
+        "LICENSE-EE.md": "Required Notice:",
+        "NOTICE": "Required Notice:",
+        "CONTRIBUTING.md": "PolyForm Noncommercial",
+    }
+    for name, needle in checks.items():
+        path = ROOT / name
+        if path.is_file() and needle not in path.read_text(encoding="utf-8"):
+            errors.append(f"{name} must contain {needle!r}")
+
+
+def check_ee_paths(errors: list[str]) -> None:
+    for ee_file in EE_FILES:
+        path = ROOT / ee_file
+        if not path.is_file():
+            errors.append(f"missing EE file listed in license policy: {ee_file}")
+            continue
+        if path.suffix not in COMMENTABLE_EXTENSIONS:
+            errors.append(f"{ee_file} must use a commentable file type or move under EE path scope")
+        elif SPDX not in first_text(path):
+            errors.append(f"{ee_file} must carry {SPDX}")
+
+    for ee_path in EE_PATHS:
+        abs_path = ROOT / ee_path
+        if not abs_path.exists():
+            errors.append(f"missing EE path listed in license policy: {ee_path}")
+            continue
+
+        for path in sorted(abs_path.rglob("*")):
+            if not path.is_file():
+                continue
+
+            relative = rel(path)
+            suffix = path.suffix
+            if suffix in COMMENTABLE_EXTENSIONS:
+                if SPDX not in first_text(path):
+                    errors.append(f"{relative} must carry {SPDX}")
+            elif suffix in NON_COMMENTABLE_EXTENSIONS:
+                continue
+            else:
+                errors.append(
+                    f"{relative} has unsupported EE file extension {suffix!r}; "
+                    "add an SPDX marker or extend check_license_boundary.py"
+                )
+
+
+def check_no_polyform_outside_ee(errors: list[str]) -> None:
+    for path in ROOT.rglob("*"):
+        if not path.is_file():
+            continue
+        if any(part in {".git", "target"} for part in path.parts):
+            continue
+        if path.suffix not in COMMENTABLE_EXTENSIONS:
+            continue
+        relative = rel(path)
+        if any(is_under(relative, ee_path) for ee_path in EE_PATHS) or relative in EE_FILES:
+            continue
+        if SPDX in first_text(path):
+            errors.append(f"{relative} has PolyForm SPDX outside EE path scope")
+
+
+def main() -> int:
+    errors: list[str] = []
+    check_required_files(errors)
+    check_ee_paths(errors)
+    check_no_polyform_outside_ee(errors)
+
+    if errors:
+        print("license boundary check failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("license boundary check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/site/rules/defaults/github-issues.toml
+++ b/src/site/rules/defaults/github-issues.toml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 # GitHub Issues and Pull Requests extraction via GitHub REST API.
 #
 # Matches github.com/{owner}/{repo}/issues/{num} and

--- a/src/site/rules/defaults/hackernews.toml
+++ b/src/site/rules/defaults/hackernews.toml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 # Hacker News item extraction via Algolia HN Search API.
 #
 # Matches individual item pages (item?id=NNN).

--- a/src/site/rules/defaults/instagram.toml
+++ b/src/site/rules/defaults/instagram.toml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 [site]
 name = "instagram"
 patterns = ["(?i)instagram\\.com/(?:p|reel)/"]

--- a/src/site/rules/defaults/mastodon.toml
+++ b/src/site/rules/defaults/mastodon.toml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 # Mastodon status extraction via Mastodon API.
 #
 # Matches known Fediverse instances with /@user/digits URL pattern.

--- a/src/site/rules/defaults/reddit.toml
+++ b/src/site/rules/defaults/reddit.toml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 # Reddit post extraction via Reddit JSON API.
 #
 # Reddit returns a bare JSON array: [post_listing, comments_listing].

--- a/src/site/rules/defaults/stackoverflow.toml
+++ b/src/site/rules/defaults/stackoverflow.toml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 # Stack Overflow question extraction via Stack Exchange API v2.3.
 #
 # Primary fetch: question metadata and body.

--- a/src/site/rules/defaults/twitter.toml
+++ b/src/site/rules/defaults/twitter.toml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 [site]
 name = "twitter"
 patterns = ["(?i)(?:x|twitter)\\.com/.+/status/\\d+"]

--- a/src/site/rules/defaults/wikipedia.toml
+++ b/src/site/rules/defaults/wikipedia.toml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 [site]
 name = "wikipedia"
 patterns = ["(?i)[a-z]{2,3}\\.wikipedia\\.org/wiki/"]

--- a/src/site/rules/defaults/youtube.toml
+++ b/src/site/rules/defaults/youtube.toml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 [site]
 name = "youtube"
 patterns = ["(?i)youtube\\.com/watch", "(?i)youtu\\.be/"]


### PR DESCRIPTION
## Why
Reviewing stale branches surfaced a real enforcement gap: several **Enterprise Edition** files on main were not carrying the `SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0` header — so files intended as commercial-licensed were not labelled as such.

## What
- **SPDX headers added** to the 11 unmarked EE files: 9 site-rule TOMLs + `crates/nab-yara-engine/Cargo.toml` + `crates/nab-yara-engine/tests/yara_guard.rs`.
- **`LICENSE-EE.md`**: added a `Required Notice` section (mirrors `NOTICE`).
- **`scripts/check_license_boundary.py`** reinstated, adapted to main's real layout (MIT text in `LICENSE`, no separate `LICENSE-MIT`). It verifies every commentable file under EE paths (`src/auth`, `src/fingerprint`, `src/waf`, `src/site`, `src/security`, `crates/nab-yara-engine`) carries the SPDX header, and that no PolyForm SPDX leaks into MIT/core scope.
- **CI**: new always-on `License boundary` job feeds `CI Gate`, enforcing the boundary on every PR (including docs-only — a PR can add an EE file without touching Rust).

## Validation
`check_license_boundary.py` passes locally (exit 0); YAML + TOML parse verified; local pre-push gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)