### PR TITLE
chore: raise nab python floor 3.9 to 3.12 (3.9 is end-of-life)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "LangChain and LlamaIndex document loaders powered by nab"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 keywords = ["langchain", "llamaindex", "llm", "web-scraping", "markdown"]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Python 3.9 reached end-of-life Oct 2025. Bumps the python subpackage requires-python to >=3.12. Compiles clean on python3.12.