### PR TITLE
feat(task): expose nab task as an MCP tool (slice-4 step 4) (MIK-5359)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,8 @@ jobs:
             command: cargo build --locked --bin nab --no-default-features --features cli,http3
           - name: mcp-binary
             command: cargo build --locked --bin nab-mcp --no-default-features
+          - name: mcp-task
+            command: cargo build --locked --bin nab-mcp --features task
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/src/bin/mcp_server/main.rs
+++ b/src/bin/mcp_server/main.rs
@@ -59,13 +59,18 @@ use rust_mcp_sdk::{McpServer, StdioTransport, TransportOptions, tool_box};
 use nab::watch::WatchManager;
 
 use structured::server_icons;
+#[cfg(feature = "task")]
+use tools::TaskTool;
 use tools::{
     AnalyzeTool, AuthLookupTool, BenchmarkTool, FetchBatchTool, FetchTool, FingerprintTool,
     LoginTool, SubmitTool, ValidateTool, WatchCreateTool, WatchListTool, WatchRemoveTool,
     get_client, init_watch_manager,
 };
 
-// Generate the tools enum
+// Generate the tools enum. `tool_box!` does not accept `#[cfg]` on a list
+// entry, so the optional `task` tool is gated by emitting the whole macro
+// invocation twice (with / without TaskTool), mutually exclusive by feature.
+#[cfg(not(feature = "task"))]
 tool_box!(
     MicroFetchTools,
     [
@@ -81,6 +86,25 @@ tool_box!(
         WatchCreateTool,
         WatchListTool,
         WatchRemoveTool
+    ]
+);
+#[cfg(feature = "task")]
+tool_box!(
+    MicroFetchTools,
+    [
+        FetchTool,
+        FetchBatchTool,
+        SubmitTool,
+        LoginTool,
+        AuthLookupTool,
+        FingerprintTool,
+        ValidateTool,
+        BenchmarkTool,
+        AnalyzeTool,
+        WatchCreateTool,
+        WatchListTool,
+        WatchRemoveTool,
+        TaskTool
     ]
 );
 
@@ -927,6 +951,8 @@ impl ServerHandler for MicroFetchHandler {
             MicroFetchTools::WatchCreateTool(t) => t.run().await,
             MicroFetchTools::WatchListTool(t) => t.run().await,
             MicroFetchTools::WatchRemoveTool(t) => t.run().await,
+            #[cfg(feature = "task")]
+            MicroFetchTools::TaskTool(t) => t.run(&runtime).await,
         }
     }
 

--- a/src/bin/mcp_server/tools/mod.rs
+++ b/src/bin/mcp_server/tools/mod.rs
@@ -27,6 +27,8 @@ pub(crate) mod fetch_batch;
 pub(crate) mod fingerprint;
 pub(crate) mod login;
 pub(crate) mod submit;
+#[cfg(feature = "task")]
+pub(crate) mod task;
 pub(crate) mod validate;
 pub(crate) mod watch;
 
@@ -45,6 +47,8 @@ pub use fetch_batch::FetchBatchTool;
 pub use fingerprint::FingerprintTool;
 pub use login::LoginTool;
 pub use submit::SubmitTool;
+#[cfg(feature = "task")]
+pub use task::TaskTool;
 pub use validate::ValidateTool;
 pub use watch::{
     WatchCreateTool, WatchListTool, WatchRemoveTool, get_watch_manager, init_watch_manager,

--- a/src/bin/mcp_server/tools/task.rs
+++ b/src/bin/mcp_server/tools/task.rs
@@ -1,0 +1,107 @@
+//! `task` MCP tool — API-first web-task entry (the single contact point).
+//!
+//! Slice-4 step 4 (host-driven seed): fetch the seed URL through the moat,
+//! YARA-screen it, surface rung-1 API leads, and return a
+//! [`nab::task::TaskOutcome`] as JSON. The self-contained MCP-sampling loop
+//! (`nab::task::run_task_loop` over an `McpSampler` + `McpFetcher`) lands in a
+//! follow-up; this exposes `nab task` as an MCP tool at rung 0 + rung-1
+//! discovery so a host LLM has the single contact point today.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use nab::AcceleratedClient;
+use nab::content::html::HtmlConversionOptions;
+use nab::task::{TaskOutcome, TaskStatus, discover_apis};
+use rust_mcp_sdk::McpServer;
+use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
+use rust_mcp_sdk::schema::{CallToolResult, TextContent, schema_utils::CallToolError};
+use serde::{Deserialize, Serialize};
+
+use crate::helpers::{convert_body_async_with_options, fetch_with_cookies, resolve_cookie_header};
+use crate::sampling;
+use crate::tools::client::get_client;
+
+#[mcp_tool(
+    name = "task",
+    description = "Run a web task: fetch a seed URL through the moat (browser
+cookies, fingerprint, HTTP/3), YARA-screen it, and return LLM-shaped markdown
+plus the rung-1 API endpoints discovered on the page that you can call directly.
+
+This is nab's single-contact-point web-task entry. Today it returns rung-0 (the
+screened seed) plus rung-1 leads (discovered_apis); to act on a lead, call the
+`fetch` tool with the chosen endpoint. The self-contained agentic loop (nab
+drives the steps itself via MCP sampling) is being wired in a follow-up.
+
+Returns: JSON TaskOutcome { goal, url, rung, status, content, discovered_apis }.",
+    read_only_hint = true,
+    open_world_hint = true
+)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct TaskTool {
+    /// Natural-language goal for the task.
+    pub goal: String,
+    /// Seed URL to start from.
+    pub url: String,
+}
+
+impl TaskTool {
+    /// Run the task tool (rung-0 seed + rung-1 discovery).
+    ///
+    /// `runtime` is used to report whether the connected client supports
+    /// `sampling/createMessage` (the self-contained loop's prerequisite).
+    pub async fn run(&self, runtime: &Arc<dyn McpServer>) -> Result<CallToolResult, CallToolError> {
+        let start = Instant::now();
+        let client: &AcceleratedClient = get_client().await;
+        let profile = client.profile().await;
+        let cookie_header = resolve_cookie_header(&self.url, None);
+        let ssrf_policy = nab::SsrfPolicy::from_env();
+
+        let (_status, content_type, _headers, body_bytes, _elapsed) = fetch_with_cookies(
+            client,
+            &self.url,
+            &cookie_header,
+            &profile,
+            &ssrf_policy,
+            start,
+        )
+        .await?;
+
+        let conversion = convert_body_async_with_options(
+            &body_bytes,
+            &content_type,
+            &self.url,
+            HtmlConversionOptions::default(),
+        )
+        .await?;
+        let markdown =
+            nab::security::guard_fetch_output(&conversion.markdown, "mcp_task", &self.url)
+                .map_err(|e| CallToolError::from_message(e.to_string()))?;
+
+        let raw = String::from_utf8_lossy(&body_bytes);
+        let discovered_apis = discover_apis(&raw);
+
+        let outcome = TaskOutcome {
+            goal: self.goal.clone(),
+            url: self.url.clone(),
+            rung: 0,
+            status: TaskStatus::Done,
+            content: markdown,
+            discovered_apis,
+        };
+        let json = serde_json::to_string_pretty(&outcome)
+            .map_err(|e| CallToolError::from_message(e.to_string()))?;
+
+        let mode = if sampling::is_supported(runtime) {
+            "[task] client supports sampling — self-contained agentic loop is being wired; \
+             for now read discovered_apis and call the `fetch` tool with a chosen endpoint."
+        } else {
+            "[task] host-driven — read discovered_apis and call the `fetch` tool with a \
+             chosen endpoint to continue."
+        };
+
+        Ok(CallToolResult::text_content(vec![TextContent::from(
+            format!("{json}\n\n{mode}"),
+        )]))
+    }
+}

--- a/src/task.rs
+++ b/src/task.rs
@@ -16,11 +16,29 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::ApiEndpoint;
+use crate::{ApiDiscovery, ApiEndpoint};
 use std::fmt::Write as _;
 
 fn default_get_method() -> String {
     "GET".to_string()
+}
+
+/// Discover candidate API endpoints in a raw HTML body. Returns an empty vec
+/// when discovery is unavailable or finds nothing (never fails). Shared by the
+/// `nab` CLI (`cmd::task`) and the `nab-mcp` `task` tool.
+#[must_use]
+pub fn discover_apis(raw_html: &str) -> Vec<DiscoveredApi> {
+    if raw_html.is_empty() {
+        return Vec::new();
+    }
+    match ApiDiscovery::new() {
+        Ok(d) => d
+            .discover_from_html(raw_html)
+            .into_iter()
+            .map(DiscoveredApi::from)
+            .collect(),
+        Err(_) => Vec::new(),
+    }
 }
 
 /// One action the task loop can take at a given rung (§4 of the design).
@@ -527,6 +545,20 @@ mod tests {
         assert!(!s.contains("error"));
         let back: ActionObservation = serde_json::from_str(&s).unwrap();
         assert_eq!(obs, back);
+    }
+
+    #[test]
+    fn discover_apis_finds_endpoints_and_skips_empty() {
+        assert!(discover_apis("").is_empty());
+        let html = r#"<html><body>
+            <script>fetch("/api/v1/users")</script>
+            <a href="/graphql">gql</a>
+        </body></html>"#;
+        let found = discover_apis(html);
+        assert!(
+            found.iter().any(|a| a.url.contains("/api/v1/users")),
+            "expected the /api/v1/users endpoint, got {found:?}"
+        );
     }
 
     /// A scripted fetcher — no network — for executor routing tests.


### PR DESCRIPTION
**Slice-4 step 4** — exposes `nab task` as an MCP tool: the §8 single-contact-point surface. A host LLM calls one `task` tool with `{goal, url}` and gets the rung-0 screened seed + the rung-1 API leads discovered on the page; to act on a lead it calls `fetch` with the chosen endpoint (host-driven). The self-contained sampling loop (`nab::task::run_task_loop` over an `McpSampler` + `McpFetcher`) is the documented follow-up — its pieces (executor + loop) already shipped in #153/#154.

## What
- **`src/bin/mcp_server/tools/task.rs`** — `TaskTool`. The seed fetch reuses `nab-mcp`'s own library-based path (`get_client` + `helpers::fetch_with_cookies` + `convert_body_async_with_options` + `nab::security::guard_fetch_output`), **not** `cmd::fetch` (the other binary). Surfaces `nab::task::discover_apis`; reports whether the client supports sampling (the loop's prerequisite).
- **`discover_apis` → `nab::task` (pub)** so both binaries share it; tested in the lib.

## The macro question, resolved
`tool_box!` **rejects** `#[cfg]` on a list entry (verified empirically: `error: no rules expected #`). Fallback: the macro is emitted **twice** — with / without `TaskTool` — mutually exclusive by the `task` feature. Import + dispatch arm are cfg-gated to match. The default and `--no-default-features` `nab-mcp` builds gate `TaskTool` out cleanly (both verified compiling).

## CI
New `mcp-task` build job (`cargo build --bin nab-mcp --features task`) so `TaskTool` is actually compiled in CI — the existing `mcp-binary` job is `--no-default-features` and gates it out. **Note:** CI clippy runs default-features only, so task code is clippy-checked **locally** via `clippy --features task --all-targets` (run, clean).

## Known follow-up (transparent)
`cmd::task` still has a private `discover_apis` identical to the new `nab::task::discover_apis`. Its removal is deferred — `cmd/task.rs` hit a session-local editor guard (a false positive on a move-refactor) this session. Both compile; no behavior change; trivial 1-commit cleanup once unlocked.

## DoD evidence (verified locally)
- `cargo fmt --all --check` → clean
- `cargo clippy --locked --features task --all-targets -- -D warnings` → clean
- `RUSTFLAGS="-Dwarnings" cargo build --locked --bins` → clean (all binaries; task gates out)
- `cargo build --locked --bin nab-mcp --features task` and `--no-default-features` → both compile
- `cargo test --locked --features task --lib --bin nab task` → **lib 14 + bin 2 passed**

`cmd_fetch` untouched. `task` feature stays out of `default`. Tool-count docs (README/plugin.json/etc., "12 tools") to bump to 13 in a docs-sync follow-up.
