### PR TITLE
fix(security): unblock the audit gate on RUSTSEC-2026-0222, documented and time-boxed

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -24,6 +24,43 @@ ignore = [
     # in its ^1.16 pin, so no bump can clear it today. Time-boxed: remove this
     # ignore once memmap2 ships the fix and yara-x picks it up. Tracked in #134.
     "RUSTSEC-2026-0204",
+    # wasmtime "stores can mix up type indices between engines"
+    # (RUSTSEC-2026-0222 / GHSA-hgjw-h833-99q9, 2026-07-31). Present TWICE in the
+    # tree: wasmtime 43.0.2 (transitive, via yara-x -> the YARA rule compiler) and
+    # wasmtime 44.0.3 (our own optional `wasm-providers` dep).
+    #
+    # Why this cannot be bumped away today: the advisory's patched lines are
+    # >=24.0.12, >=36.0.13, >=46.0.2 and >=47.0.3. There is NO patched 43.x.
+    # yara-x requires `wasmtime ^43.0.2` and 1.19.0 -- the newest published --
+    # still does, so no available yara-x release can reach a patched wasmtime.
+    # Verified against the crates.io dependency API for 1.16.0 and 1.19.0.
+    #
+    # Why suppressing it is defensible rather than lazy: CVSS 3.8 LOW, vector
+    # AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:L/A:L -- local access, high attack complexity,
+    # high privileges AND user interaction required, all impacts low. The bug needs
+    # multiple wasmtime Engines to confuse type indices between them; yara-x
+    # constructs its engine internally to execute rules WE compile from our own
+    # built-in ruleset. There is no path by which fetched remote content reaches it.
+    #
+    # Why we are not dropping yara-x to remove wasmtime: it is the fetch-time
+    # prompt-injection firewall (src/security/yara_engine.rs, 30 built-in rules
+    # covering prompt injection, exfiltration, secret detection and obfuscated
+    # shell payloads). nab fetches hostile web content for agents by design, so
+    # removing that guard to clear a local-privilege advisory would trade a
+    # reachable defence for a theoretical exposure -- a net security regression.
+    #
+    # Cost of NOT suppressing it: `cargo audit` fails hard on any advisory
+    # regardless of severity, so this 3.8 blocked all nine open dependency PRs,
+    # including the security bumps. The security gate was blocking the security
+    # fixes.
+    #
+    # TIME-BOXED. Remove this ignore when EITHER holds:
+    #   * yara-x releases a version requiring wasmtime >=46.0.2, or
+    #   * our own `wasm-providers` wasmtime is the only remaining consumer and has
+    #     been bumped to >=47.0.3 (tracked separately -- a major upgrade needing a
+    #     verified build, deliberately not bundled with this unblock).
+    # Re-check on every yara-x release. Tracked in #134.
+    "RUSTSEC-2026-0222",
     # NOTE: the lru RUSTSEC-2026-0002 ignore was removed once main moved to
     # wreq 6.0.0-rc.29 (lru >= 0.18.0, past the 0.16.3 fix). The advisory no
     # longer applies, so suppressing it would be dead config. See Cargo.toml


### PR DESCRIPTION
## The problem

**The security gate is blocking the security fixes.** All **9** open dependency PRs on this repo are `BLOCKED` because the required `Security Audit` check fails — and it fails on a **CVSS 3.8 LOW** advisory that no version bump can clear.

## Why it cannot be bumped away

`RUSTSEC-2026-0222` (wasmtime, *"stores can mix up type indices between engines"*) appears **twice**:

| wasmtime | comes from |
|---|---|
| 43.0.2 | `yara-x` (transitive, unconditional) |
| 44.0.3 | our own optional `wasm-providers` dep |

The advisory's patched lines are `>=24.0.12`, `>=36.0.13`, `>=46.0.2`, `>=47.0.3`. **There is no patched 43.x.**

`yara-x` requires `wasmtime ^43.0.2`, and **1.19.0 — the newest published — still does**. Verified against the crates.io dependency API for both 1.16.0 and 1.19.0. No available yara-x release reaches a patched wasmtime.

## Why suppressing this is defensible

CVSS vector `AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:L/A:L` — local access, high complexity, high privileges **and** user interaction required, all impacts low.

The bug requires **multiple wasmtime Engines** to confuse type indices between them. yara-x constructs its engine internally to execute rules *we* compile from *our own* built-in ruleset. Fetched remote content never reaches it.

## Why we are not dropping yara-x

`yara-x` **is** the fetch-time prompt-injection firewall (`src/security/yara_engine.rs`) — 30 built-in rules covering prompt injection, exfiltration, secret detection and obfuscated shell payloads, applied to content nab fetches from hostile sources **by design**.

Removing it to clear a local-privilege advisory would trade a **reachable** defence for a **theoretical** exposure. That is a net security regression.

Alternatives considered: yara-x has no feature that avoids wasmtime (`pulley` is still wasmtime's interpreter); the original `yara` C bindings drop wasmtime but add a C dependency with its own CVE history; hand-rolled regex matching loses the YARA rule format and reimplements a rule engine.

## Deliberately not in this PR

Bumping **our own** wasmtime `44.0.2` → `47.0.3`. That is a major upgrade needing a verified build, and coupling it here would put a guaranteed unblock behind a risky one. Separate PR.

## Time-boxing

Follows the existing convention in `.cargo/audit.toml` — narrow (one ID), rationale stated, explicit removal conditions, tracked in #134. Remove when **either**: yara-x releases a version requiring `wasmtime >=46.0.2`, **or** our own `wasm-providers` wasmtime becomes the only consumer and is bumped past 47.0.3.

## Expected effect

`Security Audit` goes green → the 9 blocked dependency PRs become mergeable → auto-merge lands them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)