### PR TITLE
feat(task): rung 3 — escalate to an external browser over CDP (MIK-5359)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,8 @@ jobs:
             command: cargo build --locked --bin nab-mcp --no-default-features
           - name: mcp-task
             command: cargo build --locked --bin nab-mcp --features task
+          - name: mcp-task-browser
+            command: cargo build --locked --bin nab-mcp --features task,browser
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/src/bin/mcp_server/tools/task.rs
+++ b/src/bin/mcp_server/tools/task.rs
@@ -12,6 +12,8 @@ use std::time::Instant;
 
 use bytes::Bytes;
 use nab::content::html::HtmlConversionOptions;
+#[cfg(feature = "browser")]
+use nab::task::run_task_loop_with_browser;
 use nab::task::{
     FetchRequest, LoopBounds, Sampler, TaskFetcher, TaskOutcome, TaskStatus, discover_apis,
     run_task_loop,
@@ -106,6 +108,22 @@ impl TaskFetcher for McpFetcher {
     }
 }
 
+/// Rung-3 backend: orchestrates the user's EXTERNAL Chrome over CDP (the opt-in
+/// `browser` feature). Connects to a running Chrome on `NAB_BROWSER_CDP_PORT`
+/// (default 9222) and renders the requested page to screened markdown. nab never
+/// bundles Chromium — this drives a browser the user already runs.
+#[cfg(feature = "browser")]
+struct CdpBrowser {
+    login: nab::BrowserLogin,
+}
+
+#[cfg(feature = "browser")]
+impl nab::task::BrowserBackend for CdpBrowser {
+    async fn render(&self, url: &str) -> anyhow::Result<String> {
+        self.login.render_markdown(url).await
+    }
+}
+
 /// The loop's brain over MCP sampling: forwards the prompt to the connected
 /// client's LLM via `sampling/createMessage` and returns its reply.
 struct McpSampler<'a> {
@@ -116,6 +134,47 @@ impl Sampler for McpSampler<'_> {
     async fn next_action(&self, prompt: &str) -> anyhow::Result<String> {
         sampling::create_message(self.runtime, prompt, 1024, None).await
     }
+}
+
+/// Run the self-contained autonomous loop. With the `browser` feature, connects
+/// to the user's running Chrome (`NAB_BROWSER_CDP_PORT`, default 9222) so the loop
+/// can escalate to rung 3; when no browser is reachable — or the feature is off —
+/// runs the rungs-0-2 loop, which defers `needs_browser` honestly.
+async fn run_autonomous_loop(
+    goal: &str,
+    seed: &str,
+    discovered: &[nab::task::DiscoveredApi],
+    sampler: &McpSampler<'_>,
+    fetcher: &McpFetcher,
+) -> nab::task::LoopOutcome {
+    #[cfg(feature = "browser")]
+    {
+        let port = std::env::var("NAB_BROWSER_CDP_PORT")
+            .ok()
+            .and_then(|p| p.parse::<u16>().ok());
+        if let Ok(login) = nab::BrowserLogin::connect(port).await {
+            let browser = CdpBrowser { login };
+            return run_task_loop_with_browser(
+                goal,
+                seed,
+                discovered,
+                sampler,
+                fetcher,
+                &browser,
+                &LoopBounds::default(),
+            )
+            .await;
+        }
+    }
+    run_task_loop(
+        goal,
+        seed,
+        discovered,
+        sampler,
+        fetcher,
+        &LoopBounds::default(),
+    )
+    .await
 }
 
 #[mcp_tool(
@@ -188,15 +247,13 @@ impl TaskTool {
         if self.autonomous && sampling::is_supported(runtime) {
             let sampler = McpSampler { runtime };
             let fetcher = McpFetcher;
-            let loop_outcome = run_task_loop(
-                &self.goal,
-                &markdown,
-                &discovered_apis,
-                &sampler,
-                &fetcher,
-                &LoopBounds::default(),
-            )
-            .await;
+            // With the `browser` feature, try to connect to the user's running
+            // Chrome so the loop can escalate to rung 3 (`needs_browser`). If no
+            // browser is reachable, fall back to the rungs-0-2 loop (which defers
+            // `needs_browser` honestly). Without the feature, always the latter.
+            let loop_outcome =
+                run_autonomous_loop(&self.goal, &markdown, &discovered_apis, &sampler, &fetcher)
+                    .await;
             let json = serde_json::to_string_pretty(&loop_outcome)
                 .map_err(|e| CallToolError::from_message(e.to_string()))?;
             return Ok(CallToolResult::text_content(vec![TextContent::from(json)]));

--- a/src/browser.rs
+++ b/src/browser.rs
@@ -259,6 +259,36 @@ impl BrowserLogin {
             .collect::<Vec<_>>()
             .join("; ")
     }
+
+    /// Rung 3: render `url` in the connected external browser and return screened,
+    /// LLM-shaped markdown. Opens a page, waits for navigation, gives the DOM a
+    /// brief settle window (SPAs hydrate client-side), extracts the rendered HTML,
+    /// converts it through nab's content pipeline, and runs the fetch-time YARA
+    /// screen. This is the primitive the task engine's [`nab::task::BrowserBackend`]
+    /// wraps so the brain-driven loop can escalate to a browser without nab ever
+    /// bundling Chromium — it orchestrates the user's EXTERNAL Chrome over CDP.
+    pub async fn render_markdown(&self, url: &str) -> Result<String> {
+        let page = self
+            .browser
+            .new_page(url)
+            .await
+            .context("failed to open browser page for rung-3 render")?;
+        page.wait_for_navigation()
+            .await
+            .context("failed to navigate the browser page")?;
+        // SPAs hydrate after load; give the DOM a brief settle window.
+        tokio::time::sleep(Duration::from_millis(800)).await;
+        let html = page
+            .content()
+            .await
+            .context("failed to read rendered DOM from the browser")?;
+        // Best-effort close so the orchestrated browser does not accumulate tabs.
+        let _ = page.close().await;
+        let markdown = crate::content::html::html_to_markdown_with_url(&html, Some(url));
+        let screened = crate::security::guard_fetch_output(&markdown, "task_browser", url)
+            .context("YARA screen rejected the rendered page")?;
+        Ok(screened)
+    }
 }
 
 /// Browser cookie

--- a/src/task.rs
+++ b/src/task.rs
@@ -70,8 +70,13 @@ pub enum TaskAction {
     },
     /// Shape the current response to a query via the content pipeline.
     Extract { extract_query: String },
-    /// Rung 3: escalate to the opt-in external-CDP browser.
-    NeedsBrowser { reason: String },
+    /// Rung 3: escalate to the opt-in external-CDP browser. `url` is the page the
+    /// browser should render (falls back to the seed page when omitted).
+    NeedsBrowser {
+        reason: String,
+        #[serde(default)]
+        url: Option<String>,
+    },
     /// Terminal: the goal is complete.
     Done {
         #[serde(default)]
@@ -243,9 +248,12 @@ pub async fn execute_action<F: TaskFetcher>(
             "extract is a loop-level action (shapes trajectory state); \
              not available in stateless single-action mode",
         )),
-        TaskAction::NeedsBrowser { reason } => Ok(deferred(
+        TaskAction::NeedsBrowser { reason, .. } => Ok(deferred(
             3,
-            &format!("browser rung is opt-in and lands in a later slice: {reason}"),
+            &format!(
+                "browser rung is loop-level (needs an injected browser backend); \
+                 not available in stateless single-action mode: {reason}"
+            ),
         )),
     }
 }
@@ -454,6 +462,36 @@ pub trait Sampler {
     async fn next_action(&self, prompt: &str) -> anyhow::Result<String>;
 }
 
+/// Rung 3: the external-browser backend the loop drives when an API/form path
+/// cannot complete the goal (`needs_browser`). nab never bundles Chromium — each
+/// binary injects a backend that orchestrates an EXTERNAL browser over CDP (the
+/// opt-in `browser` feature), applying nab's cookies + fingerprint, and returns
+/// the rendered page already shaped to markdown. The default build injects
+/// [`NoBrowser`], so the rung is an honest deferral rather than a hard dependency.
+///
+/// Native async-fn-in-trait for the same `Send`-inheritance reason as
+/// [`TaskFetcher`]: the concrete backend's future inherits its own `Send`-ness.
+#[allow(async_fn_in_trait)]
+pub trait BrowserBackend {
+    /// Render `url` in the external browser and return screened, shaped markdown.
+    async fn render(&self, url: &str) -> anyhow::Result<String>;
+}
+
+/// The default rung-3 backend: no browser compiled in. Every `render` is an honest
+/// error so [`run_task_loop`] turns `needs_browser` into a `delegate_to_browser`
+/// deferral rather than silently failing. A binary built with the `browser`
+/// feature injects a real CDP backend via [`run_task_loop_with_browser`].
+pub struct NoBrowser;
+
+impl BrowserBackend for NoBrowser {
+    async fn render(&self, _url: &str) -> anyhow::Result<String> {
+        anyhow::bail!(
+            "browser rung unavailable: build with --features browser and inject a \
+             CDP backend (or set NAB_BROWSER_CDP_WS) to enable rung 3"
+        )
+    }
+}
+
 /// One executed step of a task run.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TrajectoryStep {
@@ -570,6 +608,25 @@ pub async fn run_task_loop<S: Sampler, F: TaskFetcher>(
     fetcher: &F,
     bounds: &LoopBounds,
 ) -> LoopOutcome {
+    run_task_loop_with_browser(goal, seed, discovered, sampler, fetcher, &NoBrowser, bounds).await
+}
+
+/// [`run_task_loop`] with an injected rung-3 [`BrowserBackend`]. When the brain
+/// emits `needs_browser` carrying a `url`, the loop drives the external browser
+/// (rung 3) and feeds the rendered markdown back as the observation. With no
+/// `url`, and when the backend is [`NoBrowser`], it records an honest
+/// `delegate_to_browser` deferral. Every other action routes exactly as in
+/// [`run_task_loop`]. Pure logic over the injected backends — fully testable with
+/// a mock browser, no real Chrome.
+pub async fn run_task_loop_with_browser<S: Sampler, F: TaskFetcher, B: BrowserBackend>(
+    goal: &str,
+    seed: &str,
+    discovered: &[DiscoveredApi],
+    sampler: &S,
+    fetcher: &F,
+    browser: &B,
+    bounds: &LoopBounds,
+) -> LoopOutcome {
     let start = std::time::Instant::now();
     let mut steps: Vec<TrajectoryStep> = Vec::new();
     let mut content_chars: usize = 0;
@@ -616,13 +673,17 @@ pub async fn run_task_loop<S: Sampler, F: TaskFetcher>(
         }
         // `extract` is a loop-level action: it shapes the CURRENT response, so it
         // needs trajectory state `execute_action` (stateless) does not have. The
-        // current response is the most recent step's content, or the seed page
+        // current response is the most recent step's content, else the seed page
         // before any step has run. Pure content shaping, no network → rung 0.
         let observation = if let TaskAction::Extract { extract_query } = &action {
             let prior = steps
                 .last()
                 .map_or(seed, |s| s.observation.content.as_str());
             extract_from_content(prior, extract_query)
+        } else if let TaskAction::NeedsBrowser { url, .. } = &action {
+            // Rung 3: drive the external browser for the requested page. Needs a
+            // url (the loop holds seed CONTENT, not the seed URL) plus a backend.
+            browser_step(url.as_deref(), browser).await
         } else {
             execute_action(&action, fetcher)
                 .await
@@ -643,6 +704,25 @@ pub async fn run_task_loop<S: Sampler, F: TaskFetcher>(
         }
     }
     finish(LoopStop::MaxSteps, TaskStatus::Incomplete, steps)
+}
+
+/// Execute one rung-3 `needs_browser` step: render `url` through the injected
+/// [`BrowserBackend`]. Maps a missing url plus any backend error to an honest
+/// `Incomplete` (rung 3) so the brain can `delegate_to_browser` cleanly, never a
+/// panic. The rendered markdown is bounded like an API response.
+async fn browser_step<B: BrowserBackend>(url: Option<&str>, browser: &B) -> ActionObservation {
+    let Some(url) = url.filter(|u| !u.is_empty()) else {
+        return deferred(3, "needs_browser requires a url to render");
+    };
+    match browser.render(url).await {
+        Ok(content) => ActionObservation {
+            rung: 3,
+            status: TaskStatus::Done,
+            content: shape_api_response(&content, None),
+            error: None,
+        },
+        Err(e) => deferred(3, &format!("delegate_to_browser: {e}")),
+    }
 }
 
 // ── bench.1 measurement primitive (the kill-gate's token axis) ───────────────
@@ -758,6 +838,7 @@ mod tests {
             },
             TaskAction::NeedsBrowser {
                 reason: "captcha".into(),
+                url: None,
             },
             TaskAction::Done {
                 summary: Some("ok".into()),
@@ -999,6 +1080,7 @@ mod tests {
             (
                 TaskAction::NeedsBrowser {
                     reason: "captcha".into(),
+                    url: None,
                 },
                 3,
             ),
@@ -1344,6 +1426,125 @@ mod tests {
         let fetcher = MockFetcher::ok("x");
         let out = run_task_loop("g", "s", &[], &sampler, &fetcher, &LoopBounds::default()).await;
         assert_eq!(out.stop, LoopStop::SamplerError);
+    }
+
+    // ── rung 3: browser backend ──────────────────────────────────────────────
+
+    /// A scripted browser backend — no real Chrome — for rung-3 routing tests.
+    struct MockBrowser {
+        reply: anyhow::Result<String>,
+        last: std::sync::Mutex<Option<String>>,
+    }
+    impl MockBrowser {
+        fn ok(body: &str) -> Self {
+            Self {
+                reply: Ok(body.to_string()),
+                last: std::sync::Mutex::new(None),
+            }
+        }
+        fn err(msg: &str) -> Self {
+            Self {
+                reply: Err(anyhow::anyhow!("{msg}")),
+                last: std::sync::Mutex::new(None),
+            }
+        }
+    }
+    impl BrowserBackend for MockBrowser {
+        async fn render(&self, url: &str) -> anyhow::Result<String> {
+            *self.last.lock().unwrap() = Some(url.to_string());
+            match &self.reply {
+                Ok(s) => Ok(s.clone()),
+                Err(e) => Err(anyhow::anyhow!("{e}")),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn no_browser_backend_defers_render() {
+        // The default build's backend always defers honestly.
+        assert!(NoBrowser.render("https://x").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn loop_drives_browser_on_needs_browser_with_url() {
+        // Brain: needs_browser(url) → done. The injected backend renders rung 3.
+        let sampler = ScriptedSampler::new(&[
+            "{\"kind\":\"needs_browser\",\"reason\":\"spa\",\"url\":\"https://app/dash\"}",
+            "{\"kind\":\"done\",\"summary\":\"read the dashboard\"}",
+        ]);
+        let fetcher = MockFetcher::ok("unused");
+        let browser = MockBrowser::ok("# Dashboard\n\nBalance: 42");
+        let out = run_task_loop_with_browser(
+            "g",
+            "seed",
+            &[],
+            &sampler,
+            &fetcher,
+            &browser,
+            &LoopBounds::default(),
+        )
+        .await;
+        assert_eq!(out.stop, LoopStop::Done);
+        let step = &out.steps[0];
+        assert_eq!(step.observation.rung, 3, "browser step is rung 3");
+        assert_eq!(step.observation.status, TaskStatus::Done);
+        assert!(step.observation.content.contains("Balance: 42"));
+        // The backend received the requested url.
+        assert_eq!(
+            browser.last.lock().unwrap().clone(),
+            Some("https://app/dash".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn loop_defers_needs_browser_without_backend() {
+        // Default loop (NoBrowser): needs_browser → honest rung-3 Incomplete.
+        let sampler = ScriptedSampler::new(&[
+            "{\"kind\":\"needs_browser\",\"reason\":\"spa\",\"url\":\"https://app/x\"}",
+            "{\"kind\":\"done\"}",
+        ]);
+        let fetcher = MockFetcher::ok("unused");
+        let out = run_task_loop("g", "seed", &[], &sampler, &fetcher, &LoopBounds::default()).await;
+        assert_eq!(out.stop, LoopStop::Done);
+        let obs = &out.steps[0].observation;
+        assert_eq!(obs.rung, 3);
+        assert_eq!(obs.status, TaskStatus::Incomplete);
+        assert!(
+            obs.error
+                .as_deref()
+                .unwrap()
+                .contains("delegate_to_browser")
+        );
+    }
+
+    #[tokio::test]
+    async fn loop_defers_needs_browser_without_url() {
+        // needs_browser with no url cannot render (the loop holds seed content,
+        // not the seed URL) → honest deferral, even with a working backend.
+        let sampler = ScriptedSampler::new(&[
+            "{\"kind\":\"needs_browser\",\"reason\":\"spa\"}",
+            "{\"kind\":\"done\"}",
+        ]);
+        let fetcher = MockFetcher::ok("unused");
+        let browser = MockBrowser::err("should not be called");
+        let out = run_task_loop_with_browser(
+            "g",
+            "seed",
+            &[],
+            &sampler,
+            &fetcher,
+            &browser,
+            &LoopBounds::default(),
+        )
+        .await;
+        let obs = &out.steps[0].observation;
+        assert_eq!(obs.rung, 3);
+        assert_eq!(obs.status, TaskStatus::Incomplete);
+        assert!(obs.error.as_deref().unwrap().contains("requires a url"));
+        assert!(
+            browser.last.lock().unwrap().is_none(),
+            "backend must not be called"
+        );
     }
 
     // ── bench.1 token-gap primitive ──────────────────────────────────────────

--- a/tests/rung3_browser_live.rs
+++ b/tests/rung3_browser_live.rs
@@ -1,0 +1,35 @@
+//! Rung-3 live smoke test — renders a real page through an EXTERNAL Chrome over
+//! CDP using the task engine's browser primitive (`BrowserLogin::render_markdown`).
+//!
+//! Ignored by default (needs a running Chrome with `--remote-debugging-port`).
+//! Run against your browser:
+//!
+//! ```bash
+//! NAB_BROWSER_CDP_PORT=9222 cargo test --features browser --test rung3_browser_live -- --ignored --nocapture
+//! ```
+#![cfg(feature = "browser")]
+
+#[tokio::test]
+#[ignore = "requires a running Chrome on NAB_BROWSER_CDP_PORT (default 9222)"]
+async fn renders_real_page_through_external_chrome() {
+    let port = std::env::var("NAB_BROWSER_CDP_PORT")
+        .ok()
+        .and_then(|p| p.parse::<u16>().ok());
+
+    let login = nab::BrowserLogin::connect(port)
+        .await
+        .expect("connect to Chrome — start it with --remote-debugging-port=9222");
+
+    // example.com is tiny and stable; the render must return its heading text.
+    let url = "https://example.com/";
+    let markdown = login
+        .render_markdown(url)
+        .await
+        .expect("render_markdown should return screened markdown");
+
+    println!("[rung3] rendered {} chars of markdown", markdown.len());
+    assert!(
+        markdown.contains("Example Domain"),
+        "rendered markdown should contain the page heading, got: {markdown:.200}"
+    );
+}


### PR DESCRIPTION
## What

The last rung of the escalation ladder (design §10). When an API/form path can't complete the goal, the brain-driven loop drives the user's **external** Chrome over CDP and feeds the rendered page back as the observation. nab never bundles Chromium — it orchestrates a browser the user already runs.

## Library (`nab::task`)

- **`BrowserBackend` trait + `NoBrowser` default** — honest deferral when no browser is compiled in. Native async-fn-in-trait for `Send`-inheritance, like `TaskFetcher`.
- **`run_task_loop_with_browser`** — handles `needs_browser` in the loop (it needs the trajectory + a backend, like `extract`). With a `url` + backend → renders at rung 3, shaped + bounded; without → an honest `delegate_to_browser` deferral. `run_task_loop` is now a thin wrapper passing `&NoBrowser`, so **every existing caller and test is unchanged**.
- `NeedsBrowser` gains an optional `url` (the page to render).
- Mock-tested: render success (rung 3), no-backend deferral, no-url deferral, `NoBrowser` always defers. **33 task lib tests.**

## Library (`nab::BrowserLogin`, `feature=browser`)

- **`render_markdown(url)`** — `new_page` → wait → settle → DOM → nab content pipeline → YARA screen. The concrete rung-3 primitive, reusing the existing CDP connect.

## nab-mcp (`feature=browser`)

- **`CdpBrowser`** backend wraps `BrowserLogin`; `run_autonomous_loop` connects to the running Chrome (`NAB_BROWSER_CDP_PORT`, default 9222) and runs the rung-3-capable loop, falling back to rungs-0-2 when no browser is reachable. cfg-gated so the default `nab-mcp` (the `mcp-task` CI job) is unchanged.

## Verified end-to-end

`tests/rung3_browser_live.rs` renders a stable public test page through a **real Chrome on :9222** via `render_markdown` → 174 chars of screened markdown containing the page heading, in **1.12s**. Ignored by default (needs a live browser):

```bash
NAB_BROWSER_CDP_PORT=9222 cargo test --features browser --test rung3_browser_live -- --ignored --nocapture
```

## Scope

- `src/task.rs` (BrowserBackend + loop), `src/browser.rs` (render_markdown), `src/bin/mcp_server/tools/task.rs` (CdpBrowser wiring), `tests/rung3_browser_live.rs`, `.github/workflows/ci.yml` (mcp-task-browser job).
- `cmd_fetch` + `cmd_submit` untouched. Default build excludes browser (chromiumoxide stays opt-in).

## Verify

- `cargo fmt --check`
- `cargo clippy --features task,browser --all-targets -- -D warnings`
- `cargo test --locked --features task --lib --bin nab task` — 33 + 1 pass
- `cargo build --bin nab-mcp --features task` and `--features task,browser`
- `RUSTFLAGS=-Dwarnings cargo build --bins` — default clean

Generated with Claude Code
