### PR TITLE
chore(deps): migrate to aes-gcm 0.11 (aead 0.6 API)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,23 +29,12 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher 0.4.4",
- "cpufeatures 0.2.17",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -61,13 +50,13 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
 dependencies = [
  "aead",
- "aes 0.8.4",
- "cipher 0.4.4",
+ "aes",
+ "cipher 0.5.2",
  "ctr",
  "ghash",
  "subtle",
@@ -174,7 +163,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -185,7 +174,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -824,6 +813,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
+ "block-buffer 0.12.0",
  "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
@@ -1433,7 +1423,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1443,7 +1432,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1471,11 +1462,11 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
 dependencies = [
- "cipher 0.4.4",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -1620,7 +1611,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1720,7 +1711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2056,11 +2047,10 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "opaque-debug",
  "polyval",
 ]
 
@@ -3130,7 +3120,7 @@ name = "nab"
 version = "0.12.0"
 dependencies = [
  "addr",
- "aes 0.9.1",
+ "aes",
  "aes-gcm",
  "anyhow",
  "argon2",
@@ -3251,7 +3241,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3517,12 +3507,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-macros"
@@ -3816,13 +3800,12 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpubits",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -4594,7 +4577,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4653,7 +4636,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5030,7 +5013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5187,7 +5170,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5717,12 +5700,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.7",
- "subtle",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -6656,7 +6639,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ ego-tree = "0.11"
 which = "8"
 reqwest_cookie_store = "0.10"          # Persistent named-session cookie jars
 cookie_store = "0.22"                  # Cookie serialization for encrypted session files
-aes-gcm = "0.10.3"                     # AES-256-GCM for nab-owned session encryption
+aes-gcm = "0.11"                       # AES-256-GCM for nab-owned session encryption
 argon2 = "0.5.3"                       # Argon2id KDF for session data keys
 scrypt = { version = "0.11", default-features = false, features = ["std"] }  # PoW KDF for AWS WAF replay solver
 base64 = "0.22"                        # Base64 encoding for WAF challenge responses

--- a/src/session.rs
+++ b/src/session.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 
-use aes_gcm::aead::{Aead, KeyInit, OsRng, Payload, rand_core::RngCore};
+use aes_gcm::aead::{Aead, Generate, KeyInit, Payload};
 use aes_gcm::{Aes256Gcm, Nonce};
 use anyhow::{Context, Result, bail};
 use argon2::{Algorithm, Argon2, Params, Version};
@@ -335,8 +335,9 @@ fn load_or_create_master_secret_in(state_dir: &Path) -> Result<[u8; SESSION_KEY_
         return read_master_secret_file(&key_path);
     }
 
-    let mut secret = [0u8; SESSION_KEY_LEN];
-    OsRng.fill_bytes(&mut secret);
+    // AES-256-GCM master secret: filled from the OS CSPRNG via aead 0.6 `Generate`
+    // (getrandom-backed). Same 32-byte key material as before; no crypto change.
+    let secret: [u8; SESSION_KEY_LEN] = Generate::generate();
 
     let mut options = fs::OpenOptions::new();
     options.write(true).create_new(true);
@@ -396,12 +397,10 @@ fn encrypt_session_payload(
 ) -> Result<PersistedSessionEnvelope> {
     let master_secret = load_or_create_master_secret_in(state_dir)?;
 
-    let mut salt = [0u8; SESSION_SALT_LEN];
-    OsRng.fill_bytes(&mut salt);
+    let salt: [u8; SESSION_SALT_LEN] = Generate::generate();
     let key = derive_session_key(&master_secret, &salt)?;
 
-    let mut nonce = [0u8; SESSION_NONCE_LEN];
-    OsRng.fill_bytes(&mut nonce);
+    let nonce: [u8; SESSION_NONCE_LEN] = Generate::generate();
 
     let cipher = Aes256Gcm::new_from_slice(&key)
         .map_err(|e| anyhow::anyhow!("AES-256-GCM key setup failed: {e}"))?;
@@ -409,7 +408,7 @@ fn encrypt_session_payload(
         serde_json::to_vec(payload).context("Failed to serialize session payload to JSON")?;
     let ciphertext = cipher
         .encrypt(
-            Nonce::from_slice(&nonce),
+            &Nonce::from(nonce),
             Payload {
                 msg: &plaintext,
                 aad: session_aad(name).as_bytes(),
@@ -462,7 +461,7 @@ fn decrypt_session_payload(
         .map_err(|e| anyhow::anyhow!("AES-256-GCM key setup failed: {e}"))?;
     let plaintext = cipher
         .decrypt(
-            Nonce::from_slice(&nonce),
+            &Nonce::from(nonce),
             Payload {
                 msg: &ciphertext,
                 aad: session_aad(name).as_bytes(),
@@ -1058,6 +1057,60 @@ mod tests {
             .to_string();
         assert!(headers.contains("sid=abc"));
         assert!(headers.contains("token=xyz"));
+    }
+
+    // ── AES-256-GCM envelope crypto (aes-gcm 0.11 / aead 0.6 migration) ──────
+
+    fn sample_payload() -> PersistedSessionPayload {
+        PersistedSessionPayload {
+            profile: random_profile(),
+            cookies: Vec::new(),
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn encrypt_then_decrypt_session_payload_round_trips() {
+        let state_dir = tempfile::tempdir().unwrap();
+        let payload = sample_payload();
+
+        let envelope = encrypt_session_payload("roundtrip", &payload, state_dir.path()).unwrap();
+        let decrypted = decrypt_session_payload("roundtrip", &envelope, state_dir.path()).unwrap();
+
+        assert_eq!(decrypted.profile.user_agent, payload.profile.user_agent);
+        assert_eq!(
+            decrypted.profile.accept_language,
+            payload.profile.accept_language
+        );
+        assert!(decrypted.cookies.is_empty());
+        assert_eq!(envelope.cipher, SESSION_CIPHER);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn decrypt_session_payload_rejects_tampered_ciphertext() {
+        let state_dir = tempfile::tempdir().unwrap();
+        let mut envelope =
+            encrypt_session_payload("tamper", &sample_payload(), state_dir.path()).unwrap();
+
+        // Flip one ciphertext byte: the GCM authentication tag must reject it.
+        let mut bytes = hex::decode(&envelope.ciphertext_hex).unwrap();
+        bytes[0] ^= 0xFF;
+        envelope.ciphertext_hex = hex::encode(bytes);
+
+        assert!(decrypt_session_payload("tamper", &envelope, state_dir.path()).is_err());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn decrypt_session_payload_rejects_wrong_aad_name() {
+        let state_dir = tempfile::tempdir().unwrap();
+        // Same state dir → same master secret + salt-derived key; only the AAD
+        // (session name) differs, so GCM authentication must fail.
+        let envelope =
+            encrypt_session_payload("alice", &sample_payload(), state_dir.path()).unwrap();
+
+        assert!(decrypt_session_payload("bob", &envelope, state_dir.path()).is_err());
     }
 
     #[cfg(not(windows))]


### PR DESCRIPTION
## What

Bumps `aes-gcm` from 0.10.3 to 0.11.0, which upgrades `aead` 0.5 -> 0.6 (generic-array -> hybrid-array). `src/session.rs` (nab-owned AES-256-GCM session encryption) is the only consumer.

### API changes

- **Random bytes**: aead 0.6 no longer re-exports `OsRng` / `rand_core::RngCore` from the crate root. The three `OsRng.fill_bytes(&mut buf)` calls (master secret, salt, nonce) now use aead 0.6's idiomatic `Generate::generate()`, which draws from the same OS CSPRNG (getrandom) under the default `getrandom` feature. No new dependency, no feature flags added.
- **Nonce**: `Nonce::from_slice` is deprecated in hybrid-array 0.4; switched to `Nonce::from([u8; 12])` (the `From<[u8; N]>` impl) so clippy `-D warnings` stays green.

Everything else is unchanged: `Aes256Gcm::new_from_slice`, `encrypt`/`decrypt` with `Payload`, and the on-disk envelope format are identical.

### Crypto invariants preserved

AES-256-GCM, 32-byte key, 12-byte nonce, 16-byte salt, Argon2id KDF, AAD bound to the session name. No key/nonce size change, no hardcoded nonce, no weakening.

## Tests

Added three focused tests to `src/session.rs` proving the migration preserved correctness:

- `encrypt_then_decrypt_session_payload_round_trips` — encrypt then decrypt returns the original payload.
- `decrypt_session_payload_rejects_tampered_ciphertext` — a single flipped ciphertext byte is rejected by the GCM auth tag.
- `decrypt_session_payload_rejects_wrong_aad_name` — decrypting under a different session name fails (AAD binding).

The pre-existing round-trip test (`persist_and_load_session_round_trips_profile_and_cookies`) and ciphertext-hiding test also pass unchanged.

### Local verification (all green)

- `cargo build` — no warnings
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- Full CI build feature matrix (`--bins`; `nab --no-default-features --features cli,http3`; `nab-mcp --no-default-features`; `nab-mcp --features task`; `nab-mcp --features task,browser`)
- `cargo test --locked` — 0 failures

Supersedes #203