### PR TITLE
feat(task): bench.1 token-axis primitive + kill-gate protocol (MIK-5359)

### DIFF
--- a/docs/design/2026-05-31-nab-task-engine.md
+++ b/docs/design/2026-05-31-nab-task-engine.md
@@ -132,6 +132,54 @@ otherwise nab returns `delegate_to_browser` for the host skill to handle.
   tokens AND latency. **KILL-GATE: if it cannot beat a browser agent on the
   API-backed subset, it is just a worse browser agent — stop.**
 
+### 6.1 bench.1 protocol (how the kill-gate is actually run)
+
+The gate has two axes and two halves of evidence. Do not conflate them.
+
+**Metrics (both required to pass).** Over the 20-task corpus, compute the
+*median* (not mean — resists outlier pages) of:
+1. **Tokens** — total tokens fed to the LLM across the whole task (every step's
+   ingested context + the final answer). nab must have the lower median.
+2. **Latency** — wall-clock from task start to a correct answer. nab must have
+   the lower median.
+
+**Corpus (20 tasks).** Auth-gated and/or API-backed sites — nab's moat. Each
+task is `{ goal, seed_url, success_check }`; the API endpoint nab should discover
+is recorded for analysis but NOT given to either agent (both must discover it).
+Tasks are chosen when the gate is run; bias toward sites with a clean JSON API
+behind a heavy HTML page (the gap is widest there) and toward auth-gated flows a
+fresh browser cannot reach without nab's cookie/1Password/WebAuthn path.
+
+**nab measurement.** `nab task "<goal>" <seed_url>` driven by a host LLM over MCP
+sampling (the self-contained loop). Record the LLM's total prompt+completion
+tokens and wall-clock. No per-site API keys — auth is browser cookies + nab's
+login path.
+
+**Webwright baseline.** Vanilla `microsoft/Webwright` (Playwright backend) driven
+by the SAME LLM model on the SAME tasks. Record the same two numbers. This is a
+live run — it needs a browser, the LLM, and per-site credentials, so it is
+neither deterministic nor CI-runnable.
+
+**Pass/fail.** Pass iff `median(nab_tokens) < median(ww_tokens)` AND
+`median(nab_latency) < median(ww_latency)`. Any other outcome trips the
+kill-gate: stop and reconsider the thesis.
+
+#### Evidence shipped vs. remaining
+
+- **Shipped (deterministic, CI-runnable): the token-axis proxy.**
+  `nab::task::token_gap` / `median_ratio` measure nab's REAL shaping output
+  (readability markdown + API JSON) against a **conservative browser baseline**:
+  the raw page HTML a DOM-dumping agent feeds its LLM. The baseline is favorable
+  to the browser — real agents add accessibility trees, screenshots, and a fresh
+  DOM dump per step, none of which are counted here. Unit-proven that nab's path
+  is strictly cheaper on chrome-heavy pages. This is the moat *mechanism* shown
+  to hold, not the gate.
+- **Remaining (the actual kill-gate): the live head-to-head.** A real
+  20-task corpus, a running Webwright + LLM brain, per-site auth, and the
+  **latency** axis — none of which the token-axis proxy covers. Until that run
+  exists, **bench.1 is NOT cleared** and `nab task` does NOT graduate to the
+  default MCP surface (per §7 phasing).
+
 ## 7. Phasing
 
 1. export.1 (small, standalone-useful, aligned today).

--- a/src/task.rs
+++ b/src/task.rs
@@ -600,6 +600,92 @@ pub async fn run_task_loop<S: Sampler, F: TaskFetcher>(
     finish(LoopStop::MaxSteps, TaskStatus::Incomplete, steps)
 }
 
+// ── bench.1 measurement primitive (the kill-gate's token axis) ───────────────
+
+/// The token cost of one API-backed task, measured two ways: nab's API-first
+/// path vs. a DOM-dumping browser agent's path. The unit underlying the
+/// `bench.1` kill-gate (design §6).
+///
+/// IMPORTANT — what this is and is NOT:
+/// * This is the **token axis** of the gate, measured against a **conservative
+///   browser baseline**: the raw page HTML a DOM-dumping agent feeds its LLM.
+///   Real browser agents (Webwright/Playwright) feed MORE than raw HTML —
+///   accessibility trees and screenshots on top, and a fresh DOM dump per step —
+///   so `browser_tokens` here is a LOWER bound favorable to the browser.
+/// * It is NOT the full `bench.1` pass. The kill-gate also requires beating a
+///   live browser agent on median **latency**, over a 20-task corpus. That
+///   head-to-head needs a running Webwright + an LLM brain + per-site auth and
+///   is neither deterministic nor CI-runnable; it is the documented remaining
+///   step (see `docs/design/2026-05-31-nab-task-engine.md` §6.1). This primitive
+///   provides the deterministic, CI-runnable token-axis evidence that the moat
+///   thesis holds, nothing more.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenGap {
+    /// Tokens nab feeds the host LLM: shaped seed (readability markdown) + the
+    /// discovered API's JSON response.
+    pub nab_tokens: usize,
+    /// Tokens a DOM-dumping browser agent feeds its LLM: the raw page HTML
+    /// (single dump — a conservative lower bound).
+    pub browser_tokens: usize,
+}
+
+impl TokenGap {
+    /// `browser_tokens / nab_tokens` — how many times more tokens the browser
+    /// baseline costs. `> 1.0` means nab is cheaper. Returns `f64::INFINITY` when
+    /// nab somehow costs zero tokens (degenerate empty task).
+    #[must_use]
+    pub fn ratio(&self) -> f64 {
+        if self.nab_tokens == 0 {
+            return f64::INFINITY;
+        }
+        self.browser_tokens as f64 / self.nab_tokens as f64
+    }
+
+    /// Whether nab's path is strictly cheaper than the browser baseline.
+    #[must_use]
+    pub fn nab_wins(&self) -> bool {
+        self.nab_tokens < self.browser_tokens
+    }
+}
+
+/// Measure the [`TokenGap`] for one API-backed task from its recorded inputs: the
+/// raw seed-page HTML and the discovered API's response body.
+///
+/// nab's side runs the REAL shaping pipeline — readability markdown on the seed
+/// (`nab::content::html::html_to_markdown_with_readability`, the `nab fetch`
+/// default for article HTML) plus the API JSON returned as-is — so the
+/// measurement reflects nab's actual moat, not an idealisation. The browser side
+/// is the raw HTML token count (conservative, see [`TokenGap`]).
+#[must_use]
+pub fn token_gap(seed_html: &str, api_response: &str) -> TokenGap {
+    let nab_seed = crate::content::html::html_to_markdown_with_readability(seed_html);
+    let nab_tokens = crate::content::budget::estimate_tokens(&nab_seed)
+        + crate::content::budget::estimate_tokens(api_response);
+    let browser_tokens = crate::content::budget::estimate_tokens(seed_html);
+    TokenGap {
+        nab_tokens,
+        browser_tokens,
+    }
+}
+
+/// The median token-reduction ratio across a corpus of [`TokenGap`]s — the
+/// summary statistic the `bench.1` token axis reports (design §6 uses median, not
+/// mean, to resist outlier pages). Returns `None` for an empty corpus.
+#[must_use]
+pub fn median_ratio(gaps: &[TokenGap]) -> Option<f64> {
+    if gaps.is_empty() {
+        return None;
+    }
+    let mut ratios: Vec<f64> = gaps.iter().map(TokenGap::ratio).collect();
+    ratios.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = ratios.len() / 2;
+    Some(if ratios.len().is_multiple_of(2) {
+        f64::midpoint(ratios[mid - 1], ratios[mid])
+    } else {
+        ratios[mid]
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1180,5 +1266,94 @@ mod tests {
         let fetcher = MockFetcher::ok("x");
         let out = run_task_loop("g", "s", &[], &sampler, &fetcher, &LoopBounds::default()).await;
         assert_eq!(out.stop, LoopStop::SamplerError);
+    }
+
+    // ── bench.1 token-gap primitive ──────────────────────────────────────────
+
+    /// A chrome-heavy page: a small article buried under a large `<script>` blob,
+    /// `<style>`, and nav. Markdown conversion always drops script/style, so the
+    /// shaped output is guaranteed smaller than the raw HTML regardless of
+    /// readability's exact heuristics — a robust fixture for the measurement.
+    fn chrome_heavy_html() -> String {
+        let junk_script = "var x=0;".repeat(400); // ~3.2 KB of non-content
+        let junk_style = "a{color:red}".repeat(100);
+        format!(
+            "<html><head><style>{junk_style}</style>\
+             <script>{junk_script}</script></head><body>\
+             <nav><a href=/>home</a><a href=/about>about</a></nav>\
+             <article><h1>The Answer</h1>\
+             <p>The result you asked for is forty-two.</p></article>\
+             <footer>(c) 2026 example</footer></body></html>"
+        )
+    }
+
+    #[test]
+    fn token_gap_nab_beats_raw_dom_on_chrome_heavy_page() {
+        let html = chrome_heavy_html();
+        let gap = token_gap(&html, r#"{"answer":42}"#);
+        assert!(
+            gap.nab_wins(),
+            "nab ({}) should cost fewer tokens than the raw DOM ({})",
+            gap.nab_tokens,
+            gap.browser_tokens
+        );
+        assert!(gap.ratio() > 1.0, "ratio {} should exceed 1", gap.ratio());
+        assert!(gap.browser_tokens > gap.nab_tokens);
+    }
+
+    #[test]
+    fn token_gap_includes_the_api_response_additively() {
+        let html = chrome_heavy_html();
+        let base = token_gap(&html, "");
+        let with_api = token_gap(&html, "0123456789"); // 10 chars → +3 tokens (ceil)
+        assert_eq!(
+            with_api.nab_tokens,
+            base.nab_tokens + crate::content::budget::estimate_tokens("0123456789"),
+            "api response tokens must add to nab_tokens"
+        );
+        // The browser baseline (raw HTML) is unaffected by the API response.
+        assert_eq!(with_api.browser_tokens, base.browser_tokens);
+    }
+
+    #[test]
+    fn ratio_is_infinite_for_zero_nab_tokens() {
+        let gap = TokenGap {
+            nab_tokens: 0,
+            browser_tokens: 5,
+        };
+        assert!(gap.ratio().is_infinite());
+    }
+
+    #[test]
+    fn median_ratio_handles_empty_odd_and_even() {
+        assert!(median_ratio(&[]).is_none());
+        // Controlled ratios: 2.0, 4.0, 8.0 → median 4.0.
+        let odd = [
+            TokenGap {
+                nab_tokens: 10,
+                browser_tokens: 20,
+            },
+            TokenGap {
+                nab_tokens: 10,
+                browser_tokens: 40,
+            },
+            TokenGap {
+                nab_tokens: 10,
+                browser_tokens: 80,
+            },
+        ];
+        assert!((median_ratio(&odd).unwrap() - 4.0).abs() < f64::EPSILON);
+        // Even count → average of the two middles (2.0, 4.0) = 3.0.
+        let even = [
+            TokenGap {
+                nab_tokens: 10,
+                browser_tokens: 20,
+            },
+            TokenGap {
+                nab_tokens: 10,
+                browser_tokens: 40,
+            },
+        ];
+        assert!((median_ratio(&even).unwrap() - 3.0).abs() < f64::EPSILON);
     }
 }


### PR DESCRIPTION
## What

bench.1 is the **kill-gate** (design §6): on a 20-task API-backed subset, beat vanilla Webwright on median tokens AND latency. The full gate needs a live Webwright + an LLM brain + per-site auth + the latency axis — none deterministic or CI-runnable. This PR ships the honest, deterministic **core** and writes the protocol for the rest. **It does not claim a pass.**

## Library primitive (`nab::task`)

- `token_gap(seed_html, api_response) -> TokenGap` — nab's REAL shaping output (readability markdown via `nab::content::html` + the API JSON) vs a **conservative browser baseline**: the raw page HTML a DOM-dumping agent feeds its LLM. The baseline is favorable to the browser — real agents add accessibility trees, screenshots, and a fresh DOM dump per step, none of which are counted.
- `median_ratio(&[TokenGap]) -> Option<f64>` — the median token-reduction ratio (median, not mean, per the design — resists outlier pages).

Unit-proven: nab is strictly cheaper on a chrome-heavy page (script/style that markdown conversion always strips), the API response adds additively, and the median math is correct for empty/odd/even corpora. 27 task lib tests.

## Protocol (design doc §6.1)

Defines the actual gate so the live run can happen later: both axes (median tokens AND latency), corpus selection (auth-gated / API-backed, 20 tasks, the API endpoint withheld from both agents), nab + Webwright measurement procedures, the pass/fail computation, and an explicit **shipped-vs-remaining** split.

It states plainly:
- **Shipped** — the token-axis proxy is the moat *mechanism* shown to hold.
- **Remaining** — the live head-to-head (latency + real corpus + Webwright run, needs creds + LLM, not CI-runnable). Until it exists, **bench.1 is NOT cleared** and `nab task` does NOT graduate to the default MCP surface (per §7 phasing).

## Why no corpus / no live run here

Live page capture in this environment returns screened stubs/blocks, and a hand-authored corpus I then "beat" would be rigging, not evidence. The honest deliverable is the measurement primitive (proven correct) + the protocol — not a fabricated kill-gate pass. The runnable-corpus harness is a follow-up once real captures + a Webwright baseline exist.

## Scope

- `src/task.rs` (lib primitive + tests) + `docs/design/2026-05-31-nab-task-engine.md` (§6.1).
- No engine behavior change, no MCP tool, no CHANGELOG (matches prior task PRs). Behind the experimental `task` feature.

## Verify

- `cargo fmt --check`
- `cargo clippy --features task --all-targets -- -D warnings`
- `cargo test --locked --features task --lib --bin nab task` — 27 lib + 1 bin pass
- `cargo build --bin nab-mcp --features task` + `RUSTFLAGS=-Dwarnings cargo build --bins` — clean

Generated with Claude Code
