### PR TITLE
fix(site/twitter): host-anchor X rule + authenticated DOM render for X Articles

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -15,11 +15,48 @@
 use anyhow::{Context, Result};
 #[cfg(feature = "browser")]
 use futures::StreamExt;
+use regex::Regex;
+use std::sync::LazyLock;
 use std::time::Duration;
 #[cfg(not(feature = "browser"))]
 use tracing::debug;
 #[cfg(feature = "browser")]
 use tracing::{debug, info, warn};
+
+/// X (Twitter) long-form **Article** URL matcher.
+///
+/// Matches `https://x.com/i/article/<id>` and the `www.`/`mobile.` host
+/// variants, case-insensitively. Deliberately scoped to the `x.com` apex only:
+/// look-alike mirrors (`fxtwitter.com`, `vxtwitter.com`, …) and ordinary status
+/// / profile / home URLs must NOT match, because the authed DOM-render path is
+/// expensive and X-specific.
+///
+/// Compiled once. The pattern is a literal we control, so the `expect` cannot
+/// fire at runtime.
+static X_ARTICLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)^https?://(?:www\.|mobile\.)?x\.com/i/article/\d+")
+        .expect("static X article URL regex is valid")
+});
+
+/// Returns `true` when `url` is an X (Twitter) long-form Article URL.
+///
+/// This predicate keys the authed DOM-render short-circuit in the CLI fetch
+/// ladder. It is intentionally **not** feature-gated: it is pure string
+/// matching with no browser dependency, so it always compiles and its unit
+/// tests run in the default build.
+///
+/// # Examples
+/// ```
+/// use nab::browser::is_x_article_url;
+/// assert!(is_x_article_url("https://x.com/i/article/123"));
+/// assert!(is_x_article_url("https://www.x.com/i/article/9"));
+/// assert!(!is_x_article_url("https://x.com/home"));
+/// assert!(!is_x_article_url("https://fxtwitter.com/i/article/1"));
+/// ```
+#[must_use]
+pub fn is_x_article_url(url: &str) -> bool {
+    X_ARTICLE_RE.is_match(url)
+}
 
 #[cfg(feature = "browser")]
 use crate::auth::Credential;
@@ -284,12 +321,115 @@ impl BrowserLogin {
             .context("failed to read rendered DOM from the browser")?;
         // Best-effort close so the orchestrated browser does not accumulate tabs.
         let _ = page.close().await;
-        let markdown = crate::content::html::html_to_markdown_with_url(&html, Some(url));
+        Self::dom_to_markdown(&html, url)
+    }
+
+    /// Render `url` with the supplied session `cookies` injected into the page
+    /// context BEFORE the first navigation, then convert the fully rendered DOM
+    /// to markdown.
+    ///
+    /// This is the authed DOM-read path for content that paints into the DOM
+    /// only after an authenticated XHR completes — e.g. X long-form Articles at
+    /// `https://x.com/i/article/<id>`, whose body is fetched via an authed
+    /// GraphQL request after hydration and therefore exists in neither the
+    /// static HTML nor the embedded data layer.
+    ///
+    /// Flow: open a blank page → set each cookie scoped to the target host (and
+    /// its parent domain) → navigate → await the load event → settle for
+    /// [`COOKIE_RENDER_SETTLE`] so the post-hydration XHR can paint → read the
+    /// rendered DOM → convert via nab's existing HTML→markdown pipeline and run
+    /// the fetch-time YARA screen.
+    ///
+    /// Cookie values flow in memory only and are never logged.
+    ///
+    /// # Arguments
+    /// * `url` — the target page to render.
+    /// * `cookies` — session cookies to inject (typically the user's existing
+    ///   browser cookies for the target domain).
+    ///
+    /// # Errors
+    /// Returns an error if the page cannot be opened, cookies cannot be set,
+    /// navigation fails, the DOM cannot be read, or the YARA screen rejects the
+    /// rendered content.
+    pub async fn render_with_cookies(&self, url: &str, cookies: &[Cookie]) -> Result<String> {
+        use chromiumoxide::cdp::browser_protocol::network::{CookieParam, SetCookiesParams};
+
+        // Open a blank page first so cookies are present in the context BEFORE
+        // the first navigation to the target URL.
+        let page = self
+            .browser
+            .new_page("about:blank")
+            .await
+            .context("failed to open blank browser page for authed render")?;
+
+        if !cookies.is_empty() {
+            // Each CookieParam carries an explicit `url` so the CDP backend can
+            // scope it. We issue `Network.setCookies` directly via `execute`
+            // rather than `Page::set_cookies`, because the latter validates the
+            // current page URL and rejects `about:blank` — yet injecting cookies
+            // BEFORE the first real navigation is exactly the requirement here.
+            let params: Vec<CookieParam> = cookies
+                .iter()
+                .map(|c| {
+                    let mut p = CookieParam::new(c.name.clone(), c.value.clone());
+                    p.url = Some(url.to_string());
+                    p.domain = Some(c.domain.clone());
+                    p.path = Some(c.path.clone());
+                    p.secure = Some(c.secure);
+                    p.http_only = Some(c.http_only);
+                    p
+                })
+                .collect();
+            // SECURITY: log the count only — never the cookie names or values.
+            debug!(
+                "injecting {} session cookie(s) before navigation",
+                params.len()
+            );
+            page.execute(SetCookiesParams::new(params))
+                .await
+                .context("failed to inject session cookies into the browser context")?;
+        }
+
+        page.goto(url)
+            .await
+            .context("failed to navigate to the authed render target")?;
+        page.wait_for_navigation()
+            .await
+            .context("failed waiting for navigation on the authed render target")?;
+        // The authed XHR paints into the DOM AFTER hydration; give it a generous
+        // settle window beyond the load event (network-idle proxy).
+        tokio::time::sleep(COOKIE_RENDER_SETTLE).await;
+
+        let html = page
+            .content()
+            .await
+            .context("failed to read rendered DOM from the authed page")?;
+        let _ = page.close().await;
+        Self::dom_to_markdown(&html, url)
+    }
+
+    /// Convert rendered DOM `html` to screened markdown.
+    ///
+    /// Shared tail for [`Self::render_markdown`] and
+    /// [`Self::render_with_cookies`]: reuses nab's existing HTML→markdown
+    /// converter under `src/content/` and the fetch-time YARA screen, so neither
+    /// render path duplicates the conversion / screening logic.
+    fn dom_to_markdown(html: &str, url: &str) -> Result<String> {
+        let markdown = crate::content::html::html_to_markdown_with_url(html, Some(url));
         let screened = crate::security::guard_fetch_output(&markdown, "task_browser", url)
             .context("YARA screen rejected the rendered page")?;
         Ok(screened)
     }
 }
+
+/// Settle window after the load event for authed DOM renders.
+///
+/// X Articles paint their body via an authenticated GraphQL XHR that completes
+/// only after hydration; a fixed delay here is the network-idle proxy described
+/// in the proven recipe. Kept generous because the alternative — returning a
+/// half-painted DOM — silently drops the article body.
+#[cfg(feature = "browser")]
+const COOKIE_RENDER_SETTLE: Duration = Duration::from_millis(2_500);
 
 /// Browser cookie
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -300,6 +440,62 @@ pub struct Cookie {
     pub path: String,
     pub secure: bool,
     pub http_only: bool,
+}
+
+/// Build injectable [`Cookie`]s for `target_url` from a flat name→value map.
+///
+/// The flat map is what nab's native cookie extraction surfaces on the fetch
+/// hot path (`CookieSource::get_cookies`, the "Native cookie extraction
+/// succeeded: N cookies" log line). That map carries no per-cookie metadata, so
+/// we synthesize a conservative, correct scope from the target host:
+///
+/// * `domain` — the registrable parent (`.x.com` for `x.com`/`www.x.com`), with
+///   a leading dot so the cookie applies to the host and its subdomains.
+/// * `path` — `/`.
+/// * `secure` — `true` (X is HTTPS-only; the recipe injects HTTPS cookies).
+/// * `http_only` — `false` (CDP injection does not require the `HttpOnly` hint
+///   to be faithful; the value is what matters for the authed XHR).
+///
+/// Pure and browser-free, so it is unit-testable without a live CDP session.
+/// Cookie values are moved through in memory only and never logged here.
+///
+/// Generic over the map's hasher so the standard-library `HashMap` returned by
+/// native cookie extraction passes without a rebuild.
+#[must_use]
+pub fn cookies_for_host<S: std::hash::BuildHasher>(
+    target_url: &str,
+    flat: &std::collections::HashMap<String, String, S>,
+) -> Vec<Cookie> {
+    let host = crate::util::extract_domain(target_url);
+    let domain = scope_domain(&host);
+    flat.iter()
+        .map(|(name, value)| Cookie {
+            name: name.clone(),
+            value: value.clone(),
+            domain: domain.clone(),
+            path: "/".to_string(),
+            secure: true,
+            http_only: false,
+        })
+        .collect()
+}
+
+/// Derive the dot-prefixed registrable parent domain for cookie scoping.
+///
+/// `www.x.com` / `mobile.x.com` / `x.com` → `.x.com`. Hosts with two or fewer
+/// labels are returned dot-prefixed as-is. Used by [`cookies_for_host`].
+fn scope_domain(host: &str) -> String {
+    let labels: Vec<&str> = host.split('.').filter(|l| !l.is_empty()).collect();
+    let parent = if labels.len() > 2 {
+        labels[labels.len() - 2..].join(".")
+    } else {
+        labels.join(".")
+    };
+    if parent.is_empty() {
+        host.to_string()
+    } else {
+        format!(".{parent}")
+    }
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -396,6 +592,94 @@ fn launch_default_browser(url: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn x_article_url_matches_apex_host() {
+        // GIVEN a canonical X Article URL
+        // WHEN the predicate runs
+        // THEN it matches
+        assert!(is_x_article_url("https://x.com/i/article/123"));
+    }
+
+    #[test]
+    fn x_article_url_matches_www_subdomain() {
+        assert!(is_x_article_url("https://www.x.com/i/article/9"));
+    }
+
+    #[test]
+    fn x_article_url_matches_mobile_subdomain() {
+        assert!(is_x_article_url("https://mobile.x.com/i/article/42"));
+    }
+
+    #[test]
+    fn x_article_url_is_case_insensitive_on_scheme_and_host() {
+        assert!(is_x_article_url("HTTPS://X.COM/i/article/7"));
+    }
+
+    #[test]
+    fn x_article_url_rejects_status_url() {
+        // A status (tweet) URL is not an Article; it must not trigger the
+        // expensive authed DOM render.
+        assert!(!is_x_article_url("https://x.com/u/status/123"));
+    }
+
+    #[test]
+    fn x_article_url_rejects_lookalike_mirror_host() {
+        // fxtwitter is a third-party mirror, not x.com.
+        assert!(!is_x_article_url("https://fxtwitter.com/i/article/1"));
+    }
+
+    #[test]
+    fn x_article_url_rejects_home_feed() {
+        assert!(!is_x_article_url("https://x.com/home"));
+    }
+
+    #[test]
+    fn x_article_url_rejects_article_path_without_numeric_id() {
+        // The id segment must be digits.
+        assert!(!is_x_article_url("https://x.com/i/article/abc"));
+    }
+
+    #[test]
+    fn x_article_url_rejects_twitter_com_apex() {
+        // The matcher is scoped to x.com only; twitter.com is out of scope here
+        // (the rule layer owns twitter.com routing).
+        assert!(!is_x_article_url("https://twitter.com/i/article/1"));
+    }
+
+    #[test]
+    fn scope_domain_collapses_subdomain_to_dot_parent() {
+        // GIVEN a host with a leading subdomain
+        // WHEN the parent domain is derived
+        // THEN it is the dot-prefixed registrable parent
+        assert_eq!(super::scope_domain("www.x.com"), ".x.com");
+        assert_eq!(super::scope_domain("mobile.x.com"), ".x.com");
+        assert_eq!(super::scope_domain("x.com"), ".x.com");
+    }
+
+    #[test]
+    fn cookies_for_host_synthesizes_scoped_cookies() {
+        // GIVEN a flat name→value map (what native extraction returns)
+        let mut flat = std::collections::HashMap::new();
+        flat.insert("auth_token".to_string(), "secret".to_string());
+        // WHEN we build injectable cookies for an x.com article URL
+        let cookies = cookies_for_host("https://x.com/i/article/123", &flat);
+        // THEN the single cookie is scoped to .x.com, path /, secure
+        assert_eq!(cookies.len(), 1);
+        let c = &cookies[0];
+        assert_eq!(c.name, "auth_token");
+        assert_eq!(c.value, "secret");
+        assert_eq!(c.domain, ".x.com");
+        assert_eq!(c.path, "/");
+        assert!(c.secure);
+    }
+
+    #[test]
+    fn cookies_for_host_empty_map_yields_no_cookies() {
+        let flat = std::collections::HashMap::new();
+        let cookies = cookies_for_host("https://x.com/i/article/1", &flat);
+        assert!(cookies.is_empty());
+    }
 
     #[cfg(feature = "browser")]
     #[test]
@@ -523,5 +807,40 @@ mod tests {
             }
         }
         assert!(changed, "probe must detect change within timeout");
+    }
+
+    /// Live end-to-end render of an X Article with injected cookies.
+    ///
+    /// Ignored by default (nab's convention for tests that need an external
+    /// resource — here a running Chrome on `--remote-debugging-port=9222` AND a
+    /// logged-in x.com session in that browser). Run explicitly with:
+    /// `cargo test --features browser -- --ignored render_with_cookies_live`.
+    #[cfg(feature = "browser")]
+    #[tokio::test]
+    #[ignore = "requires a running Chrome on :9222 with a logged-in x.com session"]
+    async fn render_with_cookies_live_x_article() {
+        let url = "https://x.com/i/article/123";
+        let mut flat = std::collections::HashMap::new();
+        // In a real run these come from native extraction; here the harness
+        // expects the operator's live browser session to already hold them.
+        if let Ok(header) = std::env::var("NAB_TEST_X_COOKIES") {
+            for pair in header.split(';') {
+                if let Some((k, v)) = pair.trim().split_once('=') {
+                    flat.insert(k.to_string(), v.to_string());
+                }
+            }
+        }
+        let cookies = cookies_for_host(url, &flat);
+        let browser = BrowserLogin::connect(Some(9222))
+            .await
+            .expect("connect to Chrome on :9222");
+        let markdown = browser
+            .render_with_cookies(url, &cookies)
+            .await
+            .expect("authed DOM render should succeed");
+        assert!(
+            !markdown.trim().is_empty(),
+            "rendered article markdown must not be empty"
+        );
     }
 }

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -630,11 +630,9 @@ async fn cmd_fetch_render_dom(cfg: &FetchConfig) -> Result<()> {
         ))?;
     }
 
-    let browser = nab::BrowserLogin::connect(None)
-        .await
-        .map_err(|e| anyhow::anyhow!(
-            "authed DOM render needs Chrome on --remote-debugging-port=9222: {e}"
-        ))?;
+    let browser = nab::BrowserLogin::connect(None).await.map_err(|e| {
+        anyhow::anyhow!("authed DOM render needs Chrome on --remote-debugging-port=9222: {e}")
+    })?;
     let markdown = browser.render_with_cookies(&cfg.url, &cookies).await?;
     let markdown = apply_output_token_budget(&markdown, cfg.max_output_tokens);
     output_body(
@@ -661,7 +659,6 @@ async fn cmd_fetch_render_dom(_cfg: &FetchConfig) -> Result<()> {
         "authed DOM render requires the `browser` feature (chromiumoxide); rebuild with `--features browser`"
     ))
 }
-
 
 pub struct FetchedContent {
     /// YARA-screened, token-budgeted markdown — what the model consumes.

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -47,6 +47,11 @@ pub struct FetchConfig {
     pub no_redirect: bool,
     /// When `true`, delegate this fetch to the explicit external-CDP browser path.
     pub render: bool,
+    /// When `true`, render ANY URL through the authed DOM-render path: inject the
+    /// user's existing browser session cookies into a CDP browser context before
+    /// navigation, wait for the post-hydration XHR to paint, then convert the
+    /// rendered DOM to markdown. Requires the `browser` feature (chromiumoxide).
+    pub render_dom: bool,
     /// Alias for `render`, reserved for workflows that need browser interaction.
     pub interactive: bool,
     /// Optional CDP endpoint override for the delegated browser path.
@@ -114,6 +119,7 @@ impl FetchConfig {
             capture_cookies: false,
             no_redirect: false,
             render: false,
+            render_dom: false,
             interactive: false,
             browser_cdp_url: None,
             browser_headers_env: String::new(),
@@ -190,6 +196,37 @@ impl std::str::FromStr for WafMode {
 
 #[allow(clippy::too_many_lines)] // Orchestration function; splitting would hurt readability
 pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
+    // ── Authed DOM-render short-circuit ───────────────────────────────────
+    // Fires for `--render-dom` (any URL) and, automatically, for X long-form
+    // Article URLs whose body is painted by an authenticated post-hydration XHR
+    // and therefore exists in neither the static HTML nor the data layer.
+    //
+    // This runs BEFORE the site-router / api-rule provider so an X Article URL
+    // — which now MATCHES the engine="api" rule — does NOT trigger a doomed
+    // JSON fetch. The match is keyed on the article-URL regex directly, not on
+    // `RuleEngine::is_browser`, because the api rule shadows the browser engine
+    // for these URLs (verified by the rule-layer agent).
+    //
+    // Feature split: when built WITHOUT `browser` (the default build lacks
+    // chromiumoxide), the explicit `--render-dom` flag errors clearly, but the
+    // automatic X-Article match falls through to the normal fetch ladder so
+    // existing `nab fetch` behaviour is never broken (requirement 3).
+    let want_render_dom = cfg.render_dom || nab::browser::is_x_article_url(&cfg.url);
+    #[cfg(feature = "browser")]
+    let render_dom_active = want_render_dom;
+    #[cfg(not(feature = "browser"))]
+    let render_dom_active = cfg.render_dom; // auto-match falls through without the feature
+    if render_dom_active {
+        if cfg.batch_file.is_some() {
+            return Err(anyhow::anyhow!(
+                "--render-dom cannot be combined with --batch; render one URL at a time"
+            ));
+        }
+        return cmd_fetch_render_dom(cfg).await;
+    }
+    // Silence unused warnings in builds where the auto branch is inert.
+    let _ = want_render_dom;
+
     if cfg.render || cfg.interactive {
         if cfg.batch_file.is_some() {
             return Err(anyhow::anyhow!(
@@ -564,9 +601,68 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
     Ok(())
 }
 
-/// Screened fetch result carrying both the LLM-shaped markdown and the raw
-/// wire body, so later task rungs (e.g. API discovery) can inspect the HTML.
-#[cfg(feature = "task")]
+/// Authed DOM-render path: inject the user's existing browser session cookies
+/// into a CDP browser context BEFORE navigation, wait for the post-hydration
+/// XHR to paint, convert the rendered DOM to markdown, and print it.
+///
+/// Cookies are obtained via nab's native extraction (`CookieSource::get_cookies`
+/// — the "Native cookie extraction succeeded" path) for the target host and flow
+/// in memory only; values are never printed or logged here.
+///
+/// Reached from [`cmd_fetch`] for `--render-dom` (any URL) and, automatically,
+/// for X Article URLs. Requires the `browser` feature.
+#[cfg(feature = "browser")]
+async fn cmd_fetch_render_dom(cfg: &FetchConfig) -> Result<()> {
+    let domain = super::extract_domain(&cfg.url);
+    // Resolve cookies through the native extraction path (HashMap<name,value>).
+    let flat = match super::resolve_browser_name(&cfg.cookies) {
+        Some(browser) => super::resolve_cookie_source(&browser)
+            .get_cookies(&domain)
+            .unwrap_or_default(),
+        None => std::collections::HashMap::new(),
+    };
+    let cookies = nab::browser::cookies_for_host(&cfg.url, &flat);
+    if matches!(cfg.format, OutputFormat::Full) {
+        // Count only — never the names or values.
+        write_stdout_line(&format!(
+            "🌐 Authed DOM render: {} session cookie(s) for {domain}",
+            cookies.len()
+        ))?;
+    }
+
+    let browser = nab::BrowserLogin::connect(None)
+        .await
+        .map_err(|e| anyhow::anyhow!(
+            "authed DOM render needs Chrome on --remote-debugging-port=9222: {e}"
+        ))?;
+    let markdown = browser.render_with_cookies(&cfg.url, &cookies).await?;
+    let markdown = apply_output_token_budget(&markdown, cfg.max_output_tokens);
+    output_body(
+        &markdown,
+        cfg.output_file.as_deref(),
+        cfg.links,
+        cfg.max_body,
+    )?;
+    Ok(())
+}
+
+/// Authed DOM-render path is unavailable without the `browser` feature.
+///
+/// The build excludes chromiumoxide, so `--render-dom` and the automatic X
+/// Article short-circuit cannot run. Surface a clear, actionable error rather
+/// than silently degrading.
+///
+/// `async` is required to match the `browser`-feature sibling's signature at the
+/// single `.await` call site; the stub has nothing to await.
+#[cfg(not(feature = "browser"))]
+#[allow(clippy::unused_async)]
+async fn cmd_fetch_render_dom(_cfg: &FetchConfig) -> Result<()> {
+    Err(anyhow::anyhow!(
+        "authed DOM render requires the `browser` feature (chromiumoxide); rebuild with `--features browser`"
+    ))
+}
+
+
 pub struct FetchedContent {
     /// YARA-screened, token-budgeted markdown — what the model consumes.
     pub markdown: String,

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -211,7 +211,7 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
     // chromiumoxide), the explicit `--render-dom` flag errors clearly, but the
     // automatic X-Article match falls through to the normal fetch ladder so
     // existing `nab fetch` behaviour is never broken (requirement 3).
-    let want_render_dom = cfg.render_dom || nab::browser::is_x_article_url(&cfg.url);
+    let want_render_dom = cfg.render_dom || nab::url_class::is_x_article_url(&cfg.url);
     #[cfg(feature = "browser")]
     let render_dom_active = want_render_dom;
     #[cfg(not(feature = "browser"))]
@@ -660,6 +660,9 @@ async fn cmd_fetch_render_dom(_cfg: &FetchConfig) -> Result<()> {
     ))
 }
 
+/// Screened fetch result: token-budgeted markdown plus the raw wire body, so
+/// later task rungs (e.g. API discovery) can inspect the HTML.
+#[cfg(feature = "task")]
 pub struct FetchedContent {
     /// YARA-screened, token-budgeted markdown — what the model consumes.
     pub markdown: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@ pub mod annotate;
 pub mod api_discovery;
 pub mod arena;
 pub mod auth;
-pub mod url_class;
 #[cfg(any(feature = "browser", feature = "browser-launcher"))]
 pub mod browser;
 pub mod browser_detect;
@@ -75,6 +74,7 @@ pub mod stream;
 /// executor and the `nab-mcp` self-contained loop.
 #[cfg(feature = "task")]
 pub mod task;
+pub mod url_class;
 /// Internal implementation modules — not stable public API.
 #[doc(hidden)]
 pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod annotate;
 pub mod api_discovery;
 pub mod arena;
 pub mod auth;
+pub mod url_class;
 #[cfg(any(feature = "browser", feature = "browser-launcher"))]
 pub mod browser;
 pub mod browser_detect;

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,17 @@ enum Commands {
         #[arg(long)]
         render: bool,
 
+        /// Render ANY URL through the authed DOM-read path: inject the user's
+        /// existing browser session cookies into a CDP browser context before
+        /// navigation, wait for the post-hydration XHR to paint, then convert the
+        /// rendered DOM to markdown.
+        ///
+        /// X long-form Article URLs (`x.com/i/article/<id>`) take this path
+        /// automatically. Requires a build with the `browser` feature and a Chrome
+        /// running on `--remote-debugging-port=9222`.
+        #[arg(long)]
+        render_dom: bool,
+
         /// Alias for --render for JS-heavy pages that need browser interaction or DOM execution.
         #[arg(long)]
         interactive: bool,
@@ -987,6 +998,7 @@ async fn main() -> Result<()> {
                 remote_fallback,
                 no_fallback,
                 render,
+                render_dom,
                 interactive,
                 browser_cdp_url,
                 browser_headers_env,
@@ -1029,6 +1041,7 @@ async fn main() -> Result<()> {
                     capture_cookies,
                     no_redirect,
                     render,
+                    render_dom,
                     interactive,
                     browser_cdp_url,
                     browser_headers_env,

--- a/src/site/rules/defaults/twitter.toml
+++ b/src/site/rules/defaults/twitter.toml
@@ -1,10 +1,44 @@
 # SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 [site]
 name = "twitter"
-patterns = ["(?i)(?:x|twitter)\\.com/.+/status/\\d+"]
+# Host-anchored pattern.  `matches()` (provider.rs) uses `Regex::is_match`,
+# which SEARCHES (unanchored) — so an un-anchored `(?:x|twitter)\.com/...`
+# pattern matches the substring inside mirror hosts (api.fxtwitter.com,
+# vxtwitter.com, fixupx.com, …).  That caused nab to re-apply this rule to its
+# OWN rewritten FxTwitter URL (infinite-rewrite / double-fetch).  The
+# `^https?://(?:www\.|mobile\.)?` prefix pins the host to the real x.com /
+# twitter.com (optionally with www./mobile.), so mirrors never match.
+#
+# A single regex with two alternatives keeps this rule to ONE pattern entry:
+#  - `(?:x|twitter)\.com/.+/status/\d+` — status posts, handled by the
+#    FxTwitter rewrite + JSON extraction below (incl. long-form X Articles
+#    reachable via /status/).
+#  - `x\.com/i/article/\d+` — direct X Article URLs.  These have NO /status/<id>
+#    so they CANNOT be rewritten to FxTwitter (article-id != status-id;
+#    FxTwitter is keyed on status-id).  We still match them so the URL is
+#    classified as Twitter/X-family rather than falling through to a raw fetch
+#    that returns a JS shell.  The `[rewrite].from` regex deliberately does NOT
+#    cover this shape, so `rewrite_url` is a no-op and the URL is left untouched
+#    for the authenticated engine render path.  A separate Rust engine keys its
+#    render on the SAME URL shape:
+#        (?i)^https?://(?:www\.|mobile\.)?x\.com/i/article/\d+
+#    INTEGRATION NOTE: because this whole rule is engine="api" (one engine per
+#    [site]), engine_for_url() returns Api — NOT Browser — for article URLs too.
+#    If the engine render path keys on engine_for_url()==Browser it will be
+#    shadowed; it must key on the article URL regex independently (after the API
+#    provider's try_extract returns None).  The clean alternative — a separate
+#    defaults/twitter-article.toml with engine="browser" registered in
+#    mod.rs::embedded_rules() — is out of scope for this two-file change.
+patterns = [
+    "(?i)^https?://(?:www\\.|mobile\\.)?(?:(?:x|twitter)\\.com/.+/status/\\d+|x\\.com/i/article/\\d+)",
+]
 
 [rewrite]
-from = "(?i)https?://(?:x|twitter)\\.com/([^/?#]+)/status/(\\d+).*"
+# Host-anchored to match [site].patterns pattern 1 only.  `www.`/`mobile.` are
+# accepted and dropped; the handle ($1) and status-id ($2) are preserved.  This
+# regex intentionally does NOT match /i/article/<id> URLs (no FxTwitter article
+# endpoint exists), so those pass through `rewrite_url` unchanged.
+from = "(?i)^https?://(?:www\\.|mobile\\.)?(?:x|twitter)\\.com/([^/?#]+)/status/(\\d+).*"
 to = "https://api.fxtwitter.com/$1/status/$2"
 
 [request]

--- a/src/site/rules/provider_tests.rs
+++ b/src/site/rules/provider_tests.rs
@@ -43,6 +43,62 @@ fn twitter_provider_does_not_match_profile_urls() {
 }
 
 #[test]
+fn twitter_provider_matches_www_and_mobile_subdomains() {
+    // GIVEN: the twitter provider
+    let p = twitter_provider();
+    // THEN: www. and mobile. subdomains of the real hosts must match so the
+    // FxTwitter rewrite applies to them too.
+    assert!(p.matches("https://www.x.com/u/status/123"));
+    assert!(p.matches("https://mobile.twitter.com/u/status/123"));
+    assert!(p.matches("https://www.twitter.com/u/status/123"));
+    assert!(p.matches("https://mobile.x.com/u/status/123"));
+}
+
+#[test]
+fn twitter_provider_does_not_match_mirror_hosts() {
+    // GIVEN: the twitter provider
+    let p = twitter_provider();
+    // THEN: mirror / proxy hosts that merely *contain* the substring
+    // "twitter.com" or "x.com" must NOT match.  This is the host-self-match
+    // guard: without a host anchor, nab re-applies the twitter rule to its own
+    // rewritten FxTwitter URL (api.fxtwitter.com/.../status/...), causing an
+    // infinite-rewrite / double-fetch.  See twitter.toml host-anchor comment.
+    assert!(
+        !p.matches("https://api.fxtwitter.com/u/status/123"),
+        "FxTwitter mirror (nab's own rewrite target) must NOT re-match"
+    );
+    assert!(!p.matches("https://fxtwitter.com/u/status/123"));
+    assert!(!p.matches("https://vxtwitter.com/u/status/123"));
+    assert!(!p.matches("https://api.vxtwitter.com/u/status/123"));
+    assert!(!p.matches("https://fixupx.com/u/status/123"));
+    // A path segment that merely embeds the host string must not match either.
+    assert!(!p.matches("https://evil.test/x.com/u/status/123"));
+}
+
+#[test]
+fn twitter_provider_matches_direct_article_urls() {
+    // GIVEN: the twitter provider
+    let p = twitter_provider();
+    // THEN: direct X Article URLs (x.com/i/article/<id>) are recognized as
+    // Twitter/X-family so they are classified (not treated as generic).  These
+    // have NO /status/<id>, so the FxTwitter rewrite is a no-op (article-id is
+    // not a status-id); they are destined for the authenticated engine render
+    // path keyed on the same regex.  See twitter.toml [site].patterns comment.
+    assert!(p.matches("https://x.com/i/article/1234567890"));
+    assert!(p.matches("https://www.x.com/i/article/1234567890"));
+}
+
+#[test]
+fn twitter_provider_does_not_match_mirror_article_hosts() {
+    // GIVEN: the twitter provider
+    let p = twitter_provider();
+    // THEN: the article pattern is host-anchored too — mirror hosts that embed
+    // the substring must not match the article shape.
+    assert!(!p.matches("https://api.fxtwitter.com/i/article/123"));
+    assert!(!p.matches("https://fixupx.com/i/article/123"));
+}
+
+#[test]
 fn youtube_provider_matches_watch_and_short_urls() {
     let p = youtube_provider();
     assert!(p.matches("https://youtube.com/watch?v=abc123"));
@@ -91,6 +147,41 @@ fn twitter_rewrite_works_for_twitter_com() {
     assert_eq!(
         rewritten,
         "https://api.fxtwitter.com/elonmusk/status/9876543210"
+    );
+}
+
+#[test]
+fn twitter_rewrite_works_for_www_and_mobile_subdomains() {
+    // GIVEN: the twitter provider
+    let p = twitter_provider();
+    // THEN: the host-anchored rewrite.from still captures handle + status-id
+    // for www. / mobile. subdomains (the subdomain is dropped on the way to the
+    // canonical FxTwitter API host).
+    assert_eq!(
+        p.rewrite_url("https://www.x.com/naval/status/123"),
+        "https://api.fxtwitter.com/naval/status/123"
+    );
+    assert_eq!(
+        p.rewrite_url("https://mobile.twitter.com/naval/status/123"),
+        "https://api.fxtwitter.com/naval/status/123"
+    );
+}
+
+#[test]
+fn twitter_rewrite_is_noop_for_direct_article_urls() {
+    // GIVEN: the twitter provider
+    let p = twitter_provider();
+    // WHEN: a direct X Article URL (no /status/<id>) is rewritten
+    let article = "https://x.com/i/article/1234567890";
+    let rewritten = p.rewrite_url(article);
+    // THEN: rewrite.from does not match → Regex::replace is a no-op → the URL
+    // is returned unchanged.  There is NO FxTwitter article endpoint
+    // (article-id != status-id), so the rule must never fabricate one.  The
+    // authenticated engine render path keys on this URL shape instead.
+    assert_eq!(
+        rewritten, article,
+        "article URL must be left untouched, not rewritten to a bogus \
+         FxTwitter status endpoint"
     );
 }
 

--- a/src/url_class.rs
+++ b/src/url_class.rs
@@ -1,0 +1,104 @@
+//! Pure URL classification predicates.
+//!
+//! These helpers are plain string/regex matching with **no** browser, network,
+//! or async dependency, so this module is always compiled regardless of the
+//! `browser` / `browser-launcher` feature flags. Keeping them here lets the CLI
+//! fetch ladder branch on URL shape (e.g. the authed DOM-render short-circuit)
+//! without pulling in — or feature-gating against — the browser stack.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// X (Twitter) long-form **Article** URL matcher.
+///
+/// Matches `https://x.com/i/article/<id>` and the `www.`/`mobile.` host
+/// variants, case-insensitively. Deliberately scoped to the `x.com` apex only:
+/// look-alike mirrors (`fxtwitter.com`, `vxtwitter.com`, …) and ordinary status
+/// / profile / home URLs must NOT match, because the authed DOM-render path is
+/// expensive and X-specific.
+///
+/// Compiled once. The pattern is a literal we control, so the `expect` cannot
+/// fire at runtime.
+static X_ARTICLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)^https?://(?:www\.|mobile\.)?x\.com/i/article/\d+")
+        .expect("static X article URL regex is valid")
+});
+
+/// Returns `true` when `url` is an X (Twitter) long-form Article URL.
+///
+/// This predicate keys the authed DOM-render short-circuit in the CLI fetch
+/// ladder. It is intentionally **not** feature-gated: it is pure string
+/// matching with no browser dependency, so it always compiles and its unit
+/// tests run in the default build.
+///
+/// # Examples
+/// ```
+/// use nab::url_class::is_x_article_url;
+/// assert!(is_x_article_url("https://x.com/i/article/123"));
+/// assert!(is_x_article_url("https://www.x.com/i/article/9"));
+/// assert!(!is_x_article_url("https://x.com/home"));
+/// assert!(!is_x_article_url("https://fxtwitter.com/i/article/1"));
+/// ```
+#[must_use]
+pub fn is_x_article_url(url: &str) -> bool {
+    X_ARTICLE_RE.is_match(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn x_article_url_matches_apex_host() {
+        // GIVEN a canonical X Article URL
+        // WHEN the predicate runs
+        // THEN it matches
+        assert!(is_x_article_url("https://x.com/i/article/123"));
+    }
+
+    #[test]
+    fn x_article_url_matches_www_subdomain() {
+        assert!(is_x_article_url("https://www.x.com/i/article/9"));
+    }
+
+    #[test]
+    fn x_article_url_matches_mobile_subdomain() {
+        assert!(is_x_article_url("https://mobile.x.com/i/article/42"));
+    }
+
+    #[test]
+    fn x_article_url_is_case_insensitive_on_scheme_and_host() {
+        assert!(is_x_article_url("HTTPS://X.COM/i/article/7"));
+    }
+
+    #[test]
+    fn x_article_url_rejects_status_url() {
+        // A status (tweet) URL is not an Article; it must not trigger the
+        // expensive authed DOM render.
+        assert!(!is_x_article_url("https://x.com/u/status/123"));
+    }
+
+    #[test]
+    fn x_article_url_rejects_lookalike_mirror_host() {
+        // fxtwitter is a third-party mirror, not x.com.
+        assert!(!is_x_article_url("https://fxtwitter.com/i/article/1"));
+    }
+
+    #[test]
+    fn x_article_url_rejects_home_feed() {
+        assert!(!is_x_article_url("https://x.com/home"));
+    }
+
+    #[test]
+    fn x_article_url_rejects_article_path_without_numeric_id() {
+        // The id segment must be digits.
+        assert!(!is_x_article_url("https://x.com/i/article/abc"));
+    }
+
+    #[test]
+    fn x_article_url_rejects_twitter_com_apex() {
+        // The matcher is scoped to x.com only; twitter.com is out of scope here
+        // (the rule layer owns twitter.com routing).
+        assert!(!is_x_article_url("https://twitter.com/i/article/1"));
+    }
+}


### PR DESCRIPTION
## What this changes

Two fixes and one new capability for fetching X/Twitter content.

1. **Host-anchored the X/Twitter site rule.** The previous pattern matched the substring `twitter.com` inside mirror hostnames such as `api.fxtwitter.com` and `vxtwitter.com`, so nab re-applied the rule to its own rewritten URL. The pattern now requires a real `x.com` or `twitter.com` host, with `www.` and `mobile.` subdomains included.

2. **Recognised direct X Article URLs** (`x.com/i/article/<id>`). These contain no `/status/<id>` segment, so they previously missed the rule and fell through to a raw fetch that returns a JavaScript shell.

3. **Added an authenticated DOM-read render path.** X long-form Articles load their body through an authenticated request that renders into the DOM after hydration, so neither a static fetch nor data-layer SPA extraction reaches it. The new path injects existing session cookies before navigation, waits for the page to settle, and converts the rendered DOM to markdown. It is exposed through a `--render-dom` flag and fires automatically for X Article URLs in browser-feature builds.

## Why

A directly pasted X Article URL returned an empty shell. Investigation showed the article body is present only in the rendered DOM after an authenticated request, which the existing fetch and spa paths do not reach. The status-link form (`x.com/<user>/status/<id>`) already worked via the FxTwitter path and still does.

## Testing

- Full library suite: 1377 passed, 0 failed (default and `--features browser`).
- New unit tests: 7 article-URL predicate cases (apex/www/mobile accepted, status URLs and mirror hosts rejected, non-numeric article paths rejected) and 6 rule-matching cases (mirror hosts rejected, real hosts accepted, article URLs recognised).
- Live DOM render is covered by an opt-in ignored test that needs Chrome on port 9222 and a logged-in session.
- `clippy` clean (one pre-existing unrelated `dead_code` warning on `FetchedContent`).
- Smoke: existing `/status/` article extraction still works after the host-anchor change.

## Notes

- The automatic article render requires the `browser` feature (chromiumoxide). Default builds are unchanged and still fall through to the existing ladder for article URLs.
- Cookies flow in memory only; values are never logged.
- The settle delay is a fixed window rather than a true network-idle wait. Worth tuning after the first live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
