### PR TITLE
feat(task): inject TaskFetcher — move rung routing to nab::task executor (MIK-5359)

### DIFF
--- a/src/cmd/task.rs
+++ b/src/cmd/task.rs
@@ -5,22 +5,62 @@
 //!   fingerprint, HTTP/3), YARA-screen it, return shaped markdown.
 //! * Slice 2 (rung-1 discovery): surface API endpoints found on the page as
 //!   [`DiscoveredApi`] leads the host LLM can call directly.
-//! * Slice 3 (rung-1 execution): execute one caller-chosen [`TaskAction`] —
-//!   currently `api_call` — via [`execute_action`], returning an
-//!   [`ActionObservation`]. This is the §9.2 host-driven control flow.
+//! * Slice 3 (rung-1 execution): execute one caller-chosen [`TaskAction`].
 //!
-//! The schema types ([`TaskAction`], [`TaskOutcome`], [`ActionObservation`], …)
-//! live in the `nab::task` LIBRARY module so the `nab-mcp` self-contained loop
-//! (slice 4) can share them across the binary boundary; this module is the
-//! `nab` CLI executor over that schema. See
-//! `docs/design/2026-05-31-nab-task-engine.md` §12.
+//! The schema AND the rung-routing executor ([`nab::task::execute_action`]) live
+//! in the `nab::task` LIBRARY module so the `nab-mcp` self-contained loop (slice
+//! 4) can share them across the binary boundary. This module is the `nab` CLI
+//! adapter: it supplies a [`CmdFetcher`] (the full `cmd_fetch` moat via
+//! [`fetch_screened`]) as the injected [`TaskFetcher`] backend and wires the CLI
+//! surface. See `docs/design/2026-05-31-nab-task-engine.md` §12.
 
 use anyhow::Result;
 
 use super::fetch::{FetchConfig, fetch_screened};
 use crate::OutputFormat;
 use nab::ApiDiscovery;
-use nab::task::{ActionObservation, DiscoveredApi, TaskAction, TaskOutcome, TaskStatus};
+use nab::task::{
+    DiscoveredApi, FetchRequest, TaskAction, TaskFetcher, TaskOutcome, TaskStatus, execute_action,
+};
+
+/// The `nab` CLI's fetch backend: maps a library [`FetchRequest`] onto a
+/// [`FetchConfig`] and runs it through [`fetch_screened`], so a rung-1 `api_call`
+/// gets the full `cmd_fetch` moat (HTTP/3 + fingerprint, browser cookies, the
+/// issue-#117 cookie-profile fallback, the YARA screen, the token budget).
+struct CmdFetcher {
+    format: OutputFormat,
+}
+
+#[async_trait::async_trait(?Send)]
+impl TaskFetcher for CmdFetcher {
+    async fn fetch(&self, req: FetchRequest) -> Result<String> {
+        let cfg = fetch_request_to_config(req, self.format);
+        Ok(fetch_screened(&cfg).await?.markdown)
+    }
+}
+
+/// Pure mapping of a library [`FetchRequest`] onto a [`FetchConfig`] (headers →
+/// `Name: Value`, body → `data`, `raw_html=true` for JSON). Split out so it is
+/// unit-testable without a network round-trip.
+fn fetch_request_to_config(req: FetchRequest, format: OutputFormat) -> FetchConfig {
+    let FetchRequest {
+        url,
+        method,
+        headers,
+        body,
+    } = req;
+    let mut cfg = FetchConfig::for_url(url, format);
+    cfg.method = method;
+    cfg.data = body;
+    cfg.custom_headers = headers
+        .iter()
+        .map(|(name, value)| format!("{name}: {value}"))
+        .collect();
+    // API responses are typically JSON/structured — return the raw screened body
+    // rather than running readability extraction tuned for article HTML.
+    cfg.raw_html = true;
+    cfg
+}
 
 /// Run a web task.
 ///
@@ -30,11 +70,12 @@ use nab::task::{ActionObservation, DiscoveredApi, TaskAction, TaskOutcome, TaskS
 ///   YARA-screen, return shaped markdown plus rung-1 API leads discovered on the
 ///   page. This is the loop's first turn.
 /// * **Execute (`action` set)** — slice 3: execute one caller-chosen
-///   [`TaskAction`] (currently rung-1 `api_call`) via [`execute_action`] and
-///   return its [`ActionObservation`]. This is the §9.2 host-driven control
-///   flow: a no-sampling client reads the discovered APIs, then drives nab
-///   one step per call. The slice-4 sampling loop calls `execute_action`
-///   internally instead of round-tripping through the CLI.
+///   [`TaskAction`] (currently rung-1 `api_call`) via the library executor
+///   [`nab::task::execute_action`], with [`CmdFetcher`] as the injected backend,
+///   and return its `ActionObservation`. This is the §9.2 host-driven control
+///   flow: a no-sampling client reads the discovered APIs, then drives nab one
+///   step per call. The slice-4 sampling loop calls `execute_action` internally
+///   with its own fetcher instead of round-tripping through the CLI.
 ///
 /// When `as_json` is set the full structured result is emitted as pretty JSON;
 /// otherwise just the content is printed.
@@ -48,7 +89,7 @@ pub async fn cmd_task(
     if let Some(raw) = action_json {
         let action: TaskAction =
             serde_json::from_str(raw).map_err(|e| anyhow::anyhow!("invalid --action JSON: {e}"))?;
-        let obs = execute_action(&action, format).await?;
+        let obs = execute_action(&action, &CmdFetcher { format }).await?;
         if as_json {
             println!("{}", serde_json::to_string_pretty(&obs)?);
         } else {
@@ -107,102 +148,6 @@ fn discover_apis(raw_html: &str) -> Vec<DiscoveredApi> {
     }
 }
 
-/// Build a [`FetchConfig`] for a rung-1 `api_call`, reusing the moat
-/// (`build_client` HTTP/3 + fingerprint, browser cookies, the YARA screen) via
-/// [`FetchConfig::for_url`]. The action's method, headers, and body are mapped
-/// onto the config so [`fetch_screened`] routes through `execute_manual_request`
-/// (cookies + custom headers + body), not the simple-GET fast path.
-///
-/// Returns `None` for non-`api_call` variants — they execute elsewhere or in a
-/// later slice. Kept separate from [`execute_action`] so the pure mapping is
-/// unit-testable without a network round-trip.
-fn fetch_config_for_api_call(action: &TaskAction, format: OutputFormat) -> Option<FetchConfig> {
-    let TaskAction::ApiCall {
-        url,
-        method,
-        headers,
-        body,
-        ..
-    } = action
-    else {
-        return None;
-    };
-    let mut cfg = FetchConfig::for_url(url.clone(), format);
-    cfg.method.clone_from(method);
-    cfg.data.clone_from(body);
-    cfg.custom_headers = headers
-        .iter()
-        .map(|(name, value)| format!("{name}: {value}"))
-        .collect();
-    // API responses are typically JSON/structured — return the raw screened body
-    // rather than running readability extraction tuned for article HTML.
-    cfg.raw_html = true;
-    Some(cfg)
-}
-
-/// Execute ONE [`TaskAction`] at its rung and return the [`ActionObservation`]
-/// (the ROUTE+ACT+OBSERVE of §4, steps 3-4). This is the shared executor both
-/// control modes call: the host-driven CLI turn (`nab task … --action`) and the
-/// slice-4 self-contained sampling loop.
-///
-/// Slice 3 executes rung-1 `api_call`. The remaining variants are forward API:
-/// `submit` (rung 2) and `extract` (needs trajectory state) land with the loop
-/// slice; `needs_browser` (rung 3) is the opt-in CDP backend; `done` is terminal
-/// (owned by the loop, not the executor). Deferred variants return an honest
-/// `Incomplete` observation with a reason rather than panicking, so a driver can
-/// route around them.
-pub async fn execute_action(
-    action: &TaskAction,
-    format: OutputFormat,
-) -> Result<ActionObservation> {
-    match action {
-        TaskAction::ApiCall { .. } => {
-            let cfg = fetch_config_for_api_call(action, format)
-                .expect("ApiCall always maps to a FetchConfig");
-            match fetch_screened(&cfg).await {
-                Ok(fetched) => Ok(ActionObservation {
-                    rung: 1,
-                    status: TaskStatus::Done,
-                    content: fetched.markdown,
-                    error: None,
-                }),
-                Err(e) => Ok(ActionObservation {
-                    rung: 1,
-                    status: TaskStatus::Incomplete,
-                    content: String::new(),
-                    error: Some(e.to_string()),
-                }),
-            }
-        }
-        TaskAction::Done { .. } => Ok(ActionObservation {
-            rung: 0,
-            status: TaskStatus::Done,
-            content: String::new(),
-            error: None,
-        }),
-        TaskAction::Submit { .. } => Ok(deferred(2, "submit (rung 2) lands in a later slice")),
-        TaskAction::JsEval { .. } => Ok(deferred(1, "js_eval lands in a later slice")),
-        TaskAction::Extract { .. } => {
-            Ok(deferred(1, "extract needs trajectory state (loop slice)"))
-        }
-        TaskAction::NeedsBrowser { reason } => Ok(deferred(
-            3,
-            &format!("browser rung is opt-in and lands in a later slice: {reason}"),
-        )),
-    }
-}
-
-/// An observation for an action that is valid schema but not executable in the
-/// current slice — honest `Incomplete` with the reason, never a panic.
-fn deferred(rung: u8, why: &str) -> ActionObservation {
-    ActionObservation {
-        rung,
-        status: TaskStatus::Incomplete,
-        content: String::new(),
-        error: Some(why.to_string()),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -222,8 +167,8 @@ mod tests {
     }
 
     #[test]
-    fn api_call_maps_method_body_and_headers_onto_fetch_config() {
-        let action = TaskAction::ApiCall {
+    fn fetch_request_to_config_maps_method_body_and_headers() {
+        let req = FetchRequest {
             url: "https://api.example.test/v1/items".into(),
             method: "POST".into(),
             headers: vec![
@@ -231,10 +176,8 @@ mod tests {
                 ("Accept".into(), "application/json".into()),
             ],
             body: Some(r#"{"q":"rust"}"#.into()),
-            extract_query: None,
         };
-        let cfg = fetch_config_for_api_call(&action, OutputFormat::Full)
-            .expect("api_call maps to a config");
+        let cfg = fetch_request_to_config(req, OutputFormat::Full);
         assert_eq!(cfg.url, "https://api.example.test/v1/items");
         assert_eq!(cfg.method, "POST");
         assert_eq!(cfg.data.as_deref(), Some(r#"{"q":"rust"}"#));
@@ -249,67 +192,5 @@ mod tests {
         );
         // raw_html so an API/JSON body is returned screened-but-unmangled.
         assert!(cfg.raw_html);
-    }
-
-    #[test]
-    fn fetch_config_for_api_call_is_none_for_non_api_actions() {
-        let not_api = TaskAction::Submit {
-            url: "https://x".into(),
-            fields: vec![],
-        };
-        assert!(fetch_config_for_api_call(&not_api, OutputFormat::Full).is_none());
-    }
-
-    #[tokio::test]
-    async fn execute_action_defers_unsupported_variants_without_panicking() {
-        // submit (rung 2), js_eval, extract, needs_browser (rung 3) are valid
-        // schema but not executable this slice — each returns Incomplete + reason.
-        let cases = vec![
-            (
-                TaskAction::Submit {
-                    url: "https://x".into(),
-                    fields: vec![],
-                },
-                2u8,
-            ),
-            (
-                TaskAction::JsEval {
-                    url: "https://x".into(),
-                    script: "1".into(),
-                },
-                1,
-            ),
-            (
-                TaskAction::Extract {
-                    extract_query: "title".into(),
-                },
-                1,
-            ),
-            (
-                TaskAction::NeedsBrowser {
-                    reason: "captcha".into(),
-                },
-                3,
-            ),
-        ];
-        for (action, want_rung) in cases {
-            let obs = execute_action(&action, OutputFormat::Full).await.unwrap();
-            assert_eq!(obs.rung, want_rung, "rung for {action:?}");
-            assert_eq!(obs.status, TaskStatus::Incomplete);
-            assert!(
-                obs.error.is_some(),
-                "expected a deferral reason for {action:?}"
-            );
-            assert!(obs.content.is_empty());
-        }
-    }
-
-    #[tokio::test]
-    async fn execute_action_done_is_terminal() {
-        let obs = execute_action(&TaskAction::Done { summary: None }, OutputFormat::Full)
-            .await
-            .unwrap();
-        assert_eq!(obs.status, TaskStatus::Done);
-        assert!(obs.error.is_none());
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -122,6 +122,105 @@ pub struct ActionObservation {
     pub error: Option<String>,
 }
 
+/// A single fetch request the executor hands to a [`TaskFetcher`] — a rung-1
+/// `api_call` reduced to wire essentials. The fetcher owns the moat (client,
+/// cookies, fingerprint, YARA screen, budget); the library owns routing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FetchRequest {
+    pub url: String,
+    pub method: String,
+    pub headers: Vec<(String, String)>,
+    pub body: Option<String>,
+}
+
+/// The fetch backend the task executor runs actions through. Each binary injects
+/// its own: the `nab` CLI wraps `cmd::fetch::fetch_screened` (full moat);
+/// `nab-mcp` wraps its `FetchTool` path. The library never references a
+/// binary-only fetch type, so it stays buildable on both sides of the binary
+/// boundary (design §12.2). Injection (not a library-internal fetch) is what
+/// lets the moat scope stay a per-binary concern.
+///
+/// `?Send`: the CLI's `fetch_screened` future holds a `RefCell` across an await
+/// (not `Send`), so the trait must not require `Send` futures. Backends are
+/// awaited inline (the CLI turn, the MCP tool handler), never `spawn`ed across
+/// threads, so this costs nothing.
+#[async_trait::async_trait(?Send)]
+pub trait TaskFetcher {
+    /// Execute the request through the moat and return screened, shaped content.
+    async fn fetch(&self, req: FetchRequest) -> anyhow::Result<String>;
+}
+
+/// Execute ONE [`TaskAction`] at its rung and return the [`ActionObservation`]
+/// (the ROUTE+ACT+OBSERVE of §4, steps 3-4). The shared executor both control
+/// modes call — the host-driven CLI turn and the slice-4 sampling loop — with
+/// the fetch backend injected as a [`TaskFetcher`].
+///
+/// Executes rung-1 `api_call`. `submit` (rung 2) and `extract` (needs trajectory
+/// state) are forward API; `needs_browser` (rung 3) is the opt-in CDP backend;
+/// `done` is terminal. Deferred variants return an honest `Incomplete`
+/// observation rather than panicking, so a driver can route around them.
+pub async fn execute_action<F: TaskFetcher>(
+    action: &TaskAction,
+    fetcher: &F,
+) -> anyhow::Result<ActionObservation> {
+    match action {
+        TaskAction::ApiCall {
+            url,
+            method,
+            headers,
+            body,
+            ..
+        } => {
+            let req = FetchRequest {
+                url: url.clone(),
+                method: method.clone(),
+                headers: headers.clone(),
+                body: body.clone(),
+            };
+            match fetcher.fetch(req).await {
+                Ok(content) => Ok(ActionObservation {
+                    rung: 1,
+                    status: TaskStatus::Done,
+                    content,
+                    error: None,
+                }),
+                Err(e) => Ok(ActionObservation {
+                    rung: 1,
+                    status: TaskStatus::Incomplete,
+                    content: String::new(),
+                    error: Some(e.to_string()),
+                }),
+            }
+        }
+        TaskAction::Done { .. } => Ok(ActionObservation {
+            rung: 0,
+            status: TaskStatus::Done,
+            content: String::new(),
+            error: None,
+        }),
+        TaskAction::Submit { .. } => Ok(deferred(2, "submit (rung 2) lands in a later slice")),
+        TaskAction::JsEval { .. } => Ok(deferred(1, "js_eval lands in a later slice")),
+        TaskAction::Extract { .. } => {
+            Ok(deferred(1, "extract needs trajectory state (loop slice)"))
+        }
+        TaskAction::NeedsBrowser { reason } => Ok(deferred(
+            3,
+            &format!("browser rung is opt-in and lands in a later slice: {reason}"),
+        )),
+    }
+}
+
+/// An observation for an action that is valid schema but not executable in the
+/// current slice — honest `Incomplete` with the reason, never a panic.
+fn deferred(rung: u8, why: &str) -> ActionObservation {
+    ActionObservation {
+        rung,
+        status: TaskStatus::Incomplete,
+        content: String::new(),
+        error: Some(why.to_string()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,5 +314,126 @@ mod tests {
         assert!(!s.contains("error"));
         let back: ActionObservation = serde_json::from_str(&s).unwrap();
         assert_eq!(obs, back);
+    }
+
+    /// A scripted fetcher — no network — for executor routing tests.
+    struct MockFetcher {
+        reply: anyhow::Result<String>,
+        last: std::sync::Mutex<Option<FetchRequest>>,
+    }
+
+    impl MockFetcher {
+        fn ok(body: &str) -> Self {
+            Self {
+                reply: Ok(body.to_string()),
+                last: std::sync::Mutex::new(None),
+            }
+        }
+        fn err(msg: &str) -> Self {
+            Self {
+                reply: Err(anyhow::anyhow!("{msg}")),
+                last: std::sync::Mutex::new(None),
+            }
+        }
+    }
+
+    #[async_trait::async_trait(?Send)]
+    impl TaskFetcher for MockFetcher {
+        async fn fetch(&self, req: FetchRequest) -> anyhow::Result<String> {
+            *self.last.lock().unwrap() = Some(req);
+            match &self.reply {
+                Ok(s) => Ok(s.clone()),
+                Err(e) => Err(anyhow::anyhow!("{e}")),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_action_routes_api_call_through_the_fetcher() {
+        let f = MockFetcher::ok("{\"ok\":true}");
+        let action = TaskAction::ApiCall {
+            url: "https://api/x".into(),
+            method: "POST".into(),
+            headers: vec![("Accept".into(), "application/json".into())],
+            body: Some("{}".into()),
+            extract_query: None,
+        };
+        let obs = execute_action(&action, &f).await.unwrap();
+        assert_eq!(obs.rung, 1);
+        assert_eq!(obs.status, TaskStatus::Done);
+        assert_eq!(obs.content, "{\"ok\":true}");
+        assert!(obs.error.is_none());
+        // The action's wire essentials reached the fetcher unchanged.
+        let req = f.last.lock().unwrap().clone().unwrap();
+        assert_eq!(req.url, "https://api/x");
+        assert_eq!(req.method, "POST");
+        assert_eq!(req.body.as_deref(), Some("{}"));
+        assert_eq!(
+            req.headers,
+            vec![("Accept".to_string(), "application/json".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_action_maps_fetcher_error_to_incomplete() {
+        let f = MockFetcher::err("boom");
+        let action = TaskAction::ApiCall {
+            url: "https://api/x".into(),
+            method: "GET".into(),
+            headers: vec![],
+            body: None,
+            extract_query: None,
+        };
+        let obs = execute_action(&action, &f).await.unwrap();
+        assert_eq!(obs.rung, 1);
+        assert_eq!(obs.status, TaskStatus::Incomplete);
+        assert!(obs.content.is_empty());
+        assert!(obs.error.unwrap().contains("boom"));
+    }
+
+    #[tokio::test]
+    async fn execute_action_defers_unsupported_and_terminates_done() {
+        let f = MockFetcher::ok("unused");
+        let cases = vec![
+            (
+                TaskAction::Submit {
+                    url: "https://x".into(),
+                    fields: vec![],
+                },
+                2u8,
+            ),
+            (
+                TaskAction::JsEval {
+                    url: "https://x".into(),
+                    script: "1".into(),
+                },
+                1,
+            ),
+            (
+                TaskAction::Extract {
+                    extract_query: "t".into(),
+                },
+                1,
+            ),
+            (
+                TaskAction::NeedsBrowser {
+                    reason: "captcha".into(),
+                },
+                3,
+            ),
+        ];
+        for (action, want_rung) in cases {
+            let obs = execute_action(&action, &f).await.unwrap();
+            assert_eq!(obs.rung, want_rung, "rung for {action:?}");
+            assert_eq!(obs.status, TaskStatus::Incomplete);
+            assert!(obs.error.is_some());
+            assert!(obs.content.is_empty());
+        }
+        // Done is terminal.
+        let obs = execute_action(&TaskAction::Done { summary: None }, &f)
+            .await
+            .unwrap();
+        assert_eq!(obs.status, TaskStatus::Done);
+        assert!(obs.error.is_none());
     }
 }


### PR DESCRIPTION
**Slice-4 step 2** (design §12.2) — moves the rung-routing executor into the `nab::task` library with the fetch backend **injected** via a `TaskFetcher` trait. This is the shared executor both control modes call: the host-driven CLI turn now, the slice-4 sampling loop next.

## What
- `nab::task::execute_action<F: TaskFetcher>(action, fetcher)` owns rung routing + observation shaping. `FetchRequest` is the lib's `url/method/headers/body` abstraction — the lib **never** references `cmd::fetch::FetchConfig`, so it stays buildable on both sides of the binary boundary.
- `cmd::task` supplies `CmdFetcher`, wrapping `fetch_screened` (the full `cmd_fetch` moat: HTTP/3 + fingerprint, browser cookies, the #117 cookie-profile fallback, the YARA screen, the token budget). `cmd_task` delegates one line to the lib executor.

## Why inject, not reimplement
Each binary hands over its own fetch backend, so the lib never decides how much moat to rebuild — the open DoR moat-scope question **dissolves**. `nab-mcp` will supply a `FetchTool`-backed `TaskFetcher` in step 4. (That this makes the moat-scope question vanish is the tell injection is correct.)

## `?Send`
`TaskFetcher` is `#[async_trait(?Send)]`: the CLI's `fetch_screened` future holds a `RefCell` across an await (not `Send`). Backends are awaited inline (the CLI turn, the MCP tool handler), never `spawn`ed across threads, so this costs nothing — and it's inherent: the moat's fetch is fundamentally not-`Send`.

## Testability win
The executor is now **fully unit-testable without network** via a mock `TaskFetcher` — 8 lib tests (api_call routing, error→Incomplete, deferred variants, done-terminal, + the schema serde tests). `cmd` keeps the pure `FetchRequest→FetchConfig` mapping test (2). Slice 3's executor needed network gating; this doesn't.

## DoD evidence (verified locally under CI's gate)
- `cargo fmt --all --check` → clean
- `RUSTFLAGS="-Dwarnings" cargo build --locked --bin nab` (default) → clean — `nab::task` gates out, zero dead-code leak
- `cargo clippy --locked --features task --bin nab -- -D warnings` → clean
- `cargo test --locked --features task --lib --bin nab task` → **lib 8 + bin 2 passed**

`cmd_fetch` untouched. Feature stays out of `default`. Unblocks step 3 (the bounded `run_task_loop`).
