### PR TITLE
feat(task): slice 2 — rung-1 API discovery surfaced in TaskOutcome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,10 @@ jobs:
             os: ubuntu-latest
             command: cargo test --locked -p nab-yara-engine
             net_tests: "0"
+          - name: task-feature
+            os: ubuntu-latest
+            command: cargo test --locked --features task --bin nab cmd::task
+            net_tests: "0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,6 +228,9 @@ default = ["cli", "http3", "impersonate", "analyze", "browser-launcher", "js-dom
 # https://github.com/FluidInference/FluidAudio
 analyze = []
 cli = []
+# Experimental API-first web-task engine (`nab task`). Opt-in until rungs 1-3
+# land; slice 1 is rung-0 only (fetch -> screened markdown -> TaskOutcome).
+task = []
 # HTTP/3 + QUIC - enabled by default for maximum performance
 # Disable with: cargo build --no-default-features --features cli
 http3 = ["quinn", "h3", "h3-quinn"]

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -85,6 +85,52 @@ pub struct FetchConfig {
     pub ssrf_policy: nab::SsrfPolicy,
 }
 
+impl FetchConfig {
+    /// Construct a config for a programmatic single-URL fetch (used by
+    /// `nab task` rung 0): browser cookies on (the auth moat), OCR / media
+    /// transcription / hebb-save off, SSRF policy from env, WAF handling Auto.
+    pub fn for_url(url: String, format: OutputFormat) -> Self {
+        Self {
+            url,
+            show_headers: false,
+            show_body: false,
+            format,
+            output_file: None,
+            cookies: "auto".to_string(),
+            use_1password: false,
+            raw_html: false,
+            links: false,
+            max_body: 0,
+            max_output_tokens: None,
+            custom_headers: Vec::new(),
+            auto_referer: false,
+            warmup_url: None,
+            method: "GET".to_string(),
+            data: None,
+            capture_cookies: false,
+            no_redirect: false,
+            render: false,
+            interactive: false,
+            browser_cdp_url: None,
+            browser_headers_env: String::new(),
+            browser_wait_ms: 0,
+            batch_file: None,
+            parallel: 1,
+            proxy: None,
+            tor: false,
+            show_diff: false,
+            html_options: nab::content::html::HtmlConversionOptions::default(),
+            no_save: true,
+            no_ocr: true,
+            no_transcribe: true,
+            language: None,
+            detect_labyrinth: false,
+            waf_mode: WafMode::Auto,
+            ssrf_policy: nab::SsrfPolicy::from_env(),
+        }
+    }
+}
+
 /// Strategy for handling detected WAF challenges (AWS WAF, Cloudflare
 /// Turnstile, `DataDome`, …).
 ///
@@ -514,7 +560,75 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
     Ok(())
 }
 
-/// Execute a safe GET request, honouring the supplied SSRF policy.
+/// Fetch a URL and return the YARA-screened, token-budgeted markdown as a
+/// VALUE (instead of printing it like [`cmd_fetch`]).
+///
+/// This is the rung-0 primitive for `nab task`: the task loop needs the
+/// screened content as a string to feed the model, not stdout. It reuses the
+/// same moat helpers as [`cmd_fetch`] — `build_client` (HTTP/3 + fingerprint),
+/// browser-cookie resolution, the issue-#117 cookie-profile fallback, site
+/// providers, markdown conversion, and the `guard_fetch_output` YARA screen —
+/// but omits the display-only / interactive side-effects (`print_output`,
+/// WAF interactive solving, OCR enrichment, media transcription, hebb-save,
+/// diff). Those belong to later task-engine slices.
+///
+/// Slice-1 scaffolding: the ~40-line orchestration here is intentionally a
+/// focused subset of `cmd_fetch` rather than a risky rewrite of the flagship.
+/// Consolidate into a shared `FetchResult`-returning core when slice 1b lands
+/// (tracked in docs/design/2026-05-31-nab-task-engine.md §11).
+pub async fn fetch_to_markdown(cfg: &FetchConfig) -> Result<String> {
+    let client = build_client(cfg.no_redirect, cfg.proxy.as_deref(), cfg.tor)?;
+    let profile = client.profile().await;
+    let domain = super::extract_domain(&cfg.url);
+    let cookie_header = super::resolve_cookie_header(&cfg.cookies, &domain);
+
+    // Site providers (official APIs / structured data) when not asked for raw HTML.
+    if !cfg.raw_html {
+        let site_router = nab::site::SiteRouter::new();
+        let cookie_opt = non_empty(&cookie_header);
+        if let Some(site_content) = site_router.try_extract(&cfg.url, &client, cookie_opt).await {
+            let md = nab::security::guard_fetch_output(
+                &site_content.markdown,
+                "task_fetch_site_provider",
+                &cfg.url,
+            )?;
+            return Ok(apply_output_token_budget(&md, cfg.max_output_tokens));
+        }
+    }
+
+    let is_simple_get = cfg.method.eq_ignore_ascii_case("GET")
+        && cookie_header.is_empty()
+        && cfg.custom_headers.is_empty()
+        && cfg.data.is_none()
+        && !cfg.auto_referer
+        && !cfg.no_redirect;
+
+    let fetched = if is_simple_get {
+        execute_safe_get(&client, &cfg.url, cfg.show_headers, &cfg.ssrf_policy).await?
+    } else {
+        execute_manual_request(&client, cfg, &profile, &cookie_header).await?
+    };
+    let (_status, _version, _set_cookies, content_type, _response_headers, body_bytes) =
+        maybe_fallback_cookie_profiles(&client, cfg, &profile, &domain, fetched).await?;
+
+    let body_text = if cfg.raw_html {
+        String::from_utf8_lossy(&body_bytes).to_string()
+    } else {
+        convert_body_to_markdown(
+            &body_bytes,
+            &content_type,
+            &cfg.url,
+            cfg.format,
+            cfg.html_options,
+        )
+        .await?
+        .markdown
+    };
+
+    let body_text = nab::security::guard_fetch_output(&body_text, "task_fetch", &cfg.url)?;
+    Ok(apply_output_token_budget(&body_text, cfg.max_output_tokens))
+}
+
 async fn execute_safe_get(
     client: &AcceleratedClient,
     url: &str,

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -89,6 +89,10 @@ impl FetchConfig {
     /// Construct a config for a programmatic single-URL fetch (used by
     /// `nab task` rung 0): browser cookies on (the auth moat), OCR / media
     /// transcription / hebb-save off, SSRF policy from env, WAF handling Auto.
+    ///
+    /// Gated to the `task` feature: it has no consumer in the default build, so
+    /// shipping it there would be dead code (CI runs `-D warnings`).
+    #[cfg(feature = "task")]
     pub fn for_url(url: String, format: OutputFormat) -> Self {
         Self {
             url,
@@ -562,6 +566,7 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
 
 /// Screened fetch result carrying both the LLM-shaped markdown and the raw
 /// wire body, so later task rungs (e.g. API discovery) can inspect the HTML.
+#[cfg(feature = "task")]
 pub struct FetchedContent {
     /// YARA-screened, token-budgeted markdown — what the model consumes.
     pub markdown: String,
@@ -583,6 +588,7 @@ pub struct FetchedContent {
 /// Slice 1/2 scaffolding: a focused subset of `cmd_fetch` rather than a risky
 /// rewrite of the flagship. Consolidate into a shared core when slice 1b lands
 /// (tracked in docs/design/2026-05-31-nab-task-engine.md §11).
+#[cfg(feature = "task")]
 pub async fn fetch_screened(cfg: &FetchConfig) -> Result<FetchedContent> {
     let client = build_client(cfg.no_redirect, cfg.proxy.as_deref(), cfg.tor)?;
     let profile = client.profile().await;

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -560,23 +560,30 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
     Ok(())
 }
 
-/// Fetch a URL and return the YARA-screened, token-budgeted markdown as a
-/// VALUE (instead of printing it like [`cmd_fetch`]).
+/// Screened fetch result carrying both the LLM-shaped markdown and the raw
+/// wire body, so later task rungs (e.g. API discovery) can inspect the HTML.
+pub struct FetchedContent {
+    /// YARA-screened, token-budgeted markdown — what the model consumes.
+    pub markdown: String,
+    /// Raw wire body (HTML/JSON). Used internally (e.g. API discovery); not
+    /// surfaced to the model. Empty for site-provider results (already structured).
+    pub raw_html: String,
+}
+
+/// Fetch a URL and return the screened content as a VALUE (instead of printing
+/// it like [`cmd_fetch`]). The rung-0 primitive for `nab task`.
 ///
-/// This is the rung-0 primitive for `nab task`: the task loop needs the
-/// screened content as a string to feed the model, not stdout. It reuses the
-/// same moat helpers as [`cmd_fetch`] — `build_client` (HTTP/3 + fingerprint),
-/// browser-cookie resolution, the issue-#117 cookie-profile fallback, site
-/// providers, markdown conversion, and the `guard_fetch_output` YARA screen —
-/// but omits the display-only / interactive side-effects (`print_output`,
-/// WAF interactive solving, OCR enrichment, media transcription, hebb-save,
-/// diff). Those belong to later task-engine slices.
+/// Reuses the moat helpers from [`cmd_fetch`] — `build_client` (HTTP/3 +
+/// fingerprint), browser-cookie resolution, the issue-#117 cookie-profile
+/// fallback, site providers, markdown conversion, the `guard_fetch_output`
+/// YARA screen — but omits the display-only / interactive side-effects
+/// (`print_output`, WAF interactive solving, OCR, media transcription,
+/// hebb-save, diff). Those belong to later task-engine slices.
 ///
-/// Slice-1 scaffolding: the ~40-line orchestration here is intentionally a
-/// focused subset of `cmd_fetch` rather than a risky rewrite of the flagship.
-/// Consolidate into a shared `FetchResult`-returning core when slice 1b lands
+/// Slice 1/2 scaffolding: a focused subset of `cmd_fetch` rather than a risky
+/// rewrite of the flagship. Consolidate into a shared core when slice 1b lands
 /// (tracked in docs/design/2026-05-31-nab-task-engine.md §11).
-pub async fn fetch_to_markdown(cfg: &FetchConfig) -> Result<String> {
+pub async fn fetch_screened(cfg: &FetchConfig) -> Result<FetchedContent> {
     let client = build_client(cfg.no_redirect, cfg.proxy.as_deref(), cfg.tor)?;
     let profile = client.profile().await;
     let domain = super::extract_domain(&cfg.url);
@@ -592,7 +599,10 @@ pub async fn fetch_to_markdown(cfg: &FetchConfig) -> Result<String> {
                 "task_fetch_site_provider",
                 &cfg.url,
             )?;
-            return Ok(apply_output_token_budget(&md, cfg.max_output_tokens));
+            return Ok(FetchedContent {
+                markdown: apply_output_token_budget(&md, cfg.max_output_tokens),
+                raw_html: String::new(),
+            });
         }
     }
 
@@ -611,8 +621,9 @@ pub async fn fetch_to_markdown(cfg: &FetchConfig) -> Result<String> {
     let (_status, _version, _set_cookies, content_type, _response_headers, body_bytes) =
         maybe_fallback_cookie_profiles(&client, cfg, &profile, &domain, fetched).await?;
 
-    let body_text = if cfg.raw_html {
-        String::from_utf8_lossy(&body_bytes).to_string()
+    let raw = String::from_utf8_lossy(&body_bytes).to_string();
+    let markdown = if cfg.raw_html {
+        raw.clone()
     } else {
         convert_body_to_markdown(
             &body_bytes,
@@ -625,8 +636,11 @@ pub async fn fetch_to_markdown(cfg: &FetchConfig) -> Result<String> {
         .markdown
     };
 
-    let body_text = nab::security::guard_fetch_output(&body_text, "task_fetch", &cfg.url)?;
-    Ok(apply_output_token_budget(&body_text, cfg.max_output_tokens))
+    let markdown = nab::security::guard_fetch_output(&markdown, "task_fetch", &cfg.url)?;
+    Ok(FetchedContent {
+        markdown: apply_output_token_budget(&markdown, cfg.max_output_tokens),
+        raw_html: raw,
+    })
 }
 
 async fn execute_safe_get(

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -20,6 +20,8 @@ pub mod provider;
 pub mod spa;
 pub mod stream;
 pub mod submit;
+#[cfg(feature = "task")]
+pub mod task;
 pub mod upgrade;
 pub mod validate;
 pub mod watch;

--- a/src/cmd/task.rs
+++ b/src/cmd/task.rs
@@ -10,8 +10,9 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
-use super::fetch::{FetchConfig, fetch_to_markdown};
+use super::fetch::{FetchConfig, fetch_screened};
 use crate::OutputFormat;
+use nab::{ApiDiscovery, ApiEndpoint};
 
 fn default_get_method() -> String {
     "GET".to_string()
@@ -68,6 +69,27 @@ pub enum TaskStatus {
     NeedsHuman,
 }
 
+/// A candidate API endpoint discovered on the fetched page — a rung-1 lead the
+/// host LLM can choose to call directly instead of escalating to a browser.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscoveredApi {
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    /// The detector that surfaced this endpoint (for debugging).
+    pub source: String,
+}
+
+impl From<ApiEndpoint> for DiscoveredApi {
+    fn from(e: ApiEndpoint) -> Self {
+        Self {
+            url: e.url,
+            method: e.method,
+            source: e.source,
+        }
+    }
+}
+
 /// The result of a `nab task` run, shaped for an LLM consumer.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TaskOutcome {
@@ -77,6 +99,10 @@ pub struct TaskOutcome {
     pub rung: u8,
     pub status: TaskStatus,
     pub content: String,
+    /// Rung-1 API leads discovered on the page (may be empty). The host LLM can
+    /// call these directly rather than escalating to a browser.
+    #[serde(default)]
+    pub discovered_apis: Vec<DiscoveredApi>,
 }
 
 /// Run a web task.
@@ -86,20 +112,48 @@ pub struct TaskOutcome {
 /// is emitted as pretty JSON; otherwise just the content is printed.
 pub async fn cmd_task(goal: &str, url: &str, format: OutputFormat, as_json: bool) -> Result<()> {
     let cfg = FetchConfig::for_url(url.to_string(), format);
-    let content = fetch_to_markdown(&cfg).await?;
+    let fetched = fetch_screened(&cfg).await?;
+
+    // Rung-1 discovery: surface API endpoints found in the raw page so the host
+    // LLM can call them directly. Actually invoking them is a later slice.
+    let discovered_apis = discover_apis(&fetched.raw_html);
+
     let outcome = TaskOutcome {
         goal: goal.to_string(),
         url: url.to_string(),
-        rung: 0, // rung 0 = fetch
+        rung: 0, // rung 0 = fetch; rung-1 candidates surfaced in discovered_apis
         status: TaskStatus::Done,
-        content,
+        content: fetched.markdown,
+        discovered_apis,
     };
     if as_json {
         println!("{}", serde_json::to_string_pretty(&outcome)?);
     } else {
         println!("{}", outcome.content);
+        if !outcome.discovered_apis.is_empty() {
+            eprintln!(
+                "\n[task] {} rung-1 API candidate(s) discovered (use --json to see them)",
+                outcome.discovered_apis.len()
+            );
+        }
     }
     Ok(())
+}
+
+/// Discover candidate API endpoints in a raw HTML body. Returns an empty vec
+/// when discovery is unavailable or finds nothing (never fails the task).
+fn discover_apis(raw_html: &str) -> Vec<DiscoveredApi> {
+    if raw_html.is_empty() {
+        return Vec::new();
+    }
+    match ApiDiscovery::new() {
+        Ok(d) => d
+            .discover_from_html(raw_html)
+            .into_iter()
+            .map(DiscoveredApi::from)
+            .collect(),
+        Err(_) => Vec::new(),
+    }
 }
 
 #[cfg(test)]
@@ -159,9 +213,38 @@ mod tests {
             rung: 0,
             status: TaskStatus::Done,
             content: "c".into(),
+            discovered_apis: vec![],
         };
         let s = serde_json::to_string(&o).unwrap();
         assert!(s.contains("\"rung\":0"));
         assert!(s.contains("\"status\":\"done\""));
+    }
+
+    #[test]
+    fn discover_apis_finds_endpoints_and_skips_empty() {
+        assert!(discover_apis("").is_empty());
+        let html = r#"<html><body>
+            <script>fetch("/api/v1/users")</script>
+            <a href="/graphql">gql</a>
+        </body></html>"#;
+        let found = discover_apis(html);
+        assert!(
+            found.iter().any(|a| a.url.contains("/api/v1/users")),
+            "expected the /api/v1/users endpoint, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn discovered_api_maps_from_endpoint_and_roundtrips() {
+        let ep = ApiEndpoint {
+            url: "/api/x".into(),
+            method: Some("POST".into()),
+            source: "script-fetch".into(),
+        };
+        let d: DiscoveredApi = ep.into();
+        assert_eq!(d.url, "/api/x");
+        let s = serde_json::to_string(&d).unwrap();
+        let back: DiscoveredApi = serde_json::from_str(&s).unwrap();
+        assert_eq!(d, back);
     }
 }

--- a/src/cmd/task.rs
+++ b/src/cmd/task.rs
@@ -1,0 +1,167 @@
+//! `nab task` — API-first web-task engine (Phase 1, slice 1: rung 0).
+//!
+//! `nab task "<goal>" <url>` is the single-contact-point entry. Slice 1
+//! implements rung 0 only: fetch the seed URL through the moat (browser
+//! cookies, fingerprint, HTTP/3), YARA-screen it, and return the shaped
+//! markdown as a [`TaskOutcome`]. Rungs 1-3 (API / form / browser) and the
+//! MCP-sampling control loop land in later slices — see
+//! `docs/design/2026-05-31-nab-task-engine.md`.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use super::fetch::{FetchConfig, fetch_to_markdown};
+use crate::OutputFormat;
+
+fn default_get_method() -> String {
+    "GET".to_string()
+}
+
+/// One action the task loop can take at a given rung (§4 of the design).
+///
+/// Rungs 1-3 are emitted by the MCP-sampling loop in later slices; the schema
+/// is defined now so it is stable for the host LLM that will produce these.
+/// Variants beyond what slice 1 exercises are intentionally part of the
+/// forward API (consumed by the bounded loop in slices 2-3).
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum TaskAction {
+    /// Rung 1: call a discovered JSON API directly.
+    ApiCall {
+        url: String,
+        #[serde(default = "default_get_method")]
+        method: String,
+        #[serde(default)]
+        headers: Vec<(String, String)>,
+        #[serde(default)]
+        body: Option<String>,
+        #[serde(default)]
+        extract_query: Option<String>,
+    },
+    /// Rung 1: evaluate page JS via `QuickJS` + the authenticated fetch bridge.
+    JsEval { url: String, script: String },
+    /// Rung 2: submit a (CSRF-aware) form.
+    Submit {
+        url: String,
+        fields: Vec<(String, String)>,
+    },
+    /// Shape the current response to a query via the content pipeline.
+    Extract { extract_query: String },
+    /// Rung 3: escalate to the opt-in external-CDP browser.
+    NeedsBrowser { reason: String },
+    /// Terminal: the goal is complete.
+    Done {
+        #[serde(default)]
+        summary: Option<String>,
+    },
+}
+
+/// Terminal status of a task run. `Incomplete` / `NeedsHuman` are produced by
+/// the bounded loop in later slices.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    Done,
+    Incomplete,
+    NeedsHuman,
+}
+
+/// The result of a `nab task` run, shaped for an LLM consumer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskOutcome {
+    pub goal: String,
+    pub url: String,
+    /// The rung that produced the result (0 = fetch … 3 = browser).
+    pub rung: u8,
+    pub status: TaskStatus,
+    pub content: String,
+}
+
+/// Run a web task.
+///
+/// Slice 1: rung 0 only — fetch the seed URL (moat applied), YARA-screen, and
+/// return the shaped markdown. When `as_json` is set the full [`TaskOutcome`]
+/// is emitted as pretty JSON; otherwise just the content is printed.
+pub async fn cmd_task(goal: &str, url: &str, format: OutputFormat, as_json: bool) -> Result<()> {
+    let cfg = FetchConfig::for_url(url.to_string(), format);
+    let content = fetch_to_markdown(&cfg).await?;
+    let outcome = TaskOutcome {
+        goal: goal.to_string(),
+        url: url.to_string(),
+        rung: 0, // rung 0 = fetch
+        status: TaskStatus::Done,
+        content,
+    };
+    if as_json {
+        println!("{}", serde_json::to_string_pretty(&outcome)?);
+    } else {
+        println!("{}", outcome.content);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_action_roundtrips_through_json() {
+        let actions = vec![
+            TaskAction::ApiCall {
+                url: "https://x/api".into(),
+                method: "POST".into(),
+                headers: vec![("A".into(), "B".into())],
+                body: Some("{}".into()),
+                extract_query: Some("q".into()),
+            },
+            TaskAction::JsEval {
+                url: "https://x".into(),
+                script: "1".into(),
+            },
+            TaskAction::Submit {
+                url: "https://x".into(),
+                fields: vec![("f".into(), "v".into())],
+            },
+            TaskAction::Extract {
+                extract_query: "title".into(),
+            },
+            TaskAction::NeedsBrowser {
+                reason: "captcha".into(),
+            },
+            TaskAction::Done {
+                summary: Some("ok".into()),
+            },
+        ];
+        for a in actions {
+            let s = serde_json::to_string(&a).unwrap();
+            let back: TaskAction = serde_json::from_str(&s).unwrap();
+            assert_eq!(a, back);
+        }
+    }
+
+    #[test]
+    fn api_call_defaults_method_to_get() {
+        let a: TaskAction =
+            serde_json::from_str(r#"{"kind":"api_call","url":"https://x"}"#).unwrap();
+        match a {
+            TaskAction::ApiCall { method, .. } => assert_eq!(method, "GET"),
+            other => panic!("expected api_call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn outcome_serializes_rung_and_status() {
+        let o = TaskOutcome {
+            goal: "g".into(),
+            url: "u".into(),
+            rung: 0,
+            status: TaskStatus::Done,
+            content: "c".into(),
+        };
+        let s = serde_json::to_string(&o).unwrap();
+        assert!(s.contains("\"rung\":0"));
+        assert!(s.contains("\"status\":\"done\""));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -677,6 +677,26 @@ enum Commands {
         #[arg(long, value_name = "ORIGIN")]
         http_allow_origin: Option<String>,
     },
+
+    /// Complete a web task (experimental API-first web-task engine).
+    ///
+    /// `nab task "<goal>" <url>` fetches the seed URL through the moat
+    /// (browser cookies, fingerprint, HTTP/3), YARA-screens it, and returns the
+    /// shaped markdown. Slice 1 implements rung 0 (fetch); build with
+    /// `--features task`.
+    #[cfg(feature = "task")]
+    Task {
+        /// Natural-language goal for the task.
+        goal: String,
+        /// Seed URL to start from.
+        url: String,
+        /// Output format for the fetched content.
+        #[arg(short, long, default_value = "full")]
+        format: OutputFormat,
+        /// Emit the full `TaskOutcome` as JSON instead of just the content.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1119,6 +1139,15 @@ async fn main() -> Result<()> {
             }
             Commands::Otp { domain } => {
                 cmd::cmd_otp(&domain)?;
+            }
+            #[cfg(feature = "task")]
+            Commands::Task {
+                goal,
+                url,
+                format,
+                json,
+            } => {
+                cmd::task::cmd_task(&goal, &url, format, json).await?;
             }
             Commands::Stream {
                 source,


### PR DESCRIPTION
Stacked on #147 (slice 1). GitHub will auto-retarget this PR's base to `main` once #147 merges.

Advances toward rung 1 by **surfacing discovered API endpoints** so the host LLM can call them directly instead of escalating to a browser (invoking them = slice 3).

## What
- `fetch_to_markdown` → **`fetch_screened`** returning `FetchedContent { markdown, raw_html }` — exposes the raw wire body for discovery. `cmd_fetch` still untouched.
- `TaskOutcome` gains **`discovered_apis: Vec<DiscoveredApi>`** (`url`/`method`/`source`), mapped `From<nab::ApiEndpoint>`. `cmd_task` runs `ApiDiscovery::discover_from_html` on the raw body (never fails the task).
- Tests: discovery finds endpoints + skips empty; `DiscoveredApi` maps + round-trips. **5/5 task tests pass.**

## Validation
clippy `-D warnings` + `cargo test --features task` green; default build unaffected (flagship safe); e2e `nab task --json` now emits `discovered_apis`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Collapsed stack (2026-06-06):** slices 1 and 2 were build-coupled — slice 2 renamed and reshaped slice 1's rung-0 primitive (`fetch_to_markdown -> Result<String>` became `fetch_screened -> Result<FetchedContent>`) on the same lines, so keeping them as a stacked pair meant replaying that rename over any slice-1 fix. Retargeted this PR's base to `main` to ship rung 0 + rung-1 discovery as one squash. Supersedes #147 (closed). Includes the fix gating the task-only fetch helpers (`for_url`, `FetchedContent`, `fetch_screened`) behind the `task` feature so they are not dead code in the default build under CI's `-D warnings`. Verified locally: default `-Dwarnings` build clean, `--features task` cmd::task 5 passed, full suite 1356 passed.
