### PR TITLE
chore(audit): drop resolved lru advisory ignore RUSTSEC-2026-0002 (#134)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,12 +1,13 @@
 # cargo-audit configuration (read by `cargo audit` in CI and locally).
-# These advisories are acknowledged and tracked in GitHub issue #134.
-# Neither is fixable by a lockfile bump today; both are transitive.
+# Tracked in GitHub issue #134.
 [advisories]
 ignore = [
-    # bincode 2.x is unmaintained. Transitive dependency; no drop-in
-    # maintained replacement wired yet. Tracked in #134.
+    # bincode 2.x is unmaintained (RUSTSEC-2025-0141). Transitive dependency;
+    # no drop-in maintained replacement wired yet. No upstream patch exists
+    # (informational/unmaintained advisory). Tracked in #134.
     "RUSTSEC-2025-0141",
-    # lru 0.13 `IterMut` unsoundness. Pinned by wreq 5.3 (`lru = "^0.13"`);
-    # the only fix is wreq 6.0.0-rc (pre-release we will not ship). #134.
-    "RUSTSEC-2026-0002",
+    # NOTE: the lru RUSTSEC-2026-0002 ignore was removed once main moved to
+    # wreq 6.0.0-rc.29 (lru >= 0.18.0, past the 0.16.3 fix). The advisory no
+    # longer applies, so suppressing it would be dead config. See Cargo.toml
+    # (wreq pin rationale) and #134.
 ]


### PR DESCRIPTION
## What
Remove the stale cargo-audit ignore for **RUSTSEC-2026-0002 (lru)**. `bincode` (RUSTSEC-2025-0141, unmaintained, no upstream patch) stays ignored.

## Why
main moved to **wreq 6.0.0-rc.29**, which frees **lru to 0.18.0** — past the **0.16.3** fix for RUSTSEC-2026-0002. The advisory no longer applies, so the ignore was dead config.

Worse, its comment claimed *"pinned by wreq 5.3 / the only fix is wreq 6.0.0-rc, a pre-release we will not ship"* — which directly contradicts `Cargo.toml`, where the wreq 6.0.0-rc.29 pin is documented as a **deliberate** decision made precisely to free lru and satisfy the osv-scanner release gate. The contradiction was actively misleading.

## Evidence
- RUSTSEC-2026-0002 advisory: `patched = [">= 0.16.3"]`; the lockfile has lru **0.18.0** (single version).
- `cargo audit` on the updated config: **exit 0**, lru not flagged; only the bincode allowed-warning + a yanked warning remain (both exit-0 classes).

## AC
- `#134 NAB-AUDIT.4` — lru resolved via the wreq bump (not via a carried ignore). The audit stays honest-green: if lru ever regresses below 0.16.3, `cargo audit` fires again instead of being silently suppressed.
