### PR TITLE
feat(task): promote task schema to nab::task library module (MIK-5359)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
             net_tests: "0"
           - name: task-feature
             os: ubuntu-latest
-            command: cargo test --locked --features task --bin nab cmd::task
+            command: cargo test --locked --features task --lib --bin nab task
             net_tests: "0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/src/cmd/task.rs
+++ b/src/cmd/task.rs
@@ -9,123 +9,18 @@
 //!   currently `api_call` — via [`execute_action`], returning an
 //!   [`ActionObservation`]. This is the §9.2 host-driven control flow.
 //!
-//! The self-contained MCP-sampling control loop (rungs 2-3, the bounded
-//! brain-driven loop) lands in a later slice — see
-//! `docs/design/2026-05-31-nab-task-engine.md` §7/§9.
+//! The schema types ([`TaskAction`], [`TaskOutcome`], [`ActionObservation`], …)
+//! live in the `nab::task` LIBRARY module so the `nab-mcp` self-contained loop
+//! (slice 4) can share them across the binary boundary; this module is the
+//! `nab` CLI executor over that schema. See
+//! `docs/design/2026-05-31-nab-task-engine.md` §12.
 
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
 
 use super::fetch::{FetchConfig, fetch_screened};
 use crate::OutputFormat;
-use nab::{ApiDiscovery, ApiEndpoint};
-
-fn default_get_method() -> String {
-    "GET".to_string()
-}
-
-/// One action the task loop can take at a given rung (§4 of the design).
-///
-/// Rungs 1-3 are emitted by the MCP-sampling loop in later slices; the schema
-/// is defined now so it is stable for the host LLM that will produce these.
-/// Variants beyond what slice 1 exercises are intentionally part of the
-/// forward API (consumed by the bounded loop in slices 2-3).
-#[allow(dead_code)]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case", tag = "kind")]
-pub enum TaskAction {
-    /// Rung 1: call a discovered JSON API directly.
-    ApiCall {
-        url: String,
-        #[serde(default = "default_get_method")]
-        method: String,
-        #[serde(default)]
-        headers: Vec<(String, String)>,
-        #[serde(default)]
-        body: Option<String>,
-        #[serde(default)]
-        extract_query: Option<String>,
-    },
-    /// Rung 1: evaluate page JS via `QuickJS` + the authenticated fetch bridge.
-    JsEval { url: String, script: String },
-    /// Rung 2: submit a (CSRF-aware) form.
-    Submit {
-        url: String,
-        fields: Vec<(String, String)>,
-    },
-    /// Shape the current response to a query via the content pipeline.
-    Extract { extract_query: String },
-    /// Rung 3: escalate to the opt-in external-CDP browser.
-    NeedsBrowser { reason: String },
-    /// Terminal: the goal is complete.
-    Done {
-        #[serde(default)]
-        summary: Option<String>,
-    },
-}
-
-/// Terminal status of a task run. `Incomplete` / `NeedsHuman` are produced by
-/// the bounded loop in later slices.
-#[allow(dead_code)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum TaskStatus {
-    Done,
-    Incomplete,
-    NeedsHuman,
-}
-
-/// A candidate API endpoint discovered on the fetched page — a rung-1 lead the
-/// host LLM can choose to call directly instead of escalating to a browser.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DiscoveredApi {
-    pub url: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub method: Option<String>,
-    /// The detector that surfaced this endpoint (for debugging).
-    pub source: String,
-}
-
-impl From<ApiEndpoint> for DiscoveredApi {
-    fn from(e: ApiEndpoint) -> Self {
-        Self {
-            url: e.url,
-            method: e.method,
-            source: e.source,
-        }
-    }
-}
-
-/// The result of a `nab task` run, shaped for an LLM consumer.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct TaskOutcome {
-    pub goal: String,
-    pub url: String,
-    /// The rung that produced the result (0 = fetch … 3 = browser).
-    pub rung: u8,
-    pub status: TaskStatus,
-    pub content: String,
-    /// Rung-1 API leads discovered on the page (may be empty). The host LLM can
-    /// call these directly rather than escalating to a browser.
-    #[serde(default)]
-    pub discovered_apis: Vec<DiscoveredApi>,
-}
-
-/// The result of executing ONE [`TaskAction`] — the OBSERVE half of the loop
-/// (§4 step 4). Returned by [`execute_action`] so the host LLM (or the slice-4
-/// sampling loop) can inspect the outcome and decide the next step.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ActionObservation {
-    /// The rung that executed the action (1 = API/JS, 2 = submit, 3 = browser).
-    pub rung: u8,
-    pub status: TaskStatus,
-    /// YARA-screened, token-budgeted content the action produced (empty on error
-    /// or when the action is not executable in the current slice).
-    pub content: String,
-    /// Set when the action failed or is deferred to a later slice.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<String>,
-}
+use nab::ApiDiscovery;
+use nab::task::{ActionObservation, DiscoveredApi, TaskAction, TaskOutcome, TaskStatus};
 
 /// Run a web task.
 ///
@@ -313,66 +208,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn task_action_roundtrips_through_json() {
-        let actions = vec![
-            TaskAction::ApiCall {
-                url: "https://x/api".into(),
-                method: "POST".into(),
-                headers: vec![("A".into(), "B".into())],
-                body: Some("{}".into()),
-                extract_query: Some("q".into()),
-            },
-            TaskAction::JsEval {
-                url: "https://x".into(),
-                script: "1".into(),
-            },
-            TaskAction::Submit {
-                url: "https://x".into(),
-                fields: vec![("f".into(), "v".into())],
-            },
-            TaskAction::Extract {
-                extract_query: "title".into(),
-            },
-            TaskAction::NeedsBrowser {
-                reason: "captcha".into(),
-            },
-            TaskAction::Done {
-                summary: Some("ok".into()),
-            },
-        ];
-        for a in actions {
-            let s = serde_json::to_string(&a).unwrap();
-            let back: TaskAction = serde_json::from_str(&s).unwrap();
-            assert_eq!(a, back);
-        }
-    }
-
-    #[test]
-    fn api_call_defaults_method_to_get() {
-        let a: TaskAction =
-            serde_json::from_str(r#"{"kind":"api_call","url":"https://x"}"#).unwrap();
-        match a {
-            TaskAction::ApiCall { method, .. } => assert_eq!(method, "GET"),
-            other => panic!("expected api_call, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn outcome_serializes_rung_and_status() {
-        let o = TaskOutcome {
-            goal: "g".into(),
-            url: "u".into(),
-            rung: 0,
-            status: TaskStatus::Done,
-            content: "c".into(),
-            discovered_apis: vec![],
-        };
-        let s = serde_json::to_string(&o).unwrap();
-        assert!(s.contains("\"rung\":0"));
-        assert!(s.contains("\"status\":\"done\""));
-    }
-
-    #[test]
     fn discover_apis_finds_endpoints_and_skips_empty() {
         assert!(discover_apis("").is_empty());
         let html = r#"<html><body>
@@ -384,20 +219,6 @@ mod tests {
             found.iter().any(|a| a.url.contains("/api/v1/users")),
             "expected the /api/v1/users endpoint, got {found:?}"
         );
-    }
-
-    #[test]
-    fn discovered_api_maps_from_endpoint_and_roundtrips() {
-        let ep = ApiEndpoint {
-            url: "/api/x".into(),
-            method: Some("POST".into()),
-            source: "script-fetch".into(),
-        };
-        let d: DiscoveredApi = ep.into();
-        assert_eq!(d.url, "/api/x");
-        let s = serde_json::to_string(&d).unwrap();
-        let back: DiscoveredApi = serde_json::from_str(&s).unwrap();
-        assert_eq!(d, back);
     }
 
     #[test]
@@ -490,22 +311,5 @@ mod tests {
             .unwrap();
         assert_eq!(obs.status, TaskStatus::Done);
         assert!(obs.error.is_none());
-    }
-
-    #[test]
-    fn action_observation_serializes_and_omits_absent_error() {
-        let obs = ActionObservation {
-            rung: 1,
-            status: TaskStatus::Done,
-            content: "ok".into(),
-            error: None,
-        };
-        let s = serde_json::to_string(&obs).unwrap();
-        assert!(s.contains("\"rung\":1"));
-        assert!(s.contains("\"status\":\"done\""));
-        // error is None -> skipped, not serialized as null.
-        assert!(!s.contains("error"));
-        let back: ActionObservation = serde_json::from_str(&s).unwrap();
-        assert_eq!(obs, back);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,10 @@ pub mod session;
 pub mod site;
 pub mod ssrf;
 pub mod stream;
+/// Task-engine schema (experimental). Feature-gated; shared by the `nab` CLI
+/// executor and the `nab-mcp` self-contained loop.
+#[cfg(feature = "task")]
+pub mod task;
 /// Internal implementation modules — not stable public API.
 #[doc(hidden)]
 pub mod util;

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,219 @@
+//! `nab::task` — the task-engine schema (shared contract).
+//!
+//! These are the plain serde types the API-first web-task engine speaks: the
+//! action the loop emits ([`TaskAction`]), the per-step observation
+//! ([`ActionObservation`]), the rung-1 API leads ([`DiscoveredApi`]), the final
+//! [`TaskOutcome`], and the terminal [`TaskStatus`].
+//!
+//! They live in the **library** (not the `nab` binary's `cmd` module) so both
+//! consumers share one contract: the `nab` CLI executor (`cmd::task`) and the
+//! `nab-mcp` self-contained sampling loop (slice 4). The executor and the loop
+//! are built on top of these types; see
+//! `docs/design/2026-05-31-nab-task-engine.md` §12 for the binary-boundary
+//! rationale behind keeping the schema here.
+//!
+//! Feature-gated behind `task` (experimental until the loop is proven).
+
+use serde::{Deserialize, Serialize};
+
+use crate::ApiEndpoint;
+
+fn default_get_method() -> String {
+    "GET".to_string()
+}
+
+/// One action the task loop can take at a given rung (§4 of the design).
+///
+/// The schema is stable for the host LLM (or the slice-4 sampling loop) that
+/// produces these. Variants beyond what the current executor runs are part of
+/// the forward API — `submit` (rung 2) and `extract` land with the loop slice.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum TaskAction {
+    /// Rung 1: call a discovered JSON API directly.
+    ApiCall {
+        url: String,
+        #[serde(default = "default_get_method")]
+        method: String,
+        #[serde(default)]
+        headers: Vec<(String, String)>,
+        #[serde(default)]
+        body: Option<String>,
+        #[serde(default)]
+        extract_query: Option<String>,
+    },
+    /// Rung 1: evaluate page JS via `QuickJS` + the authenticated fetch bridge.
+    JsEval { url: String, script: String },
+    /// Rung 2: submit a (CSRF-aware) form.
+    Submit {
+        url: String,
+        fields: Vec<(String, String)>,
+    },
+    /// Shape the current response to a query via the content pipeline.
+    Extract { extract_query: String },
+    /// Rung 3: escalate to the opt-in external-CDP browser.
+    NeedsBrowser { reason: String },
+    /// Terminal: the goal is complete.
+    Done {
+        #[serde(default)]
+        summary: Option<String>,
+    },
+}
+
+/// Terminal status of a task run. `Incomplete` / `NeedsHuman` are produced by
+/// the bounded loop in later slices.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    Done,
+    Incomplete,
+    NeedsHuman,
+}
+
+/// A candidate API endpoint discovered on the fetched page — a rung-1 lead the
+/// host LLM can choose to call directly instead of escalating to a browser.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscoveredApi {
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    /// The detector that surfaced this endpoint (for debugging).
+    pub source: String,
+}
+
+impl From<ApiEndpoint> for DiscoveredApi {
+    fn from(e: ApiEndpoint) -> Self {
+        Self {
+            url: e.url,
+            method: e.method,
+            source: e.source,
+        }
+    }
+}
+
+/// The result of a `nab task` run, shaped for an LLM consumer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TaskOutcome {
+    pub goal: String,
+    pub url: String,
+    /// The rung that produced the result (0 = fetch … 3 = browser).
+    pub rung: u8,
+    pub status: TaskStatus,
+    pub content: String,
+    /// Rung-1 API leads discovered on the page (may be empty). The host LLM can
+    /// call these directly rather than escalating to a browser.
+    #[serde(default)]
+    pub discovered_apis: Vec<DiscoveredApi>,
+}
+
+/// The result of executing ONE [`TaskAction`] — the OBSERVE half of the loop
+/// (§4 step 4). Returned by the executor so the host LLM (or the slice-4
+/// sampling loop) can inspect the outcome and decide the next step.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActionObservation {
+    /// The rung that executed the action (1 = API/JS, 2 = submit, 3 = browser).
+    pub rung: u8,
+    pub status: TaskStatus,
+    /// YARA-screened, token-budgeted content the action produced (empty on error
+    /// or when the action is not executable in the current slice).
+    pub content: String,
+    /// Set when the action failed or is deferred to a later slice.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn task_action_roundtrips_through_json() {
+        let actions = vec![
+            TaskAction::ApiCall {
+                url: "https://x/api".into(),
+                method: "POST".into(),
+                headers: vec![("A".into(), "B".into())],
+                body: Some("{}".into()),
+                extract_query: Some("q".into()),
+            },
+            TaskAction::JsEval {
+                url: "https://x".into(),
+                script: "1".into(),
+            },
+            TaskAction::Submit {
+                url: "https://x".into(),
+                fields: vec![("f".into(), "v".into())],
+            },
+            TaskAction::Extract {
+                extract_query: "title".into(),
+            },
+            TaskAction::NeedsBrowser {
+                reason: "captcha".into(),
+            },
+            TaskAction::Done {
+                summary: Some("ok".into()),
+            },
+        ];
+        for a in actions {
+            let s = serde_json::to_string(&a).unwrap();
+            let back: TaskAction = serde_json::from_str(&s).unwrap();
+            assert_eq!(a, back);
+        }
+    }
+
+    #[test]
+    fn api_call_defaults_method_to_get() {
+        let a: TaskAction =
+            serde_json::from_str(r#"{"kind":"api_call","url":"https://x"}"#).unwrap();
+        match a {
+            TaskAction::ApiCall { method, .. } => assert_eq!(method, "GET"),
+            other => panic!("expected api_call, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn outcome_serializes_rung_and_status() {
+        let o = TaskOutcome {
+            goal: "g".into(),
+            url: "u".into(),
+            rung: 0,
+            status: TaskStatus::Done,
+            content: "c".into(),
+            discovered_apis: vec![],
+        };
+        let s = serde_json::to_string(&o).unwrap();
+        assert!(s.contains("\"rung\":0"));
+        assert!(s.contains("\"status\":\"done\""));
+    }
+
+    #[test]
+    fn discovered_api_maps_from_endpoint_and_roundtrips() {
+        let ep = ApiEndpoint {
+            url: "/api/x".into(),
+            method: Some("POST".into()),
+            source: "script-fetch".into(),
+        };
+        let d: DiscoveredApi = ep.into();
+        assert_eq!(d.url, "/api/x");
+        let s = serde_json::to_string(&d).unwrap();
+        let back: DiscoveredApi = serde_json::from_str(&s).unwrap();
+        assert_eq!(d, back);
+    }
+
+    #[test]
+    fn action_observation_serializes_and_omits_absent_error() {
+        let obs = ActionObservation {
+            rung: 1,
+            status: TaskStatus::Done,
+            content: "ok".into(),
+            error: None,
+        };
+        let s = serde_json::to_string(&obs).unwrap();
+        assert!(s.contains("\"rung\":1"));
+        assert!(s.contains("\"status\":\"done\""));
+        // error is None -> skipped, not serialized as null.
+        assert!(!s.contains("error"));
+        let back: ActionObservation = serde_json::from_str(&s).unwrap();
+        assert_eq!(obs, back);
+    }
+}


### PR DESCRIPTION
**Slice-4 step 1** — the binary-boundary prerequisite (design §12.2). Promotes the task-engine schema to a `nab::task` **library** module so the slice-4 self-contained loop can share it.

## What
Move `TaskAction`, `TaskStatus`, `DiscoveredApi` (+`From<ApiEndpoint>`), `TaskOutcome`, `ActionObservation` from the binary-only `src/cmd/task.rs` to a new `src/task.rs` (`nab::task`), behind the `task` feature.

## Why
The slice-4 self-contained sampling loop lives in `nab-mcp` (only it can request a client sampling step) and **cannot reach `cmd::task` across the binary boundary**. A library schema lets both consumers — the `nab` CLI executor (`cmd::task`) and the `nab-mcp` loop — share one contract instead of duplicating it. `cmd::task` now imports from `nab::task` and keeps the executor (`execute_action` / `discover_apis` / `fetch_config_for_api_call` / `cmd_task`).

## Details
- As `pub` library API the types are no longer dead-code → the `#[allow(dead_code)]` allows are dropped.
- The 5 pure schema tests move to the lib module; the 5 executor tests stay in `cmd`.
- **CI fix:** the `task-feature` job moves from `--bin nab cmd::task` to `--lib --bin nab task` so it runs BOTH targets — the old command would have silently stopped running the moved schema tests.
- `cmd_fetch` untouched. Feature stays out of `default`.

## DoD evidence (verified locally under CI's gate)
- `cargo fmt --all --check` → clean
- `RUSTFLAGS="-Dwarnings" cargo build --locked --bin nab` (default) → clean — `nab::task` gates out of the default binary, zero dead-code leak
- `cargo clippy --locked --features task --bin nab -- -D warnings` → clean
- `cargo test --locked --features task --lib --bin nab task` → **lib 5 + bin 5 passed**

No behaviour change — pure relocation + the CI command fix. This unblocks slice-4 steps 2-5 (lib executor, bounded loop, MCP `task` tool, route.1/bench.1).
