### PR TITLE
feat(task): self-contained sampling loop in the MCP task tool (slice-4 step 4b) (MIK-5359)

### DIFF
--- a/src/bin/mcp_server/tools/task.rs
+++ b/src/bin/mcp_server/tools/task.rs
@@ -10,9 +10,15 @@
 use std::sync::Arc;
 use std::time::Instant;
 
-use nab::AcceleratedClient;
+use bytes::Bytes;
 use nab::content::html::HtmlConversionOptions;
-use nab::task::{TaskOutcome, TaskStatus, discover_apis};
+use nab::task::{
+    FetchRequest, LoopBounds, Sampler, TaskFetcher, TaskOutcome, TaskStatus, discover_apis,
+    run_task_loop,
+};
+use nab::{AcceleratedClient, SafeFetchConfig, SafeRequestOptions, SsrfPolicy};
+use reqwest::Method;
+use reqwest::header::{COOKIE, HeaderName, HeaderValue};
 use rust_mcp_sdk::McpServer;
 use rust_mcp_sdk::macros::{JsonSchema, mcp_tool};
 use rust_mcp_sdk::schema::{CallToolResult, TextContent, schema_utils::CallToolError};
@@ -21,6 +27,67 @@ use serde::{Deserialize, Serialize};
 use crate::helpers::{convert_body_async_with_options, fetch_with_cookies, resolve_cookie_header};
 use crate::sampling;
 use crate::tools::client::get_client;
+
+/// `nab-mcp`'s fetch backend for the self-contained loop: executes a rung-1
+/// `api_call` (method + headers + body) through the moat via the library
+/// `AcceleratedClient`, then YARA-screens + shapes the response. Mirrors the
+/// CLI's `CmdFetcher` but on lib primitives (the binary boundary, design §12.2).
+struct McpFetcher;
+
+impl TaskFetcher for McpFetcher {
+    async fn fetch(&self, req: FetchRequest) -> anyhow::Result<String> {
+        let client: &AcceleratedClient = get_client().await;
+        let profile = client.profile().await;
+        let mut headers = profile.to_headers();
+        let cookie_header = resolve_cookie_header(&req.url, None);
+        if !cookie_header.is_empty() {
+            headers.insert(COOKIE, HeaderValue::from_str(&cookie_header)?);
+        }
+        for (name, value) in &req.headers {
+            headers.insert(
+                HeaderName::from_bytes(name.as_bytes())?,
+                HeaderValue::from_str(value)?,
+            );
+        }
+        let method = Method::from_bytes(req.method.as_bytes())?;
+        let resp = client
+            .request_safe(
+                &req.url,
+                SafeRequestOptions {
+                    method,
+                    headers,
+                    body: req.body.map(Bytes::from),
+                    config: SafeFetchConfig::default(),
+                    ssrf_policy: SsrfPolicy::from_env(),
+                },
+            )
+            .await
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let conversion = convert_body_async_with_options(
+            &resp.body,
+            &resp.content_type,
+            &req.url,
+            HtmlConversionOptions::default(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let screened =
+            nab::security::guard_fetch_output(&conversion.markdown, "mcp_task_api", &req.url)?;
+        Ok(screened)
+    }
+}
+
+/// The loop's brain over MCP sampling: forwards the prompt to the connected
+/// client's LLM via `sampling/createMessage` and returns its reply.
+struct McpSampler<'a> {
+    runtime: &'a Arc<dyn McpServer>,
+}
+
+impl Sampler for McpSampler<'_> {
+    async fn next_action(&self, prompt: &str) -> anyhow::Result<String> {
+        sampling::create_message(self.runtime, prompt, 1024, None).await
+    }
+}
 
 #[mcp_tool(
     name = "task",
@@ -43,6 +110,11 @@ pub struct TaskTool {
     pub goal: String,
     /// Seed URL to start from.
     pub url: String,
+    /// When true AND the client supports sampling, nab runs the bounded
+    /// self-contained loop (sample → execute → observe → repeat) and returns the
+    /// full trajectory. Defaults to false (host-driven: seed + `discovered_apis`).
+    #[serde(default)]
+    pub autonomous: bool,
 }
 
 impl TaskTool {
@@ -80,6 +152,26 @@ impl TaskTool {
 
         let raw = String::from_utf8_lossy(&body_bytes);
         let discovered_apis = discover_apis(&raw);
+
+        // Self-contained mode (§9.1): when the caller opts in and the client
+        // supports sampling, nab drives the whole bounded loop itself — the host
+        // LLM is the brain (McpSampler), nab supplies execution (McpFetcher).
+        if self.autonomous && sampling::is_supported(runtime) {
+            let sampler = McpSampler { runtime };
+            let fetcher = McpFetcher;
+            let loop_outcome = run_task_loop(
+                &self.goal,
+                &markdown,
+                &discovered_apis,
+                &sampler,
+                &fetcher,
+                &LoopBounds::default(),
+            )
+            .await;
+            let json = serde_json::to_string_pretty(&loop_outcome)
+                .map_err(|e| CallToolError::from_message(e.to_string()))?;
+            return Ok(CallToolResult::text_content(vec![TextContent::from(json)]));
+        }
 
         let outcome = TaskOutcome {
             goal: self.goal.clone(),

--- a/src/cmd/task.rs
+++ b/src/cmd/task.rs
@@ -4,23 +4,23 @@
 //! * Slice 1 (rung 0): fetch the seed URL through the moat (browser cookies,
 //!   fingerprint, HTTP/3), YARA-screen it, return shaped markdown.
 //! * Slice 2 (rung-1 discovery): surface API endpoints found on the page as
-//!   [`DiscoveredApi`] leads the host LLM can call directly.
+//!   [`nab::task::DiscoveredApi`] leads the host LLM can call directly.
 //! * Slice 3 (rung-1 execution): execute one caller-chosen [`TaskAction`].
 //!
-//! The schema AND the rung-routing executor ([`nab::task::execute_action`]) live
-//! in the `nab::task` LIBRARY module so the `nab-mcp` self-contained loop (slice
-//! 4) can share them across the binary boundary. This module is the `nab` CLI
-//! adapter: it supplies a [`CmdFetcher`] (the full `cmd_fetch` moat via
-//! [`fetch_screened`]) as the injected [`TaskFetcher`] backend and wires the CLI
-//! surface. See `docs/design/2026-05-31-nab-task-engine.md` §12.
+//! The schema, the rung-routing executor ([`nab::task::execute_action`]), and
+//! [`nab::task::discover_apis`] live in the `nab::task` LIBRARY module so the
+//! `nab-mcp` self-contained loop (slice 4) can share them across the binary
+//! boundary. This module is the `nab` CLI adapter: it supplies a [`CmdFetcher`]
+//! (the full `cmd_fetch` moat via [`fetch_screened`]) as the injected
+//! [`TaskFetcher`] backend and wires the CLI surface. See
+//! `docs/design/2026-05-31-nab-task-engine.md` §12.
 
 use anyhow::Result;
 
 use super::fetch::{FetchConfig, fetch_screened};
 use crate::OutputFormat;
-use nab::ApiDiscovery;
 use nab::task::{
-    DiscoveredApi, FetchRequest, TaskAction, TaskFetcher, TaskOutcome, TaskStatus, execute_action,
+    FetchRequest, TaskAction, TaskFetcher, TaskOutcome, TaskStatus, discover_apis, execute_action,
 };
 
 /// The `nab` CLI's fetch backend: maps a library [`FetchRequest`] onto a
@@ -31,7 +31,6 @@ struct CmdFetcher {
     format: OutputFormat,
 }
 
-#[async_trait::async_trait(?Send)]
 impl TaskFetcher for CmdFetcher {
     async fn fetch(&self, req: FetchRequest) -> Result<String> {
         let cfg = fetch_request_to_config(req, self.format);
@@ -132,39 +131,9 @@ pub async fn cmd_task(
     Ok(())
 }
 
-/// Discover candidate API endpoints in a raw HTML body. Returns an empty vec
-/// when discovery is unavailable or finds nothing (never fails the task).
-fn discover_apis(raw_html: &str) -> Vec<DiscoveredApi> {
-    if raw_html.is_empty() {
-        return Vec::new();
-    }
-    match ApiDiscovery::new() {
-        Ok(d) => d
-            .discover_from_html(raw_html)
-            .into_iter()
-            .map(DiscoveredApi::from)
-            .collect(),
-        Err(_) => Vec::new(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn discover_apis_finds_endpoints_and_skips_empty() {
-        assert!(discover_apis("").is_empty());
-        let html = r#"<html><body>
-            <script>fetch("/api/v1/users")</script>
-            <a href="/graphql">gql</a>
-        </body></html>"#;
-        let found = discover_apis(html);
-        assert!(
-            found.iter().any(|a| a.url.contains("/api/v1/users")),
-            "expected the /api/v1/users endpoint, got {found:?}"
-        );
-    }
 
     #[test]
     fn fetch_request_to_config_maps_method_body_and_headers() {

--- a/src/task.rs
+++ b/src/task.rs
@@ -159,11 +159,13 @@ pub struct FetchRequest {
 /// boundary (design §12.2). Injection (not a library-internal fetch) is what
 /// lets the moat scope stay a per-binary concern.
 ///
-/// `?Send`: the CLI's `fetch_screened` future holds a `RefCell` across an await
-/// (not `Send`), so the trait must not require `Send` futures. Backends are
-/// awaited inline (the CLI turn, the MCP tool handler), never `spawn`ed across
-/// threads, so this costs nothing.
-#[async_trait::async_trait(?Send)]
+/// Native async-fn-in-trait (not `async_trait`): the returned future inherits
+/// the concrete impl's `Send`-ness. The CLI's `fetch_screened` future holds a
+/// `RefCell` (not `Send`) and is awaited inline; the `nab-mcp` backend's future
+/// is `Send`, so `run_task_loop` over it satisfies the MCP framework's `Send`
+/// requirement. `async_trait(?Send)` would box both as non-`Send`, breaking the
+/// MCP path.
+#[allow(async_fn_in_trait)]
 pub trait TaskFetcher {
     /// Execute the request through the moat and return screened, shaped content.
     async fn fetch(&self, req: FetchRequest) -> anyhow::Result<String>;
@@ -264,8 +266,9 @@ impl Default for LoopBounds {
 
 /// The loop's brain: given a prompt (goal + trajectory + discovered APIs), return
 /// the next action as JSON text. `nab-mcp` wraps `sampling/createMessage`; tests
-/// script a fixed sequence. `?Send` for the same reason as [`TaskFetcher`].
-#[async_trait::async_trait(?Send)]
+/// script a fixed sequence. Native async-fn-in-trait for the same `Send`-inheritance
+/// reason as [`TaskFetcher`].
+#[allow(async_fn_in_trait)]
 pub trait Sampler {
     /// Return the next action as a JSON object (optionally fenced in markdown).
     async fn next_action(&self, prompt: &str) -> anyhow::Result<String>;
@@ -582,7 +585,6 @@ mod tests {
         }
     }
 
-    #[async_trait::async_trait(?Send)]
     impl TaskFetcher for MockFetcher {
         async fn fetch(&self, req: FetchRequest) -> anyhow::Result<String> {
             *self.last.lock().unwrap() = Some(req);
@@ -697,7 +699,6 @@ mod tests {
         }
     }
 
-    #[async_trait::async_trait(?Send)]
     impl Sampler for ScriptedSampler {
         async fn next_action(&self, _prompt: &str) -> anyhow::Result<String> {
             let mut i = self.idx.lock().unwrap();


### PR DESCRIPTION
**Slice-4 step 4b** — wires `nab::task::run_task_loop` into the `task` MCP tool so a sampling-capable client gets the **autonomous self-contained loop**: nab drives `sample → execute → observe → repeat` itself — no second tool, no API key. Opt-in via `autonomous: true` (defaults false = host-driven seed).

## The two injected backends (in `nab-mcp`)
- **`McpSampler`** — the brain: wraps `sampling::create_message` (the connected client's LLM) as the loop's `Sampler`.
- **`McpFetcher`** — execution: runs a rung-1 `api_call` (method + headers + body, cookies, SSRF, YARA screen) via the library `AcceleratedClient` (`request_safe`), **not** `cmd::fetch` (the binary boundary, §12.2).

## The Send fix (load-bearing)
The MCP framework requires tool futures to be `Send`, but `#[async_trait(?Send)]` **always boxes futures as non-`Send`** — so `run_task_loop` driven through the traits yielded a non-`Send` future `TaskTool::run` couldn't return (`error: dyn Future … cannot be sent between threads safely`).

Fix: converted `Sampler` + `TaskFetcher` from `async_trait(?Send)` to **native async-fn-in-trait** (Rust 1.95) with `#[allow(async_fn_in_trait)]`. The returned future now **inherits the concrete impl's `Send`-ness**:
- CLI `CmdFetcher` (holds a `RefCell`, non-`Send`, awaited inline) → still fine.
- `McpFetcher`/`McpSampler` (`Send`) → the loop is `Send` → `TaskTool::run` is `Send`. ✓

All impls (`CmdFetcher`, `McpFetcher`, `McpSampler`, the lib test mocks) drop the `async_trait` attribute.

## Also
Removes the `cmd::task::discover_apis` duplicate (it's `nab::task::discover_apis` since #155); the test lives in the lib now. (This was the cleanup deferred from #155 — the editor guard that blocked it is cleared.)

## DoD evidence (verified locally)
- `cargo fmt --all --check` → clean
- `cargo clippy --locked --features task --all-targets -- -D warnings` → clean (incl. pedantic + doc_markdown)
- `cargo check --bin nab-mcp --features task` → compiles (the Send fix) · `--no-default-features` → compiles (task gated out)
- `RUSTFLAGS="-Dwarnings" cargo build --locked --bins` → clean
- `cargo test --locked --features task --lib --bin nab task` → **lib 14 + bin 1 passed**

`cmd_fetch` untouched. `task` feature stays out of `default`. After this, `nab task` is the self-contained agent the design targets (§9.1); what remains is `route.1` + the `bench.1` kill-gate, plus the deferred rungs (submit/extract/browser).
