### PR TITLE
feat(task): nab task engine slice 1 — rung 0 behind opt-in task feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,10 @@ jobs:
             os: ubuntu-latest
             command: cargo test --locked -p nab-yara-engine
             net_tests: "0"
+          - name: task-feature
+            os: ubuntu-latest
+            command: cargo test --locked --features task --bin nab cmd::task
+            net_tests: "0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,6 +228,9 @@ default = ["cli", "http3", "impersonate", "analyze", "browser-launcher", "js-dom
 # https://github.com/FluidInference/FluidAudio
 analyze = []
 cli = []
+# Experimental API-first web-task engine (`nab task`). Opt-in until rungs 1-3
+# land; slice 1 is rung-0 only (fetch -> screened markdown -> TaskOutcome).
+task = []
 # HTTP/3 + QUIC - enabled by default for maximum performance
 # Disable with: cargo build --no-default-features --features cli
 http3 = ["quinn", "h3", "h3-quinn"]

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -85,6 +85,52 @@ pub struct FetchConfig {
     pub ssrf_policy: nab::SsrfPolicy,
 }
 
+impl FetchConfig {
+    /// Construct a config for a programmatic single-URL fetch (used by
+    /// `nab task` rung 0): browser cookies on (the auth moat), OCR / media
+    /// transcription / hebb-save off, SSRF policy from env, WAF handling Auto.
+    pub fn for_url(url: String, format: OutputFormat) -> Self {
+        Self {
+            url,
+            show_headers: false,
+            show_body: false,
+            format,
+            output_file: None,
+            cookies: "auto".to_string(),
+            use_1password: false,
+            raw_html: false,
+            links: false,
+            max_body: 0,
+            max_output_tokens: None,
+            custom_headers: Vec::new(),
+            auto_referer: false,
+            warmup_url: None,
+            method: "GET".to_string(),
+            data: None,
+            capture_cookies: false,
+            no_redirect: false,
+            render: false,
+            interactive: false,
+            browser_cdp_url: None,
+            browser_headers_env: String::new(),
+            browser_wait_ms: 0,
+            batch_file: None,
+            parallel: 1,
+            proxy: None,
+            tor: false,
+            show_diff: false,
+            html_options: nab::content::html::HtmlConversionOptions::default(),
+            no_save: true,
+            no_ocr: true,
+            no_transcribe: true,
+            language: None,
+            detect_labyrinth: false,
+            waf_mode: WafMode::Auto,
+            ssrf_policy: nab::SsrfPolicy::from_env(),
+        }
+    }
+}
+
 /// Strategy for handling detected WAF challenges (AWS WAF, Cloudflare
 /// Turnstile, `DataDome`, …).
 ///
@@ -514,7 +560,75 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
     Ok(())
 }
 
-/// Execute a safe GET request, honouring the supplied SSRF policy.
+/// Fetch a URL and return the YARA-screened, token-budgeted markdown as a
+/// VALUE (instead of printing it like [`cmd_fetch`]).
+///
+/// This is the rung-0 primitive for `nab task`: the task loop needs the
+/// screened content as a string to feed the model, not stdout. It reuses the
+/// same moat helpers as [`cmd_fetch`] — `build_client` (HTTP/3 + fingerprint),
+/// browser-cookie resolution, the issue-#117 cookie-profile fallback, site
+/// providers, markdown conversion, and the `guard_fetch_output` YARA screen —
+/// but omits the display-only / interactive side-effects (`print_output`,
+/// WAF interactive solving, OCR enrichment, media transcription, hebb-save,
+/// diff). Those belong to later task-engine slices.
+///
+/// Slice-1 scaffolding: the ~40-line orchestration here is intentionally a
+/// focused subset of `cmd_fetch` rather than a risky rewrite of the flagship.
+/// Consolidate into a shared `FetchResult`-returning core when slice 1b lands
+/// (tracked in docs/design/2026-05-31-nab-task-engine.md §11).
+pub async fn fetch_to_markdown(cfg: &FetchConfig) -> Result<String> {
+    let client = build_client(cfg.no_redirect, cfg.proxy.as_deref(), cfg.tor)?;
+    let profile = client.profile().await;
+    let domain = super::extract_domain(&cfg.url);
+    let cookie_header = super::resolve_cookie_header(&cfg.cookies, &domain);
+
+    // Site providers (official APIs / structured data) when not asked for raw HTML.
+    if !cfg.raw_html {
+        let site_router = nab::site::SiteRouter::new();
+        let cookie_opt = non_empty(&cookie_header);
+        if let Some(site_content) = site_router.try_extract(&cfg.url, &client, cookie_opt).await {
+            let md = nab::security::guard_fetch_output(
+                &site_content.markdown,
+                "task_fetch_site_provider",
+                &cfg.url,
+            )?;
+            return Ok(apply_output_token_budget(&md, cfg.max_output_tokens));
+        }
+    }
+
+    let is_simple_get = cfg.method.eq_ignore_ascii_case("GET")
+        && cookie_header.is_empty()
+        && cfg.custom_headers.is_empty()
+        && cfg.data.is_none()
+        && !cfg.auto_referer
+        && !cfg.no_redirect;
+
+    let fetched = if is_simple_get {
+        execute_safe_get(&client, &cfg.url, cfg.show_headers, &cfg.ssrf_policy).await?
+    } else {
+        execute_manual_request(&client, cfg, &profile, &cookie_header).await?
+    };
+    let (_status, _version, _set_cookies, content_type, _response_headers, body_bytes) =
+        maybe_fallback_cookie_profiles(&client, cfg, &profile, &domain, fetched).await?;
+
+    let body_text = if cfg.raw_html {
+        String::from_utf8_lossy(&body_bytes).to_string()
+    } else {
+        convert_body_to_markdown(
+            &body_bytes,
+            &content_type,
+            &cfg.url,
+            cfg.format,
+            cfg.html_options,
+        )
+        .await?
+        .markdown
+    };
+
+    let body_text = nab::security::guard_fetch_output(&body_text, "task_fetch", &cfg.url)?;
+    Ok(apply_output_token_budget(&body_text, cfg.max_output_tokens))
+}
+
 async fn execute_safe_get(
     client: &AcceleratedClient,
     url: &str,

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -20,6 +20,8 @@ pub mod provider;
 pub mod spa;
 pub mod stream;
 pub mod submit;
+#[cfg(feature = "task")]
+pub mod task;
 pub mod upgrade;
 pub mod validate;
 pub mod watch;

--- a/src/cmd/task.rs
+++ b/src/cmd/task.rs
@@ -1,0 +1,167 @@
+//! `nab task` — API-first web-task engine (Phase 1, slice 1: rung 0).
+//!
+//! `nab task "<goal>" <url>` is the single-contact-point entry. Slice 1
+//! implements rung 0 only: fetch the seed URL through the moat (browser
+//! cookies, fingerprint, HTTP/3), YARA-screen it, and return the shaped
+//! markdown as a [`TaskOutcome`]. Rungs 1-3 (API / form / browser) and the
+//! MCP-sampling control loop land in later slices — see
+//! `docs/design/2026-05-31-nab-task-engine.md`.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use super::fetch::{FetchConfig, fetch_to_markdown};
+use crate::OutputFormat;
+
+fn default_get_method() -> String {
+    "GET".to_string()
+}
+
+/// One action the task loop can take at a given rung (§4 of the design).
+///
+/// Rungs 1-3 are emitted by the MCP-sampling loop in later slices; the schema
+/// is defined now so it is stable for the host LLM that will produce these.
+/// Variants beyond what slice 1 exercises are intentionally part of the
+/// forward API (consumed by the bounded loop in slices 2-3).
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum TaskAction {
+    /// Rung 1: call a discovered JSON API directly.
+    ApiCall {
+        url: String,
+        #[serde(default = "default_get_method")]
+        method: String,
+        #[serde(default)]
+        headers: Vec<(String, String)>,
+        #[serde(default)]
+        body: Option<String>,
+        #[serde(default)]
+        extract_query: Option<String>,
+    },
+    /// Rung 1: evaluate page JS via `QuickJS` + the authenticated fetch bridge.
+    JsEval { url: String, script: String },
+    /// Rung 2: submit a (CSRF-aware) form.
+    Submit {
+        url: String,
+        fields: Vec<(String, String)>,
+    },
+    /// Shape the current response to a query via the content pipeline.
+    Extract { extract_query: String },
+    /// Rung 3: escalate to the opt-in external-CDP browser.
+    NeedsBrowser { reason: String },
+    /// Terminal: the goal is complete.
+    Done {
+        #[serde(default)]
+        summary: Option<String>,
+    },
+}
+
+/// Terminal status of a task run. `Incomplete` / `NeedsHuman` are produced by
+/// the bounded loop in later slices.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    Done,
+    Incomplete,
+    NeedsHuman,
+}
+
+/// The result of a `nab task` run, shaped for an LLM consumer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskOutcome {
+    pub goal: String,
+    pub url: String,
+    /// The rung that produced the result (0 = fetch … 3 = browser).
+    pub rung: u8,
+    pub status: TaskStatus,
+    pub content: String,
+}
+
+/// Run a web task.
+///
+/// Slice 1: rung 0 only — fetch the seed URL (moat applied), YARA-screen, and
+/// return the shaped markdown. When `as_json` is set the full [`TaskOutcome`]
+/// is emitted as pretty JSON; otherwise just the content is printed.
+pub async fn cmd_task(goal: &str, url: &str, format: OutputFormat, as_json: bool) -> Result<()> {
+    let cfg = FetchConfig::for_url(url.to_string(), format);
+    let content = fetch_to_markdown(&cfg).await?;
+    let outcome = TaskOutcome {
+        goal: goal.to_string(),
+        url: url.to_string(),
+        rung: 0, // rung 0 = fetch
+        status: TaskStatus::Done,
+        content,
+    };
+    if as_json {
+        println!("{}", serde_json::to_string_pretty(&outcome)?);
+    } else {
+        println!("{}", outcome.content);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_action_roundtrips_through_json() {
+        let actions = vec![
+            TaskAction::ApiCall {
+                url: "https://x/api".into(),
+                method: "POST".into(),
+                headers: vec![("A".into(), "B".into())],
+                body: Some("{}".into()),
+                extract_query: Some("q".into()),
+            },
+            TaskAction::JsEval {
+                url: "https://x".into(),
+                script: "1".into(),
+            },
+            TaskAction::Submit {
+                url: "https://x".into(),
+                fields: vec![("f".into(), "v".into())],
+            },
+            TaskAction::Extract {
+                extract_query: "title".into(),
+            },
+            TaskAction::NeedsBrowser {
+                reason: "captcha".into(),
+            },
+            TaskAction::Done {
+                summary: Some("ok".into()),
+            },
+        ];
+        for a in actions {
+            let s = serde_json::to_string(&a).unwrap();
+            let back: TaskAction = serde_json::from_str(&s).unwrap();
+            assert_eq!(a, back);
+        }
+    }
+
+    #[test]
+    fn api_call_defaults_method_to_get() {
+        let a: TaskAction =
+            serde_json::from_str(r#"{"kind":"api_call","url":"https://x"}"#).unwrap();
+        match a {
+            TaskAction::ApiCall { method, .. } => assert_eq!(method, "GET"),
+            other => panic!("expected api_call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn outcome_serializes_rung_and_status() {
+        let o = TaskOutcome {
+            goal: "g".into(),
+            url: "u".into(),
+            rung: 0,
+            status: TaskStatus::Done,
+            content: "c".into(),
+        };
+        let s = serde_json::to_string(&o).unwrap();
+        assert!(s.contains("\"rung\":0"));
+        assert!(s.contains("\"status\":\"done\""));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -677,6 +677,26 @@ enum Commands {
         #[arg(long, value_name = "ORIGIN")]
         http_allow_origin: Option<String>,
     },
+
+    /// Complete a web task (experimental API-first web-task engine).
+    ///
+    /// `nab task "<goal>" <url>` fetches the seed URL through the moat
+    /// (browser cookies, fingerprint, HTTP/3), YARA-screens it, and returns the
+    /// shaped markdown. Slice 1 implements rung 0 (fetch); build with
+    /// `--features task`.
+    #[cfg(feature = "task")]
+    Task {
+        /// Natural-language goal for the task.
+        goal: String,
+        /// Seed URL to start from.
+        url: String,
+        /// Output format for the fetched content.
+        #[arg(short, long, default_value = "full")]
+        format: OutputFormat,
+        /// Emit the full `TaskOutcome` as JSON instead of just the content.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1119,6 +1139,15 @@ async fn main() -> Result<()> {
             }
             Commands::Otp { domain } => {
                 cmd::cmd_otp(&domain)?;
+            }
+            #[cfg(feature = "task")]
+            Commands::Task {
+                goal,
+                url,
+                format,
+                json,
+            } => {
+                cmd::task::cmd_task(&goal, &url, format, json).await?;
             }
             Commands::Stream {
                 source,


### PR DESCRIPTION
First build slice of the ratified API-first web-task engine (MIK-5359, design doc §1-§11). Single-contact-point entry + **rung 0 (fetch)** end-to-end; rungs 1-3 + the MCP-sampling loop follow.

## What
- **`fetch_to_markdown`** (`src/cmd/fetch.rs`): content-returning rung-0 core reusing the moat helpers (`build_client` = HTTP/3 + fingerprint, browser cookies, #117 fallback, site providers, markdown conversion, `guard_fetch_output` YARA screen, token budget). **`cmd_fetch` is untouched — zero flagship regression risk.** Documented as slice-1 scaffolding to consolidate into a shared `FetchResult` core later (§11).
- **`FetchConfig::for_url`**: programmatic constructor with task defaults.
- **`src/cmd/task.rs`**: §4 action schema (`TaskAction`), `TaskStatus`, `TaskOutcome`, `cmd_task` (rung 0) + 3 serde unit tests.
- **CLI**: feature-gated `nab task <goal> <url> [--format] [--json]`.
- **Cargo**: opt-in `task` feature (**not** default — experimental until rungs 1-3).
- **CI**: `Test (task-feature)` matrix entry.

## Validation
- `cargo check` (default) green — flagship unaffected.
- `cargo check`/`clippy -D warnings`/`test --features task` green (3/3 tests).
- e2e smoke: `nab task "summarize" <url> --json` → `TaskOutcome { rung: 0, status: "done", content: <moat-fetched YARA-screened markdown> }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)