### PR TITLE
docs: add brew trust step for Homebrew 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Your agent will install the binary, wire itself up, and start fetching. Works in
 **Or install and try manually:**
 
 ```bash
+brew trust --tap MikkoParkkola/tap   # Homebrew 6.0+
 brew install MikkoParkkola/tap/nab                            # install
 nab fetch https://news.ycombinator.com                        # fetch as markdown
 nab models fetch fluidaudio                                   # download ASR model


### PR DESCRIPTION
Adds the `brew trust --tap MikkoParkkola/tap` step (Homebrew 6.0 tap-trust). Required when HOMEBREW_REQUIRE_TAP_TRUST is set, harmless otherwise. Matches the canonical homebrew-tap README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)