### PR TITLE
test(task): route.1 gate — loop stays at lowest rung (MIK-5359)

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -744,6 +744,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn route_1_stays_at_lowest_rung_when_api_completes() {
+        // route.1 (design §6): when an API path completes the goal, the router
+        // must stay at the lowest rung — rung 3 (browser) must never fire. Brain
+        // solves via one rung-1 api_call then done.
+        let sampler = ScriptedSampler::new(&[
+            "{\"kind\":\"api_call\",\"url\":\"https://api/x\"}",
+            "{\"kind\":\"done\",\"summary\":\"ok\"}",
+        ]);
+        let fetcher = MockFetcher::ok("data");
+        let out = run_task_loop("g", "seed", &[], &sampler, &fetcher, &LoopBounds::default()).await;
+        assert_eq!(out.stop, LoopStop::Done);
+        // Every executed step stayed at the lowest rung (≤ 1); the browser rung
+        // (3) never fired because an API path existed. This is the route.1 gate:
+        // the rung telemetry on each step is the proof.
+        assert!(
+            out.steps.iter().all(|s| s.observation.rung <= 1),
+            "router escalated above rung 1 when an API path completed: {:?}",
+            out.steps
+        );
+        assert!(
+            !out.steps.iter().any(|s| s.observation.rung == 3),
+            "rung 3 (browser) fired despite an available API path"
+        );
+    }
+
+    #[tokio::test]
     async fn loop_stops_at_max_steps() {
         // Sampler always asks for another api_call; never done.
         let sampler = ScriptedSampler::new(&[


### PR DESCRIPTION
route.1 (design §6): a mock-driven lib test proving `run_task_loop`, when an API path completes the goal (api_call → done), stays at the lowest rung — every executed step has `ActionObservation.rung <= 1` and rung 3 (browser) never fires. The per-step rung telemetry on `LoopOutcome.steps` is the proof surface.

Verified locally: clippy --features task -D warnings clean; `cargo test --features task --lib --bin nab task` => lib 15 + bin 1 passed (incl route_1_stays_at_lowest_rung_when_api_completes). CI task-feature job re-runs it on clean runners.

Small, test-only; src/task.rs +26.