### PR TITLE
chore: drop duplicate X article URL matcher from browser.rs

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -15,48 +15,11 @@
 use anyhow::{Context, Result};
 #[cfg(feature = "browser")]
 use futures::StreamExt;
-use regex::Regex;
-use std::sync::LazyLock;
 use std::time::Duration;
 #[cfg(not(feature = "browser"))]
 use tracing::debug;
 #[cfg(feature = "browser")]
 use tracing::{debug, info, warn};
-
-/// X (Twitter) long-form **Article** URL matcher.
-///
-/// Matches `https://x.com/i/article/<id>` and the `www.`/`mobile.` host
-/// variants, case-insensitively. Deliberately scoped to the `x.com` apex only:
-/// look-alike mirrors (`fxtwitter.com`, `vxtwitter.com`, …) and ordinary status
-/// / profile / home URLs must NOT match, because the authed DOM-render path is
-/// expensive and X-specific.
-///
-/// Compiled once. The pattern is a literal we control, so the `expect` cannot
-/// fire at runtime.
-static X_ARTICLE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)^https?://(?:www\.|mobile\.)?x\.com/i/article/\d+")
-        .expect("static X article URL regex is valid")
-});
-
-/// Returns `true` when `url` is an X (Twitter) long-form Article URL.
-///
-/// This predicate keys the authed DOM-render short-circuit in the CLI fetch
-/// ladder. It is intentionally **not** feature-gated: it is pure string
-/// matching with no browser dependency, so it always compiles and its unit
-/// tests run in the default build.
-///
-/// # Examples
-/// ```
-/// use nab::browser::is_x_article_url;
-/// assert!(is_x_article_url("https://x.com/i/article/123"));
-/// assert!(is_x_article_url("https://www.x.com/i/article/9"));
-/// assert!(!is_x_article_url("https://x.com/home"));
-/// assert!(!is_x_article_url("https://fxtwitter.com/i/article/1"));
-/// ```
-#[must_use]
-pub fn is_x_article_url(url: &str) -> bool {
-    X_ARTICLE_RE.is_match(url)
-}
 
 #[cfg(feature = "browser")]
 use crate::auth::Credential;
@@ -592,60 +555,6 @@ fn launch_default_browser(url: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn x_article_url_matches_apex_host() {
-        // GIVEN a canonical X Article URL
-        // WHEN the predicate runs
-        // THEN it matches
-        assert!(is_x_article_url("https://x.com/i/article/123"));
-    }
-
-    #[test]
-    fn x_article_url_matches_www_subdomain() {
-        assert!(is_x_article_url("https://www.x.com/i/article/9"));
-    }
-
-    #[test]
-    fn x_article_url_matches_mobile_subdomain() {
-        assert!(is_x_article_url("https://mobile.x.com/i/article/42"));
-    }
-
-    #[test]
-    fn x_article_url_is_case_insensitive_on_scheme_and_host() {
-        assert!(is_x_article_url("HTTPS://X.COM/i/article/7"));
-    }
-
-    #[test]
-    fn x_article_url_rejects_status_url() {
-        // A status (tweet) URL is not an Article; it must not trigger the
-        // expensive authed DOM render.
-        assert!(!is_x_article_url("https://x.com/u/status/123"));
-    }
-
-    #[test]
-    fn x_article_url_rejects_lookalike_mirror_host() {
-        // fxtwitter is a third-party mirror, not x.com.
-        assert!(!is_x_article_url("https://fxtwitter.com/i/article/1"));
-    }
-
-    #[test]
-    fn x_article_url_rejects_home_feed() {
-        assert!(!is_x_article_url("https://x.com/home"));
-    }
-
-    #[test]
-    fn x_article_url_rejects_article_path_without_numeric_id() {
-        // The id segment must be digits.
-        assert!(!is_x_article_url("https://x.com/i/article/abc"));
-    }
-
-    #[test]
-    fn x_article_url_rejects_twitter_com_apex() {
-        // The matcher is scoped to x.com only; twitter.com is out of scope here
-        // (the rule layer owns twitter.com routing).
-        assert!(!is_x_article_url("https://twitter.com/i/article/1"));
-    }
 
     #[test]
     fn scope_domain_collapses_subdomain_to_dot_parent() {


### PR DESCRIPTION
## What

Removes the duplicate X (Twitter) article URL matcher from browser.rs. The
canonical implementation lives in url_class.rs and is the one consumed by the
fetch command. The browser.rs copy (is_x_article_url, the X_ARTICLE_RE static,
its LazyLock plus Regex imports, and 9 tests) was dead duplication with zero
callers.

## Why

Single source of truth for X article URL classification. The browser.rs copy
only added maintenance risk.

## Validation

cargo fmt, clippy, and test all green (1374 passed, 0 failed). Pre-push hook OK.

Refs MIK-5863.
