### PR TITLE
fix(pdf): extract born-digital PDFs in default build, stop false "scanned" (#195)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1620,7 +1620,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1720,7 +1720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3251,7 +3251,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4046,9 +4046,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4594,7 +4594,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4653,7 +4653,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5030,7 +5030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5187,7 +5187,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6656,7 +6656,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3147,6 +3147,7 @@ dependencies = [
  "criterion",
  "dirs",
  "ego-tree",
+ "flate2",
  "futures",
  "h3",
  "h3-quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,11 @@ roxmltree = "0.21"
 # PDF extraction (optional - requires pdfium dynamic library)
 pdfium-render = { version = "0.9", default-features = true, optional = true }
 
+# FlateDecode (zlib) inflation for the default-build light PDF extractor.
+# Already present transitively; declared direct so pdf_light can decompress
+# born-digital content streams without pdfium. (#195)
+flate2 = "1.1"
+
 # Browser automation via Chrome DevTools Protocol (optional)
 chromiumoxide = { version = "0.9", optional = true, default-features = false, features = ["rustls", "zip8"] }
 

--- a/src/content/pdf_light.rs
+++ b/src/content/pdf_light.rs
@@ -29,7 +29,10 @@
 //! [PDF: 3 pages, scanned — no text layer. Use OCR or rebuild with --features pdf]
 //! ```
 
+use std::io::Read as _;
+
 use anyhow::Result;
+use flate2::read::{DeflateDecoder, ZlibDecoder};
 
 use super::{ContentHandler, ConversionResult};
 
@@ -38,8 +41,30 @@ use super::{ContentHandler, ConversionResult};
 /// Protects against extremely large PDFs consuming excessive memory.
 const MAX_SCAN_BYTES: usize = 2 * 1024 * 1024;
 
+/// Maximum total inflated bytes to retain from `FlateDecode` streams.
+///
+/// Bounds memory + protects against zip-bomb content streams. Decompression
+/// stops appending once this ceiling is reached.
+const MAX_DECOMPRESSED_BYTES: usize = 8 * 1024 * 1024;
+
 /// Maximum output characters to prevent flooding LLM context windows.
 const MAX_OUTPUT_CHARS: usize = 50_000;
+
+/// Classification of *why* a PDF has no extractable text layer in the light path.
+///
+/// Born-digital PDFs (with embedded fonts) must never be reported as "scanned":
+/// they have a text layer the lightweight extractor simply could not decode
+/// (e.g. custom CMap/ToUnicode font encoding). That is a distinct failure from a
+/// genuinely image-only scan, which needs OCR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PdfKind {
+    /// Embedded fonts present → there is a text layer (born-digital).
+    HasTextLayer,
+    /// Only image `XObjects`, no fonts → genuine scan, needs OCR.
+    ImageOnly,
+    /// No clear font or image markers were found.
+    Indeterminate,
+}
 
 /// Lightweight PDF handler (no pdfium dependency).
 pub struct PdfLightHandler;
@@ -57,9 +82,22 @@ impl ContentHandler for PdfLightHandler {
         }
 
         let page_count = count_pages(bytes);
-        let text = extract_pdf_text(&bytes[..bytes.len().min(MAX_SCAN_BYTES)]);
+        let scan = &bytes[..bytes.len().min(MAX_SCAN_BYTES)];
 
-        let markdown = build_markdown(text, page_count);
+        // Collect stream contents (inflating FlateDecode, skipping images).
+        // Born-digital PDFs keep their text inside compressed content streams,
+        // which a raw byte scan cannot see.
+        let decompressed = collect_stream_contents(scan).unwrap_or_default();
+
+        // Scan decompressed streams first; fall back to raw bytes for
+        // old-style uncompressed PDFs.
+        let text = extract_pdf_text(&decompressed).or_else(|| extract_pdf_text(scan));
+
+        // Classify on raw bytes plus decompressed content, so fonts hidden
+        // inside compressed object streams still count as a text layer.
+        let kind = classify_pdf(scan, &decompressed);
+
+        let markdown = build_markdown(text, page_count, kind);
 
         Ok(ConversionResult {
             markdown,
@@ -242,14 +280,62 @@ fn parse_literal_string(bytes: &[u8]) -> Option<(String, usize)> {
     while i < bytes.len() {
         match bytes[i] {
             b'\\' if i + 1 < bytes.len() => {
-                let escaped = match bytes[i + 1] {
-                    b'n' => '\n',
-                    b'r' => '\r',
-                    b't' => '\t',
-                    c => char::from(c),
-                };
-                result.push(escaped);
-                i += 2;
+                match bytes[i + 1] {
+                    b'n' => {
+                        result.push('\n');
+                        i += 2;
+                    }
+                    b'r' => {
+                        result.push('\r');
+                        i += 2;
+                    }
+                    b't' => {
+                        result.push('\t');
+                        i += 2;
+                    }
+                    b'b' => {
+                        result.push('\u{8}');
+                        i += 2;
+                    }
+                    b'f' => {
+                        result.push('\u{c}');
+                        i += 2;
+                    }
+                    // Octal escape `\ddd` (1-3 octal digits) per PDF spec —
+                    // e.g. \050 → '(', \051 → ')'. Without this the digits leak
+                    // into the text as literal mojibake (#195).
+                    d @ b'0'..=b'7' => {
+                        let mut val = (d - b'0') as u32;
+                        let mut consumed = 2;
+                        for k in 0..2 {
+                            match bytes.get(i + 2 + k) {
+                                Some(&c @ b'0'..=b'7') => {
+                                    val = val * 8 + (c - b'0') as u32;
+                                    consumed += 1;
+                                }
+                                _ => break,
+                            }
+                        }
+                        let byte = (val & 0xFF) as u8;
+                        if byte.is_ascii_graphic() || byte == b' ' {
+                            result.push(char::from(byte));
+                        }
+                        i += consumed;
+                    }
+                    // `\<newline>` is a line continuation: emit nothing.
+                    b'\n' => i += 2,
+                    b'\r' => {
+                        i += 2;
+                        if bytes.get(i) == Some(&b'\n') {
+                            i += 1;
+                        }
+                    }
+                    c => {
+                        // `\(`, `\)`, `\\`, and any other escaped char → literal.
+                        result.push(char::from(c));
+                        i += 2;
+                    }
+                }
             }
             b'(' => {
                 depth += 1;
@@ -381,31 +467,181 @@ fn sanitize_pdf_string(s: &str) -> String {
         .collect()
 }
 
+/// Collect decoded `stream … endstream` payloads from a PDF for text scanning.
+///
+/// `FlateDecode` (zlib) streams are inflated; uncompressed content streams are
+/// kept verbatim; image streams (`/DCTDecode`, `/CCITTFaxDecode`, `/JPXDecode`,
+/// `/Subtype /Image`) are skipped — they carry no text. Returns `None` when no
+/// streams are found so the caller can fall back to a raw byte scan.
+///
+/// ponytail: heuristic stream walker, not a full PDF parser. It does not apply
+/// PNG/TIFF predictors (used by some object/xref streams) or LZW; such streams
+/// simply yield no text rather than wrong text. Upgrade path: `--features pdf`
+/// (pdfium) for full-fidelity decoding.
+fn collect_stream_contents(bytes: &[u8]) -> Option<Vec<u8>> {
+    const KW: &[u8] = b"stream";
+    let mut out: Vec<u8> = Vec::new();
+    let mut i = 0;
+    let mut found_any = false;
+    // Start of the current object's dictionary lookback — never reaches back
+    // past the previous stream, so one object's filters can't bleed into the next.
+    let mut prev_end = 0usize;
+
+    while i + KW.len() <= bytes.len() {
+        if &bytes[i..i + KW.len()] != KW {
+            i += 1;
+            continue;
+        }
+        // Reject the "stream" inside "endstream": the preceding byte is a letter.
+        if i > 0 && bytes[i - 1].is_ascii_alphabetic() {
+            i += KW.len();
+            continue;
+        }
+        found_any = true;
+
+        // The stream dictionary precedes the keyword; inspect a bounded window
+        // clamped to this object (after the previous stream's end).
+        let dict_start = i.saturating_sub(512).max(prev_end);
+        let dict = &bytes[dict_start..i];
+
+        // Data begins after the EOL that follows the `stream` keyword
+        // (CRLF or LF per the PDF spec).
+        let mut data_start = i + KW.len();
+        if bytes.get(data_start) == Some(&b'\r') {
+            data_start += 1;
+        }
+        if bytes.get(data_start) == Some(&b'\n') {
+            data_start += 1;
+        }
+
+        let Some(rel_end) = find_subsequence(&bytes[data_start..], b"endstream") else {
+            break;
+        };
+        let data = &bytes[data_start..data_start + rel_end];
+        i = data_start + rel_end + b"endstream".len();
+        prev_end = i;
+
+        if dict_is_image(dict) {
+            continue;
+        }
+
+        if window_contains(dict, b"/FlateDecode") {
+            if let Some(inflated) = inflate_flate(data) {
+                append_capped(&mut out, &inflated);
+            }
+        } else if !window_contains(dict, b"Decode") {
+            // Uncompressed content stream — keep verbatim.
+            append_capped(&mut out, data);
+        }
+
+        if out.len() >= MAX_DECOMPRESSED_BYTES {
+            break;
+        }
+    }
+
+    if found_any { Some(out) } else { None }
+}
+
+/// Append `src` to `dst` without exceeding [`MAX_DECOMPRESSED_BYTES`].
+fn append_capped(dst: &mut Vec<u8>, src: &[u8]) {
+    let room = MAX_DECOMPRESSED_BYTES.saturating_sub(dst.len());
+    if room == 0 {
+        return;
+    }
+    dst.extend_from_slice(&src[..src.len().min(room)]);
+}
+
+/// Returns `true` if a stream dictionary window denotes image data (no text).
+fn dict_is_image(dict: &[u8]) -> bool {
+    window_contains(dict, b"/DCTDecode")
+        || window_contains(dict, b"/CCITTFaxDecode")
+        || window_contains(dict, b"/JPXDecode")
+        || window_contains(dict, b"/JBIG2Decode")
+        || window_contains(dict, b"/Image")
+}
+
+/// Inflate a zlib (`FlateDecode`) stream, capped at [`MAX_DECOMPRESSED_BYTES`].
+///
+/// Tries zlib (with header) first, then raw DEFLATE for producers that omit it.
+/// Partial output is accepted: a truncated/corrupt tail still yields the text
+/// decoded so far.
+fn inflate_flate(data: &[u8]) -> Option<Vec<u8>> {
+    let mut buf = Vec::new();
+    let mut z = ZlibDecoder::new(data).take(MAX_DECOMPRESSED_BYTES as u64);
+    if z.read_to_end(&mut buf).is_ok() && !buf.is_empty() {
+        return Some(buf);
+    }
+    buf.clear();
+    let mut d = DeflateDecoder::new(data).take(MAX_DECOMPRESSED_BYTES as u64);
+    let _ = d.read_to_end(&mut buf);
+    if buf.is_empty() { None } else { Some(buf) }
+}
+
+/// Classify why a PDF has (or lacks) a text layer, for honest messaging (#195).
+///
+/// An embedded font anywhere (raw bytes or decompressed streams) means the
+/// document has a real text layer — it must never be labelled "scanned".
+fn classify_pdf(raw: &[u8], decompressed: &[u8]) -> PdfKind {
+    let has_font = window_contains(raw, b"/Font")
+        || window_contains(raw, b"/FontDescriptor")
+        || window_contains(decompressed, b"/Font")
+        || window_contains(decompressed, b"/FontDescriptor");
+    if has_font {
+        return PdfKind::HasTextLayer;
+    }
+
+    let has_image = dict_is_image(raw) || dict_is_image(decompressed);
+    if has_image {
+        return PdfKind::ImageOnly;
+    }
+
+    PdfKind::Indeterminate
+}
+
+/// Returns `true` if `haystack` contains `needle`.
+fn window_contains(haystack: &[u8], needle: &[u8]) -> bool {
+    find_subsequence(haystack, needle).is_some()
+}
+
+/// First index of `needle` in `haystack`, or `None`.
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
 /// Build the final markdown output from extracted text and page count.
-fn build_markdown(text: Option<String>, page_count: usize) -> String {
+fn build_markdown(text: Option<String>, page_count: usize, kind: PdfKind) -> String {
+    let pages_label = if page_count == 1 {
+        "1 page".to_string()
+    } else {
+        format!("{page_count} pages")
+    };
+
     match text {
         Some(extracted) if !extracted.trim().is_empty() => {
-            let pages_label = if page_count == 1 {
-                "1 page".to_string()
-            } else {
-                format!("{page_count} pages")
-            };
             format!(
                 "[PDF: {pages_label}, text extracted — for full fidelity rebuild with `--features pdf`]\n\n{}",
                 extracted.trim()
             )
         }
-        _ => {
-            let pages_label = if page_count == 1 {
-                "1 page".to_string()
-            } else {
-                format!("{page_count} pages")
-            };
-            format!(
-                "[PDF: {pages_label}, scanned — no text layer detected. \
-                 Use OCR or rebuild with `--features pdf` for pdfium extraction.]"
-            )
-        }
+        // No text extracted. Distinguish a born-digital PDF the light extractor
+        // could not decode from a genuine image-only scan (#195) — never report
+        // a PDF with an embedded font layer as "scanned".
+        _ => match kind {
+            PdfKind::HasTextLayer => format!(
+                "[PDF: {pages_label}, text layer present but not decoded by the built-in extractor \
+                 (likely custom font encoding). Rebuild with `--features pdf` for pdfium extraction.]"
+            ),
+            PdfKind::ImageOnly => format!(
+                "[PDF: {pages_label}, scanned (image-only) — no text layer detected. Use OCR to extract text.]"
+            ),
+            PdfKind::Indeterminate => format!(
+                "[PDF: {pages_label}, no extractable text. If this is a scan, use OCR; \
+                 otherwise rebuild with `--features pdf` for pdfium extraction.]"
+            ),
+        },
     }
 }
 
@@ -483,8 +719,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_literal_string_decodes_octal_escapes() {
+        // \050 → '(', \051 → ')' per PDF spec (#195 mojibake fix)
+        let (s, _) = parse_literal_string(b"(RL\\050x\\051)").unwrap();
+        assert_eq!(s, "RL(x)");
+    }
+
+    #[test]
+    fn parse_literal_string_octal_line_continuation_is_dropped() {
+        // A backslash before a newline is a line continuation, not a char.
+        let (s, _) = parse_literal_string(b"(ab\\\ncd)").unwrap();
+        assert_eq!(s, "abcd");
+    }
+
+    #[test]
     fn parse_literal_string_handles_nested_parens() {
-        // GIVEN: literal string with unescaped nested parens
         let (s, _) = parse_literal_string(b"(outer (inner) end)").unwrap();
         // THEN: nested parens preserved
         assert_eq!(s, "outer (inner) end");
@@ -566,26 +815,48 @@ mod tests {
     #[test]
     fn build_markdown_with_text_includes_extraction_note() {
         // GIVEN: extracted text and page count
-        let md = build_markdown(Some("Sample content".to_string()), 2);
+        let md = build_markdown(Some("Sample content".to_string()), 2, PdfKind::HasTextLayer);
         // THEN: contains PDF header and the text
         assert!(md.contains("[PDF: 2 pages"), "got: {md}");
         assert!(md.contains("Sample content"), "got: {md}");
     }
 
     #[test]
-    fn build_markdown_with_no_text_reports_scanned_pdf() {
-        // GIVEN: no extracted text
-        let md = build_markdown(None, 5);
-        // THEN: reports as scanned PDF
+    fn build_markdown_image_only_reports_scanned() {
+        // GIVEN: no text, classified as image-only
+        let md = build_markdown(None, 5, PdfKind::ImageOnly);
+        // THEN: reports as scanned PDF, suggests OCR
         assert!(md.contains("[PDF:"), "got: {md}");
         assert!(md.contains("scanned"), "got: {md}");
+        assert!(md.contains("OCR"), "got: {md}");
         assert!(md.contains("5 pages"), "got: {md}");
+    }
+
+    #[test]
+    fn build_markdown_born_digital_never_reports_scanned() {
+        // GIVEN: no text extracted but an embedded font layer is present (#195)
+        let md = build_markdown(None, 28, PdfKind::HasTextLayer);
+        // THEN: must NOT mislabel a born-digital PDF as scanned
+        assert!(
+            !md.contains("scanned"),
+            "born-digital must not say scanned: {md}"
+        );
+        assert!(md.contains("text layer present"), "got: {md}");
+        assert!(md.contains("--features pdf"), "got: {md}");
+    }
+
+    #[test]
+    fn build_markdown_messages_are_distinct_per_kind() {
+        // AC #195: image-only message must differ from the feature-not-compiled case.
+        let image = build_markdown(None, 3, PdfKind::ImageOnly);
+        let born = build_markdown(None, 3, PdfKind::HasTextLayer);
+        assert_ne!(image, born, "scanned vs born-digital messages must differ");
     }
 
     #[test]
     fn build_markdown_single_page_uses_singular_form() {
         // GIVEN: single-page PDF with no text
-        let md = build_markdown(None, 1);
+        let md = build_markdown(None, 1, PdfKind::ImageOnly);
         // THEN: "1 page" (not "1 pages")
         assert!(md.contains("1 page"), "got: {md}");
         assert!(!md.contains("1 pages"), "got: {md}");
@@ -619,18 +890,103 @@ mod tests {
     }
 
     #[test]
-    fn pdf_light_handler_reports_scanned_for_no_text_layer() {
-        // GIVEN: PDF with no BT/ET blocks (binary/scanned)
-        let pdf = b"%PDF-1.4\n/Type /Page\n/Type /Page\nxref\n%%EOF";
+    fn pdf_light_handler_reports_scanned_for_image_only_pdf() {
+        // GIVEN: an image-only PDF (image XObject, DCTDecode, no fonts)
+        let pdf = b"%PDF-1.4\n/Type /Page\n<< /Type /XObject /Subtype /Image /Filter /DCTDecode >>\nstream\n\xff\xd8\xff\xe0junk\nendstream\nxref\n%%EOF";
         let handler = PdfLightHandler;
         // WHEN: converting to markdown
         let result = handler.to_markdown(pdf, "application/pdf").unwrap();
-        // THEN: reports scanned PDF
+        // THEN: reports scanned PDF (genuine image, needs OCR)
         assert!(
             result.markdown.contains("scanned"),
             "got: {}",
             result.markdown
         );
+    }
+
+    #[test]
+    fn pdf_light_handler_extracts_text_from_flate_compressed_stream() {
+        // GIVEN: a born-digital PDF whose text lives in a FlateDecode stream (#195).
+        // This is the regression case: raw byte scanning sees nothing; only
+        // inflating the stream recovers the text.
+        let content = b"BT\n(Hello from a compressed stream) Tj\nET";
+        let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        use std::io::Write as _;
+        enc.write_all(content).unwrap();
+        let compressed = enc.finish().unwrap();
+
+        let mut pdf: Vec<u8> = Vec::new();
+        pdf.extend_from_slice(b"%PDF-1.5\n/Type /Page\n/Font /F1\n");
+        pdf.extend_from_slice(b"<< /Filter /FlateDecode /Length ");
+        pdf.extend_from_slice(compressed.len().to_string().as_bytes());
+        pdf.extend_from_slice(b" >>\nstream\n");
+        pdf.extend_from_slice(&compressed);
+        pdf.extend_from_slice(b"\nendstream\n%%EOF");
+
+        let handler = PdfLightHandler;
+        // WHEN: converting to markdown
+        let result = handler.to_markdown(&pdf, "application/pdf").unwrap();
+        // THEN: the compressed text is extracted and it is NOT called scanned
+        assert!(
+            result.markdown.contains("Hello from a compressed stream"),
+            "got: {}",
+            result.markdown
+        );
+        assert!(
+            !result.markdown.contains("scanned"),
+            "born-digital compressed PDF must not be scanned: {}",
+            result.markdown
+        );
+    }
+
+    #[test]
+    fn collect_stream_contents_inflates_flate_and_skips_images() {
+        let text = b"BT (visible) Tj ET";
+        let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        use std::io::Write as _;
+        enc.write_all(text).unwrap();
+        let compressed = enc.finish().unwrap();
+
+        let mut pdf: Vec<u8> = Vec::new();
+        // image stream — must be skipped
+        pdf.extend_from_slice(
+            b"<< /Subtype /Image /Filter /DCTDecode >>\nstream\nRAWIMAGE\nendstream\n",
+        );
+        // text stream — must be inflated
+        pdf.extend_from_slice(b"<< /Filter /FlateDecode >>\nstream\n");
+        pdf.extend_from_slice(&compressed);
+        pdf.extend_from_slice(b"\nendstream\n");
+
+        let out = collect_stream_contents(&pdf).expect("streams present");
+        let s = String::from_utf8_lossy(&out);
+        assert!(s.contains("visible"), "inflated text missing: {s}");
+        assert!(
+            !s.contains("RAWIMAGE"),
+            "image stream should be skipped: {s}"
+        );
+    }
+
+    #[test]
+    fn classify_pdf_detects_born_digital_via_font() {
+        let pdf = b"%PDF-1.5\n<< /Type /Font /Subtype /Type1 /FontDescriptor 1 0 R >>";
+        assert_eq!(classify_pdf(pdf, b""), PdfKind::HasTextLayer);
+    }
+
+    #[test]
+    fn classify_pdf_detects_image_only() {
+        let pdf = b"%PDF-1.5\n<< /Subtype /Image /Filter /DCTDecode >>";
+        assert_eq!(classify_pdf(pdf, b""), PdfKind::ImageOnly);
+    }
+
+    #[test]
+    fn inflate_flate_handles_corrupt_tail_gracefully() {
+        let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        use std::io::Write as _;
+        enc.write_all(b"good text here").unwrap();
+        let mut compressed = enc.finish().unwrap();
+        compressed.truncate(compressed.len().saturating_sub(2)); // corrupt the tail
+        // Should not panic; returns whatever decoded (possibly None on tiny input).
+        let _ = inflate_flate(&compressed);
     }
 
     #[test]

--- a/src/content/pdf_light.rs
+++ b/src/content/pdf_light.rs
@@ -647,6 +647,8 @@ fn build_markdown(text: Option<String>, page_count: usize, kind: PdfKind) -> Str
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write as _;
+
     use super::*;
 
     // ─── PDF detection ────────────────────────────────────────────────────
@@ -911,7 +913,6 @@ mod tests {
         // inflating the stream recovers the text.
         let content = b"BT\n(Hello from a compressed stream) Tj\nET";
         let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
-        use std::io::Write as _;
         enc.write_all(content).unwrap();
         let compressed = enc.finish().unwrap();
 
@@ -943,7 +944,6 @@ mod tests {
     fn collect_stream_contents_inflates_flate_and_skips_images() {
         let text = b"BT (visible) Tj ET";
         let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
-        use std::io::Write as _;
         enc.write_all(text).unwrap();
         let compressed = enc.finish().unwrap();
 
@@ -981,7 +981,6 @@ mod tests {
     #[test]
     fn inflate_flate_handles_corrupt_tail_gracefully() {
         let mut enc = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
-        use std::io::Write as _;
         enc.write_all(b"good text here").unwrap();
         let mut compressed = enc.finish().unwrap();
         compressed.truncate(compressed.len().saturating_sub(2)); // corrupt the tail

--- a/tests/pdf_light_tests.rs
+++ b/tests/pdf_light_tests.rs
@@ -1,0 +1,169 @@
+//! Integration tests for the **default-build** light PDF path
+//! (`nab::content::pdf_light`), exercised through the public
+//! `ContentHandler` / `ContentRouter` API.
+//!
+//! These tests are the regression guard for issue #195: born-digital PDFs whose
+//! text lives in FlateDecode (zlib-compressed) content streams were falsely
+//! reported as "scanned" because the light extractor only scanned raw bytes.
+//!
+//! Gated on `not(feature = "pdf")` — when the pdfium feature is enabled a
+//! different handler is wired in (`tests/pdf_tests.rs` covers that path), so
+//! these assertions about the light handler's messages would not apply.
+
+#![cfg(not(feature = "pdf"))]
+
+use flate2::Compression;
+use flate2::write::ZlibEncoder;
+use std::io::Write;
+
+use nab::content::pdf_light::PdfLightHandler;
+use nab::content::{ContentHandler, ContentRouter};
+
+// ── Fixture builders ────────────────────────────────────────────────────────
+
+/// Zlib-compress a PDF content-stream body (what FlateDecode stores).
+fn flate(body: &[u8]) -> Vec<u8> {
+    let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(body).unwrap();
+    enc.finish().unwrap()
+}
+
+/// Build a born-digital PDF whose only text lives in a FlateDecode stream.
+/// Declares a `/Font` so it classifies as having a text layer.
+fn born_digital_flate_pdf(content_stream: &[u8]) -> Vec<u8> {
+    let compressed = flate(content_stream);
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.5\n");
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Page >>\nendobj\n");
+    pdf.extend_from_slice(
+        b"2 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n",
+    );
+    pdf.extend_from_slice(b"3 0 obj\n<< /Filter /FlateDecode /Length ");
+    pdf.extend_from_slice(compressed.len().to_string().as_bytes());
+    pdf.extend_from_slice(b" >>\nstream\n");
+    pdf.extend_from_slice(&compressed);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n%%EOF");
+    pdf
+}
+
+/// Build a genuinely image-only PDF: an image XObject, no fonts.
+fn image_only_pdf() -> Vec<u8> {
+    let mut pdf = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+    pdf.extend_from_slice(b"1 0 obj\n<< /Type /Page >>\nendobj\n");
+    pdf.extend_from_slice(
+        b"2 0 obj\n<< /Type /XObject /Subtype /Image /Width 100 /Height 100 /Filter /DCTDecode /Length 8 >>\nstream\n",
+    );
+    pdf.extend_from_slice(b"\xff\xd8\xff\xe0junk");
+    pdf.extend_from_slice(b"\nendstream\nendobj\n%%EOF");
+    pdf
+}
+
+// ── #195 regression: compressed born-digital extracts text ──────────────────
+
+#[test]
+fn flate_born_digital_extracts_text_via_handler() {
+    let pdf = born_digital_flate_pdf(b"BT (Compressed body text) Tj ET");
+    let md = PdfLightHandler
+        .to_markdown(&pdf, "application/pdf")
+        .unwrap()
+        .markdown;
+    assert!(md.contains("Compressed body text"), "got: {md}");
+    assert!(
+        !md.contains("scanned"),
+        "must not mislabel born-digital: {md}"
+    );
+    assert!(md.contains("text extracted"), "got: {md}");
+}
+
+#[test]
+fn flate_born_digital_routes_through_content_router() {
+    // The default ContentRouter must dispatch application/pdf to the light handler
+    // and extract compressed text end-to-end.
+    let pdf = born_digital_flate_pdf(b"BT (Routed through ContentRouter) Tj ET");
+    let md = ContentRouter::new()
+        .convert(&pdf, "application/pdf")
+        .unwrap()
+        .markdown;
+    assert!(md.contains("Routed through ContentRouter"), "got: {md}");
+    assert!(!md.contains("scanned"), "got: {md}");
+}
+
+// ── Three distinct verdicts (AC #195) ───────────────────────────────────────
+
+#[test]
+fn image_only_pdf_reports_scanned_with_ocr_hint() {
+    let md = PdfLightHandler
+        .to_markdown(&image_only_pdf(), "application/pdf")
+        .unwrap()
+        .markdown;
+    assert!(md.contains("scanned"), "image-only should be scanned: {md}");
+    assert!(md.contains("OCR"), "should hint OCR: {md}");
+}
+
+#[test]
+fn born_digital_without_decodable_text_is_not_scanned() {
+    // Font present (text layer) but the stream carries no BT/ET we can decode:
+    // must route to the "text layer present" message, never "scanned".
+    let pdf = born_digital_flate_pdf(b"q 1 0 0 1 0 0 cm Q"); // graphics ops, no text
+    let md = PdfLightHandler
+        .to_markdown(&pdf, "application/pdf")
+        .unwrap()
+        .markdown;
+    assert!(
+        !md.contains("scanned"),
+        "born-digital must not be scanned: {md}"
+    );
+    assert!(md.contains("text layer present"), "got: {md}");
+}
+
+#[test]
+fn scanned_and_feature_messages_differ() {
+    let image = PdfLightHandler
+        .to_markdown(&image_only_pdf(), "application/pdf")
+        .unwrap()
+        .markdown;
+    let born = PdfLightHandler
+        .to_markdown(&born_digital_flate_pdf(b"q Q"), "application/pdf")
+        .unwrap()
+        .markdown;
+    assert_ne!(
+        image, born,
+        "the two failure messages must be distinguishable"
+    );
+}
+
+// ── Octal escape decoding through the full path (#195 mojibake) ──────────────
+
+#[test]
+fn octal_escapes_decode_in_compressed_text() {
+    // \050 → '(', \051 → ')' — without decoding these leak as digits.
+    let pdf = born_digital_flate_pdf(b"BT (RL\\050x\\051) Tj ET");
+    let md = PdfLightHandler
+        .to_markdown(&pdf, "application/pdf")
+        .unwrap()
+        .markdown;
+    assert!(md.contains("RL(x)"), "octal escapes should decode: {md}");
+    assert!(!md.contains("050"), "raw octal digits leaked: {md}");
+}
+
+// ── No regression: uncompressed PDFs still work ─────────────────────────────
+
+#[test]
+fn uncompressed_simple_pdf_still_extracts() {
+    let pdf = b"%PDF-1.4\n/Type /Page\n/Font /F1\nBT (Plain uncompressed text) Tj ET\n%%EOF";
+    let md = PdfLightHandler
+        .to_markdown(pdf, "application/pdf")
+        .unwrap()
+        .markdown;
+    assert!(md.contains("Plain uncompressed text"), "got: {md}");
+}
+
+#[test]
+fn non_pdf_bytes_error() {
+    assert!(
+        PdfLightHandler
+            .to_markdown(b"<html>nope</html>", "application/pdf")
+            .is_err()
+    );
+}

--- a/tests/pdf_light_tests.rs
+++ b/tests/pdf_light_tests.rs
@@ -3,7 +3,7 @@
 //! `ContentHandler` / `ContentRouter` API.
 //!
 //! These tests are the regression guard for issue #195: born-digital PDFs whose
-//! text lives in FlateDecode (zlib-compressed) content streams were falsely
+//! text lives in `FlateDecode` (zlib-compressed) content streams were falsely
 //! reported as "scanned" because the light extractor only scanned raw bytes.
 //!
 //! Gated on `not(feature = "pdf")` — when the pdfium feature is enabled a
@@ -21,14 +21,14 @@ use nab::content::{ContentHandler, ContentRouter};
 
 // ── Fixture builders ────────────────────────────────────────────────────────
 
-/// Zlib-compress a PDF content-stream body (what FlateDecode stores).
+/// Zlib-compress a PDF content-stream body (what `FlateDecode` stores).
 fn flate(body: &[u8]) -> Vec<u8> {
     let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
     enc.write_all(body).unwrap();
     enc.finish().unwrap()
 }
 
-/// Build a born-digital PDF whose only text lives in a FlateDecode stream.
+/// Build a born-digital PDF whose only text lives in a `FlateDecode` stream.
 /// Declares a `/Font` so it classifies as having a text layer.
 fn born_digital_flate_pdf(content_stream: &[u8]) -> Vec<u8> {
     let compressed = flate(content_stream);
@@ -46,7 +46,7 @@ fn born_digital_flate_pdf(content_stream: &[u8]) -> Vec<u8> {
     pdf
 }
 
-/// Build a genuinely image-only PDF: an image XObject, no fonts.
+/// Build a genuinely image-only PDF: an image `XObject`, no fonts.
 fn image_only_pdf() -> Vec<u8> {
     let mut pdf = Vec::new();
     pdf.extend_from_slice(b"%PDF-1.4\n");


### PR DESCRIPTION
Fixes #195.

## Problem
`nab fetch <born-digital PDF>` on the default (Homebrew/release) build returned a 1-line `[PDF: N pages, scanned — no text layer]` placeholder instead of text. The light handler (`pdf_light.rs`, used when the `pdf`/pdfium feature is off) scanned only **raw** bytes for `BT`/`ET` text operators and could not read FlateDecode (zlib) content streams — where modern born-digital PDFs keep their text.

Proven on the repro (`cdn.openai.com/pdf/beneficial-rl.pdf`): 28 pages, **556 FlateDecode streams**, embedded Computer Modern fonts (`pdffonts` confirms born-digital, not a scan).

## Fix — local, no new runtime dependency
`flate2` was already in the dependency tree; no pdfium, no cloud service.

1. **Inflate FlateDecode content streams** before the `BT`/`ET` scan; skip image XObjects (`DCTDecode`/`CCITTFax`/`JPXDecode`/`JBIG2`/`Image`). Zip-bomb guarded via `MAX_DECOMPRESSED_BYTES`; falls back to the raw scan for old uncompressed PDFs.
2. **Three honest verdicts** instead of one — a born-digital PDF (embedded `/Font`) is never mislabelled "scanned":
   - `HasTextLayer` → "text layer present, rebuild with `--features pdf`"
   - `ImageOnly` → "scanned (image-only), use OCR"
   - `Indeterminate` → generic hint
3. **Decode literal-string octal escapes** (`\050`→`(`) and line continuations, removing mojibake.

## Acceptance criteria (#195)
- [x] Born-digital PDF returns markdown text in the default build (no rebuild) — verified live: `[PDF: 28 pages, text extracted]` + readable body.
- [x] The repro PDF extracts real text.
- [x] Image-only PDF yields a message **distinct** from the feature-not-compiled / born-digital case (no false "scanned").

## Tests
- `pdf_light` unit tests: 34 (FlateDecode extraction, image-only classification, three messages, octal decode, corrupt-tail safety).
- New `tests/pdf_light_tests.rs`: 8 end-to-end via `ContentRouter` (gated `not(feature="pdf")`).
- Full lib suite green: **1383 passed, 0 failed**.

## Known ceiling (documented, routed to `--features pdf`)
No `ToUnicode`/CMap decoding in the light tier, so custom-encoded ligatures (`fi`) and `TJ` inter-word spacing are imperfect. The opt-in pdfium tier remains the high-fidelity path. Shipping pdfium by default was deliberately **not** done — it needs a native `libpdfium` dynamic library at runtime, which dents the single-self-contained-binary promise; the light-path fix covers born-digital papers with zero of that cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)