### PR TITLE
chore(deps): document gimli-yanked transitive pin, close cargo-audit #134

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,17 @@
 # cargo-audit configuration (read by `cargo audit` in CI and locally).
 # Tracked in GitHub issue #134.
+#
+# Yanked-crate status (cargo audit prints these as non-failing warnings; the
+# CI `cargo audit` step has no `--deny yanked`, so it stays exit-0 / honest-green):
+#   * gimli 0.32.3 (yanked) — transitive via yara-x 1.16 -> walrus 0.26.1, which
+#     requires `gimli = "^0.32"` and so cannot accept the non-yanked 0.33.1.
+#     yara-x is already latest in its `^1.16` line; clearing this would mean
+#     bumping the security-critical YARA engine past its pin solely for a
+#     non-failing cosmetic warning — out of scope per #134's fail-fast. A second,
+#     non-yanked gimli 0.33.1 already coexists in the tree for the other consumers.
+#   * aes / lru — previously flagged in #134, now RESOLVED (no longer in the tree).
+# cargo-audit ignores RUSTSEC IDs, not yanked-by-crate, so gimli is documented
+# here rather than listed below.
 [advisories]
 ignore = [
     # bincode 2.x is unmaintained (RUSTSEC-2025-0141). Transitive dependency;


### PR DESCRIPTION
## What

Documents the final state of the four cargo-audit advisories tracked in #134 and keeps `cargo audit` honest-green. Closes #134.

`cargo audit` on `main` exits 0. Per-advisory resolution:

| Advisory | Status |
|---|---|
| `lru` RUSTSEC-2026-0002 (unsound) | **Resolved** — `main` moved to `wreq 6.0.0-rc.29` (lru ≥ 0.18, past the 0.16.3 fix); the ignore was already removed. |
| `aes` (yanked) | **Resolved** — no longer in the dependency tree. |
| `bincode` RUSTSEC-2025-0141 (unmaintained) | **Documented audit ignore** — no maintained drop-in; informational advisory. |
| `gimli 0.32.3` (yanked) | **Documented** — transitive via `yara-x 1.16 → walrus 0.26.1` (requires `^0.32`, cannot take the non-yanked 0.33.1). `yara-x` is already latest in its `^1.16` line; a non-yanked `gimli 0.33.1` already coexists for the other consumers. |

## Why document rather than force

`gimli 0.32.3` is pinned by `walrus 0.26.1`, which `yara-x 1.16` depends on. Clearing it would mean bumping the security-critical YARA engine past its pin solely to silence a **non-failing** yanked warning (`cargo audit` has no `--deny yanked`, so CI is already exit-0). That is exactly the "do not chase upstream" path #134's own fail-fast calls out. `cargo-audit` ignores RUSTSEC IDs, not yanked-by-crate, so `gimli` is recorded as an inline-justified comment in `.cargo/audit.toml` — satisfying NAB-AUDIT.1's "listed with justification" branch.

## AC verdicts

- NAB-AUDIT.1 — ✅ `cargo audit` exit-0; remaining warnings carry inline justification (bincode in `ignore`, gimli in the config comment).
- NAB-AUDIT.2 — ✅ `aes` resolved (gone); `gimli` transitive-pinned, documented per fail-fast.
- NAB-AUDIT.3 — ✅ `bincode` retention justified in the ignore comment.
- NAB-AUDIT.4 — ✅ `lru` resolved by the `wreq 6.0.0-rc.29` move; ignore removed.
- NAB-AUDIT.5 — ✅ CI Security Audit stays green; full suite passes.

## Verify

- `cargo audit` → exit 0, "1 allowed warning found" (bincode) + the non-failing gimli yanked notice.
- `.cargo/audit.toml` parses; pre-push suite green.

Generated with Claude Code
