### PR TITLE
fix: add non-interactive macOS Keychain mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ Optional plugin configuration at `~/.config/nab/plugins.toml`. See [docs/getting
 | `HTTP_PROXY` / `http_proxy` | HTTP proxy URL |
 | `ALL_PROXY` / `all_proxy` | Proxy for all protocols |
 | `RUST_LOG` | Logging level (e.g., `nab=debug`) |
+| `NAB_KEYCHAIN_INTERACTION` | Set to `never` for background automation: macOS Keychain reads cannot open UI, and prompt-capable Python cookie fallback is disabled |
 | `PUSHOVER_USER` / `PUSHOVER_TOKEN` | Pushover notifications for MFA |
 | `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` | Telegram notifications for MFA |
 
@@ -500,7 +501,7 @@ This tool includes browser cookie extraction and fingerprint spoofing capabiliti
 
 **MCP server not connecting?** Run `nab-mcp` directly in your terminal to see errors. Verify the binary exists with `which nab-mcp`. If installed via `cargo install nab`, both `nab` and `nab-mcp` should be on your `$PATH`.
 
-**Cookie extraction failing?** Grant Full Disk Access to your terminal in **System Settings > Privacy & Security > Full Disk Access** (macOS). Browser cookies are stored in protected directories. Use `--cookies brave` to target a specific browser.
+**Cookie extraction failing?** Grant Full Disk Access to your terminal in **System Settings > Privacy & Security > Full Disk Access** (macOS). Browser cookies are stored in protected directories. Use `--cookies brave` to target a specific browser. Background tools that must never show a Keychain authorization dialog can run `NAB_KEYCHAIN_INTERACTION=never nab ...`; this fails closed instead of invoking a prompt-capable fallback.
 
 **ASR model not found?** Run `nab models fetch fluidaudio` to download the model (~542 MB). The model directory is `~/.nab/models/`. Use `nab models list` to see what's installed.
 

--- a/man/nab.1
+++ b/man/nab.1
@@ -149,6 +149,10 @@ HTTP proxy URL.
 .B HTTPS_PROXY
 HTTPS proxy URL.
 .TP
+.B NAB_KEYCHAIN_INTERACTION
+Set to \fBnever\fR for background automation. macOS Keychain reads cannot open
+authorization UI, and the prompt-capable Python cookie fallback is disabled.
+.TP
 .B ANTHROPIC_API_KEY
 Claude API key for video vision analysis (\fBanalyze\fR command).
 .SH FILES

--- a/src/auth/cookies/db.rs
+++ b/src/auth/cookies/db.rs
@@ -102,11 +102,7 @@ pub(super) fn query_cookie_db(temp_db: &std::path::Path, domain: &str) -> Result
         .output()
         .context("Failed to query cookie database")?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        warn!("SQLite query failed: {}", stderr);
-        return Ok(Vec::new());
-    }
+    ensure_sqlite_query_succeeded(output.status.success(), &output.stderr, "cookie")?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     Ok(parse_cookie_rows(&stdout))
@@ -140,14 +136,22 @@ pub(super) fn query_cookie_db_rich(
         .output()
         .context("Failed to query cookie database")?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        warn!("SQLite rich query failed: {}", stderr);
-        return Ok(Vec::new());
-    }
+    ensure_sqlite_query_succeeded(output.status.success(), &output.stderr, "rich cookie")?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     Ok(parse_rich_cookie_rows(&stdout))
+}
+
+fn ensure_sqlite_query_succeeded(success: bool, stderr: &[u8], query_kind: &str) -> Result<()> {
+    if success {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(stderr);
+    let diagnostic = stderr.trim();
+    if diagnostic.is_empty() {
+        anyhow::bail!("SQLite {query_kind} query failed with no diagnostic");
+    }
+    anyhow::bail!("SQLite {query_kind} query failed: {diagnostic}");
 }
 
 // ─── Parsing ──────────────────────────────────────────────────────────────────
@@ -353,6 +357,21 @@ pub(super) fn has_domain_tag(temp_db: &std::path::Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unsuccessful_sqlite_query_preserves_stderr() {
+        let err =
+            ensure_sqlite_query_succeeded(false, b"database disk image is malformed", "cookie")
+                .expect_err("nonzero sqlite3 status must not look like zero rows");
+        let message = err.to_string();
+        assert!(message.contains("cookie"));
+        assert!(message.contains("database disk image is malformed"));
+    }
+
+    #[test]
+    fn successful_sqlite_query_is_accepted() {
+        ensure_sqlite_query_succeeded(true, b"", "cookie").expect("successful sqlite3 status");
+    }
 
     #[test]
     fn parse_rich_rows_reads_all_metadata_columns_positionally() {

--- a/src/auth/cookies/db.rs
+++ b/src/auth/cookies/db.rs
@@ -65,22 +65,29 @@ pub(super) fn copy_db_to_temp(cookie_path: &std::path::Path) -> Result<std::path
     Ok(temp_db)
 }
 
-/// Query the `meta` table for the DB schema version (0 if unavailable).
+/// Query the `meta` table for the DB schema version.
 ///
 /// Chromium increments this monotonically; v24 added `SHA-256(host_key)` prepended
 /// to every decrypted cookie value.
-pub(super) fn query_db_schema_version(temp_db: &std::path::Path) -> u32 {
-    let Some(db_str) = temp_db.to_str() else {
-        return 0;
-    };
+pub(super) fn query_db_schema_version(temp_db: &std::path::Path) -> Result<u32> {
+    let db_str = temp_db
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("Invalid temp database path"))?;
     let output = Command::new("sqlite3")
         .args([db_str, "SELECT value FROM meta WHERE key='version';"])
-        .output();
-    let Ok(out) = output else { return 0 };
-    String::from_utf8_lossy(&out.stdout)
-        .trim()
+        .output()
+        .context("Failed to query cookie schema version")?;
+    parse_schema_version_output(output.status.success(), &output.stdout, &output.stderr)
+}
+
+fn parse_schema_version_output(success: bool, stdout: &[u8], stderr: &[u8]) -> Result<u32> {
+    ensure_sqlite_query_succeeded(success, stderr, "cookie schema version")?;
+    let version = std::str::from_utf8(stdout)
+        .context("SQLite cookie schema version was not valid UTF-8")?
+        .trim();
+    version
         .parse()
-        .unwrap_or(0)
+        .with_context(|| format!("Invalid SQLite cookie schema version: {version:?}"))
 }
 
 /// Query the cookie database for rows matching `domain` and its parents.
@@ -348,10 +355,10 @@ pub(super) fn decrypt_rich_rows(
     cookies
 }
 /// Query the schema version of `temp_db` and return whether domain tags are present.
-pub(super) fn has_domain_tag(temp_db: &std::path::Path) -> bool {
-    let version = query_db_schema_version(temp_db);
+pub(super) fn has_domain_tag(temp_db: &std::path::Path) -> Result<bool> {
+    let version = query_db_schema_version(temp_db)?;
     debug!("Cookie DB schema v{version}");
-    version >= SCHEMA_VERSION_WITH_DOMAIN_TAG
+    Ok(version >= SCHEMA_VERSION_WITH_DOMAIN_TAG)
 }
 
 #[cfg(test)]
@@ -371,6 +378,28 @@ mod tests {
     #[test]
     fn successful_sqlite_query_is_accepted() {
         ensure_sqlite_query_succeeded(true, b"", "cookie").expect("successful sqlite3 status");
+    }
+
+    #[test]
+    fn unsuccessful_schema_query_preserves_stderr() {
+        let err = parse_schema_version_output(false, b"", b"meta table is malformed")
+            .expect_err("nonzero schema query must not become schema version zero");
+        assert!(err.to_string().contains("meta table is malformed"));
+    }
+
+    #[test]
+    fn malformed_schema_version_is_an_error() {
+        let err = parse_schema_version_output(true, b"not-a-version\n", b"")
+            .expect_err("malformed schema output must not become schema version zero");
+        assert!(err.to_string().contains("not-a-version"));
+    }
+
+    #[test]
+    fn valid_schema_version_is_parsed() {
+        assert_eq!(
+            parse_schema_version_output(true, b"24\n", b"").expect("valid schema version"),
+            24
+        );
     }
 
     #[test]

--- a/src/auth/cookies/mod.rs
+++ b/src/auth/cookies/mod.rs
@@ -93,11 +93,40 @@ fn rich_cookie_rows_need_key(rows: &[db::RichCookieRow]) -> bool {
         .any(|row| row.value.is_empty() && !row.encrypted_bytes.is_empty())
 }
 
-fn load_cookie_key_if_needed<F>(needed: bool, load: F) -> Result<Option<Vec<u8>>>
+fn load_cookie_key_if_needed<F>(
+    needed: bool,
+    interaction: KeychainInteraction,
+    load: F,
+) -> Result<Option<Vec<u8>>>
 where
     F: FnOnce() -> Result<Vec<u8>>,
 {
-    if needed { load().map(Some) } else { Ok(None) }
+    if !needed {
+        return Ok(None);
+    }
+    match load() {
+        Ok(key) => Ok(Some(key)),
+        Err(err) if interaction == KeychainInteraction::Never => Err(err),
+        Err(_) => Ok(None),
+    }
+}
+
+fn load_cookie_domain_tag_if_needed<F>(
+    needed: bool,
+    interaction: KeychainInteraction,
+    load: F,
+) -> Result<Option<bool>>
+where
+    F: FnOnce() -> Result<bool>,
+{
+    if !needed {
+        return Ok(None);
+    }
+    match load() {
+        Ok(has_domain_tag) => Ok(Some(has_domain_tag)),
+        Err(err) if interaction == KeychainInteraction::Never => Err(err),
+        Err(_) => Ok(None),
+    }
 }
 
 // ─── CookieSource ─────────────────────────────────────────────────────────────
@@ -263,21 +292,27 @@ impl CookieSource {
         }
 
         let temp_db = copy_db_to_temp(&cookie_path)?;
-        let domain_tag = has_domain_tag(&temp_db);
-        let rows = query_cookie_db(&temp_db, domain);
+        let extraction = (|| {
+            let rows = query_cookie_db(&temp_db, domain)?;
+            let needs_key = cookie_rows_need_key(&rows);
+            let domain_tag = load_cookie_domain_tag_if_needed(needs_key, interaction, || {
+                has_domain_tag(&temp_db)
+            })?;
+            Ok::<_, anyhow::Error>((domain_tag, rows))
+        })();
         if let Some(parent) = temp_db.parent() {
             let _ = std::fs::remove_dir_all(parent);
         }
-        let rows = rows?;
+        let (domain_tag, rows) = extraction?;
 
         if rows.is_empty() {
             return Ok(HashMap::new());
         }
 
-        let key = load_cookie_key_if_needed(cookie_rows_need_key(&rows), || {
+        let key = load_cookie_key_if_needed(domain_tag.is_some(), interaction, || {
             self.get_keychain_key_with_interaction(interaction)
         })?;
-        let cookies = decrypt_rows(rows, key.as_deref(), domain_tag);
+        let cookies = decrypt_rows(rows, key.as_deref(), domain_tag.unwrap_or(false));
 
         if cookies.is_empty() {
             debug!("Native extraction: 0 cookies for {}", domain);
@@ -415,21 +450,27 @@ except Exception as e:
         }
 
         let temp_db = copy_db_to_temp(&cookie_path)?;
-        let domain_tag = has_domain_tag(&temp_db);
-        let rows = query_cookie_db_rich(&temp_db, domain);
+        let extraction = (|| {
+            let rows = query_cookie_db_rich(&temp_db, domain)?;
+            let needs_key = rich_cookie_rows_need_key(&rows);
+            let domain_tag = load_cookie_domain_tag_if_needed(needs_key, interaction, || {
+                has_domain_tag(&temp_db)
+            })?;
+            Ok::<_, anyhow::Error>((domain_tag, rows))
+        })();
         if let Some(parent) = temp_db.parent() {
             let _ = std::fs::remove_dir_all(parent);
         }
-        let rows = rows?;
+        let (domain_tag, rows) = extraction?;
 
         if rows.is_empty() {
             return Ok(Vec::new());
         }
 
-        let key = load_cookie_key_if_needed(rich_cookie_rows_need_key(&rows), || {
+        let key = load_cookie_key_if_needed(domain_tag.is_some(), interaction, || {
             self.get_keychain_key_with_interaction(interaction)
         })?;
-        let cookies = decrypt_rich_rows(rows, key.as_deref(), domain_tag);
+        let cookies = decrypt_rich_rows(rows, key.as_deref(), domain_tag.unwrap_or(false));
         Ok(cookies)
     }
 }

--- a/src/auth/cookies/mod.rs
+++ b/src/auth/cookies/mod.rs
@@ -22,6 +22,8 @@ mod tests;
 
 use std::collections::HashMap;
 use std::process::Command;
+#[cfg(target_os = "macos")]
+use std::sync::Mutex;
 
 use anyhow::{Context, Result};
 use tracing::{debug, info, warn};
@@ -30,6 +32,47 @@ use super::{Credential, OnePasswordAuth};
 use db::{copy_db_to_temp, decrypt_rows, domain_candidates, has_domain_tag, query_cookie_db};
 use db::{decrypt_rich_rows, query_cookie_db_rich};
 use storage_state::{PlaywrightCookie, SameSite};
+
+/// Controls whether browser-cookie extraction may ask macOS to authorize a
+/// Keychain read. Automated callers should set this to `never` so a background
+/// fetch cannot open GUI dialogs.
+pub const KEYCHAIN_INTERACTION_ENV: &str = "NAB_KEYCHAIN_INTERACTION";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeychainInteraction {
+    Allow,
+    Never,
+}
+
+fn keychain_interaction_from_env_value(value: Option<&str>) -> KeychainInteraction {
+    match value.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+        None | Some("" | "allow" | "true" | "1" | "yes" | "on") => KeychainInteraction::Allow,
+        Some(_) => KeychainInteraction::Never,
+    }
+}
+
+fn configured_keychain_interaction() -> KeychainInteraction {
+    keychain_interaction_from_env_value(std::env::var(KEYCHAIN_INTERACTION_ENV).ok().as_deref())
+}
+
+fn resolve_cookie_lookup<F>(
+    native: Result<HashMap<String, String>>,
+    interaction: KeychainInteraction,
+    fallback: F,
+) -> Result<HashMap<String, String>>
+where
+    F: FnOnce() -> Result<HashMap<String, String>>,
+{
+    match native {
+        Ok(cookies) if !cookies.is_empty() => Ok(cookies),
+        Err(err) if interaction == KeychainInteraction::Never => Err(err),
+        Ok(cookies) if interaction == KeychainInteraction::Never => Ok(cookies),
+        Ok(_) | Err(_) => fallback(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+static KEYCHAIN_UI_LOCK: Mutex<()> = Mutex::new(());
 
 // ─── CookieSource ─────────────────────────────────────────────────────────────
 
@@ -79,12 +122,15 @@ impl CookieSource {
     ///
     /// On macOS, uses `security-framework` to query the system Keychain.
     /// On Linux, returns an error — only GNOME Keyring is supported there (TODO).
-    fn get_keychain_key(self) -> Result<Vec<u8>> {
+    fn get_keychain_key_with_interaction(
+        self,
+        interaction: KeychainInteraction,
+    ) -> Result<Vec<u8>> {
         let service = self.keychain_service();
         if service.is_empty() {
             anyhow::bail!("Browser does not use Keychain encryption");
         }
-        let password = Self::read_keychain_password(service)?;
+        let password = Self::read_keychain_password(service, interaction)?;
         crypto::derive_cookie_key(&password)
     }
 
@@ -93,8 +139,35 @@ impl CookieSource {
     /// Uses `security-framework` on macOS. Other platforms intentionally return an
     /// error so cookie extraction can fall back to Python `browser_cookie3`.
     #[cfg(target_os = "macos")]
-    fn read_keychain_password(service: &str) -> Result<Vec<u8>> {
+    fn read_keychain_password(service: &str, interaction: KeychainInteraction) -> Result<Vec<u8>> {
+        use security_framework::os::macos::keychain::SecKeychain;
         use security_framework::passwords::get_generic_password;
+
+        // SecKeychainSetUserInteractionAllowed is process-global. Serialize
+        // non-interactive reads so one lookup cannot restore UI while another
+        // is still in progress. If the caller had already disabled UI, do not
+        // create security-framework's RAII lock because its Drop always
+        // re-enables interaction rather than restoring the previous state.
+        let _serial_guard = if interaction == KeychainInteraction::Never {
+            Some(
+                KEYCHAIN_UI_LOCK
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("Keychain interaction lock was poisoned"))?,
+            )
+        } else {
+            None
+        };
+        let _interaction_guard = if interaction == KeychainInteraction::Never
+            && SecKeychain::user_interaction_allowed()
+                .context("Could not read Keychain interaction policy")?
+        {
+            Some(
+                SecKeychain::disable_user_interaction()
+                    .context("Could not disable Keychain interaction")?,
+            )
+        } else {
+            None
+        };
 
         let account = service.strip_suffix(" Safe Storage").unwrap_or(service);
         get_generic_password(service, account)
@@ -103,7 +176,10 @@ impl CookieSource {
 
     /// Non-macOS platforms do not have native keychain support in `nab` yet.
     #[cfg(not(target_os = "macos"))]
-    fn read_keychain_password(_service: &str) -> Result<Vec<u8>> {
+    fn read_keychain_password(
+        _service: &str,
+        _interaction: KeychainInteraction,
+    ) -> Result<Vec<u8>> {
         anyhow::bail!(
             "Native keychain lookup is only supported on macOS; using Python cookie fallback"
         )
@@ -111,23 +187,39 @@ impl CookieSource {
 
     /// Get cookies for a domain from the specified browser.
     ///
-    /// Tries native Rust extraction first, falls back to Python `browser_cookie3`.
+    /// Tries native Rust extraction first and normally falls back to Python
+    /// `browser_cookie3`. When [`KEYCHAIN_INTERACTION_ENV`] forbids UI, the
+    /// Python fallback is skipped because it can perform a second Keychain read.
     pub fn get_cookies(&self, domain: &str) -> Result<HashMap<String, String>> {
+        self.get_cookies_with_interaction(domain, configured_keychain_interaction())
+    }
+
+    fn get_cookies_with_interaction(
+        self,
+        domain: &str,
+        interaction: KeychainInteraction,
+    ) -> Result<HashMap<String, String>> {
         debug!("Getting cookies for {} from {:?}", domain, self);
 
-        match self.get_cookies_native(domain) {
+        let native = self.get_cookies_native(domain, interaction);
+        match &native {
             Ok(cookies) if !cookies.is_empty() => {
                 info!(
                     "Native cookie extraction succeeded: {} cookies",
                     cookies.len()
                 );
-                return Ok(cookies);
+            }
+            Ok(_) if interaction == KeychainInteraction::Never => {
+                debug!("Native extraction returned empty; prompt-capable fallback disabled");
             }
             Ok(_) => debug!("Native extraction returned empty, trying Python fallback"),
-            Err(e) => debug!("Native extraction failed: {}, trying Python fallback", e),
+            Err(e) if interaction == KeychainInteraction::Never => {
+                debug!("Native extraction failed; prompt-capable fallback disabled: {e}");
+            }
+            Err(e) => debug!("Native extraction failed: {e}, trying Python fallback"),
         }
 
-        self.get_cookies_via_python(domain)
+        resolve_cookie_lookup(native, interaction, || self.get_cookies_via_python(domain))
     }
 
     /// Native Rust cookie extraction from the browser `SQLite` database.
@@ -137,7 +229,11 @@ impl CookieSource {
     ///
     /// For DB schema v24+, the decrypted plaintext has a 32-byte `SHA-256(host_key)`
     /// prefix that is stripped automatically.
-    fn get_cookies_native(self, domain: &str) -> Result<HashMap<String, String>> {
+    fn get_cookies_native(
+        self,
+        domain: &str,
+        interaction: KeychainInteraction,
+    ) -> Result<HashMap<String, String>> {
         let cookie_path = self
             .cookie_path()
             .context("Could not determine cookie path")?;
@@ -153,8 +249,19 @@ impl CookieSource {
             let _ = std::fs::remove_dir_all(parent);
         }
 
-        let key = self.get_keychain_key().ok();
-        let cookies = decrypt_rows(rows, key.as_deref(), domain_tag);
+        if rows.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let key = self.get_keychain_key_with_interaction(interaction);
+        let cookies = decrypt_rows(rows, key.as_deref().ok(), domain_tag);
+
+        if cookies.is_empty()
+            && interaction == KeychainInteraction::Never
+            && !self.keychain_service().is_empty()
+        {
+            key?;
+        }
 
         if cookies.is_empty() {
             debug!("Native extraction: 0 cookies for {}", domain);
@@ -255,12 +362,16 @@ except Exception as e:
     pub fn get_cookies_rich(&self, domain: &str) -> Result<Vec<PlaywrightCookie>> {
         debug!("Getting rich cookies for {} from {:?}", domain, self);
 
-        match self.get_cookies_rich_native(domain) {
+        let interaction = configured_keychain_interaction();
+
+        match self.get_cookies_rich_native(domain, interaction) {
             Ok(cookies) if !cookies.is_empty() => {
                 info!("Native rich extraction: {} cookies", cookies.len());
                 return Ok(cookies);
             }
+            Ok(cookies) if interaction == KeychainInteraction::Never => return Ok(cookies),
             Ok(_) => debug!("Native rich extraction empty, falling back to name/value"),
+            Err(e) if interaction == KeychainInteraction::Never => return Err(e),
             Err(e) => debug!("Native rich extraction failed: {e}, falling back to name/value"),
         }
 
@@ -274,7 +385,11 @@ except Exception as e:
     }
 
     /// Native Rust rich extraction from the Chromium `SQLite` database.
-    fn get_cookies_rich_native(self, domain: &str) -> Result<Vec<PlaywrightCookie>> {
+    fn get_cookies_rich_native(
+        self,
+        domain: &str,
+        interaction: KeychainInteraction,
+    ) -> Result<Vec<PlaywrightCookie>> {
         let cookie_path = self
             .cookie_path()
             .context("Could not determine cookie path")?;
@@ -290,8 +405,19 @@ except Exception as e:
             let _ = std::fs::remove_dir_all(parent);
         }
 
-        let key = self.get_keychain_key().ok();
-        Ok(decrypt_rich_rows(rows, key.as_deref(), domain_tag))
+        if rows.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let key = self.get_keychain_key_with_interaction(interaction);
+        let cookies = decrypt_rich_rows(rows, key.as_deref().ok(), domain_tag);
+        if cookies.is_empty()
+            && interaction == KeychainInteraction::Never
+            && !self.keychain_service().is_empty()
+        {
+            key?;
+        }
+        Ok(cookies)
     }
 }
 

--- a/src/auth/cookies/mod.rs
+++ b/src/auth/cookies/mod.rs
@@ -51,8 +51,17 @@ fn keychain_interaction_from_env_value(value: Option<&str>) -> KeychainInteracti
     }
 }
 
+fn keychain_interaction_from_env_os_value(value: Option<&std::ffi::OsStr>) -> KeychainInteraction {
+    match value {
+        None => KeychainInteraction::Allow,
+        Some(value) => value.to_str().map_or(KeychainInteraction::Never, |value| {
+            keychain_interaction_from_env_value(Some(value))
+        }),
+    }
+}
+
 fn configured_keychain_interaction() -> KeychainInteraction {
-    keychain_interaction_from_env_value(std::env::var(KEYCHAIN_INTERACTION_ENV).ok().as_deref())
+    keychain_interaction_from_env_os_value(std::env::var_os(KEYCHAIN_INTERACTION_ENV).as_deref())
 }
 
 fn resolve_cookie_lookup<F>(
@@ -73,6 +82,23 @@ where
 
 #[cfg(target_os = "macos")]
 static KEYCHAIN_UI_LOCK: Mutex<()> = Mutex::new(());
+
+fn cookie_rows_need_key(rows: &[db::CookieRow]) -> bool {
+    rows.iter()
+        .any(|row| row.value.is_empty() && !row.encrypted_bytes.is_empty())
+}
+
+fn rich_cookie_rows_need_key(rows: &[db::RichCookieRow]) -> bool {
+    rows.iter()
+        .any(|row| row.value.is_empty() && !row.encrypted_bytes.is_empty())
+}
+
+fn load_cookie_key_if_needed<F>(needed: bool, load: F) -> Result<Option<Vec<u8>>>
+where
+    F: FnOnce() -> Result<Vec<u8>>,
+{
+    if needed { load().map(Some) } else { Ok(None) }
+}
 
 // ─── CookieSource ─────────────────────────────────────────────────────────────
 
@@ -148,15 +174,9 @@ impl CookieSource {
         // is still in progress. If the caller had already disabled UI, do not
         // create security-framework's RAII lock because its Drop always
         // re-enables interaction rather than restoring the previous state.
-        let _serial_guard = if interaction == KeychainInteraction::Never {
-            Some(
-                KEYCHAIN_UI_LOCK
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("Keychain interaction lock was poisoned"))?,
-            )
-        } else {
-            None
-        };
+        let _serial_guard = KEYCHAIN_UI_LOCK
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Keychain interaction lock was poisoned"))?;
         let _interaction_guard = if interaction == KeychainInteraction::Never
             && SecKeychain::user_interaction_allowed()
                 .context("Could not read Keychain interaction policy")?
@@ -244,24 +264,20 @@ impl CookieSource {
 
         let temp_db = copy_db_to_temp(&cookie_path)?;
         let domain_tag = has_domain_tag(&temp_db);
-        let rows = query_cookie_db(&temp_db, domain)?;
+        let rows = query_cookie_db(&temp_db, domain);
         if let Some(parent) = temp_db.parent() {
             let _ = std::fs::remove_dir_all(parent);
         }
+        let rows = rows?;
 
         if rows.is_empty() {
             return Ok(HashMap::new());
         }
 
-        let key = self.get_keychain_key_with_interaction(interaction);
-        let cookies = decrypt_rows(rows, key.as_deref().ok(), domain_tag);
-
-        if cookies.is_empty()
-            && interaction == KeychainInteraction::Never
-            && !self.keychain_service().is_empty()
-        {
-            key?;
-        }
+        let key = load_cookie_key_if_needed(cookie_rows_need_key(&rows), || {
+            self.get_keychain_key_with_interaction(interaction)
+        })?;
+        let cookies = decrypt_rows(rows, key.as_deref(), domain_tag);
 
         if cookies.is_empty() {
             debug!("Native extraction: 0 cookies for {}", domain);
@@ -400,23 +416,20 @@ except Exception as e:
 
         let temp_db = copy_db_to_temp(&cookie_path)?;
         let domain_tag = has_domain_tag(&temp_db);
-        let rows = query_cookie_db_rich(&temp_db, domain)?;
+        let rows = query_cookie_db_rich(&temp_db, domain);
         if let Some(parent) = temp_db.parent() {
             let _ = std::fs::remove_dir_all(parent);
         }
+        let rows = rows?;
 
         if rows.is_empty() {
             return Ok(Vec::new());
         }
 
-        let key = self.get_keychain_key_with_interaction(interaction);
-        let cookies = decrypt_rich_rows(rows, key.as_deref().ok(), domain_tag);
-        if cookies.is_empty()
-            && interaction == KeychainInteraction::Never
-            && !self.keychain_service().is_empty()
-        {
-            key?;
-        }
+        let key = load_cookie_key_if_needed(rich_cookie_rows_need_key(&rows), || {
+            self.get_keychain_key_with_interaction(interaction)
+        })?;
+        let cookies = decrypt_rich_rows(rows, key.as_deref(), domain_tag);
         Ok(cookies)
     }
 }

--- a/src/auth/cookies/mod.rs
+++ b/src/auth/cookies/mod.rs
@@ -83,6 +83,13 @@ where
 #[cfg(target_os = "macos")]
 static KEYCHAIN_UI_LOCK: Mutex<()> = Mutex::new(());
 
+#[cfg(target_os = "macos")]
+fn lock_ignoring_poison<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 fn cookie_rows_need_key(rows: &[db::CookieRow]) -> bool {
     rows.iter()
         .any(|row| row.value.is_empty() && !row.encrypted_bytes.is_empty())
@@ -203,9 +210,7 @@ impl CookieSource {
         // is still in progress. If the caller had already disabled UI, do not
         // create security-framework's RAII lock because its Drop always
         // re-enables interaction rather than restoring the previous state.
-        let _serial_guard = KEYCHAIN_UI_LOCK
-            .lock()
-            .map_err(|_| anyhow::anyhow!("Keychain interaction lock was poisoned"))?;
+        let _serial_guard = lock_ignoring_poison(&KEYCHAIN_UI_LOCK);
         let _interaction_guard = if interaction == KeychainInteraction::Never
             && SecKeychain::user_interaction_allowed()
                 .context("Could not read Keychain interaction policy")?

--- a/src/auth/cookies/tests.rs
+++ b/src/auth/cookies/tests.rs
@@ -5,7 +5,8 @@
 use super::{
     CookieSource, KeychainInteraction, cookie_rows_need_key, crypto::*, db::*,
     keychain_interaction_from_env_os_value, keychain_interaction_from_env_value,
-    load_cookie_key_if_needed, resolve_cookie_lookup, rich_cookie_rows_need_key,
+    load_cookie_domain_tag_if_needed, load_cookie_key_if_needed, resolve_cookie_lookup,
+    rich_cookie_rows_need_key,
 };
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
@@ -163,7 +164,7 @@ fn mixed_plaintext_and_encrypted_rows_require_a_successful_key_read() {
     ];
     assert!(cookie_rows_need_key(&rows));
 
-    let err = load_cookie_key_if_needed(true, || {
+    let err = load_cookie_key_if_needed(true, KeychainInteraction::Never, || {
         Err(anyhow::anyhow!("Keychain interaction is not allowed"))
     })
     .expect_err("encrypted rows must preserve the key-read failure");
@@ -178,9 +179,79 @@ fn plaintext_rows_skip_keychain_loading() {
         encrypted_bytes: Vec::new(),
     }];
     assert!(!cookie_rows_need_key(&rows));
-    let key = load_cookie_key_if_needed(false, || panic!("plaintext rows must not read Keychain"))
-        .expect("plaintext rows should not need a key");
+    let key = load_cookie_key_if_needed(false, KeychainInteraction::Never, || {
+        panic!("plaintext rows must not read Keychain")
+    })
+    .expect("plaintext rows should not need a key");
     assert!(key.is_none());
+}
+
+#[test]
+fn interactive_mixed_rows_retain_plaintext_when_key_read_fails() {
+    let rows = vec![
+        CookieRow {
+            name: "plain".into(),
+            value: "available".into(),
+            encrypted_bytes: Vec::new(),
+        },
+        CookieRow {
+            name: "session".into(),
+            value: String::new(),
+            encrypted_bytes: vec![1, 2, 3],
+        },
+    ];
+    let key = load_cookie_key_if_needed(true, KeychainInteraction::Allow, || {
+        Err(anyhow::anyhow!("interactive Keychain read failed"))
+    })
+    .expect("interactive mode should preserve recoverable plaintext rows");
+    let native = decrypt_rows(rows, key.as_deref(), false);
+    let fallback_called = std::cell::Cell::new(false);
+    let cookies = resolve_cookie_lookup(Ok(native), KeychainInteraction::Allow, || {
+        fallback_called.set(true);
+        Err(anyhow::anyhow!("Python fallback failed"))
+    })
+    .expect("plaintext native cookie should survive failed key and fallback paths");
+
+    assert_eq!(cookies.get("plain").map(String::as_str), Some("available"));
+    assert!(!cookies.contains_key("session"));
+    assert!(
+        !fallback_called.get(),
+        "usable native plaintext avoids fallback"
+    );
+}
+
+#[test]
+fn interactive_schema_failure_skips_encrypted_rows_without_losing_plaintext() {
+    let domain_tag = load_cookie_domain_tag_if_needed(true, KeychainInteraction::Allow, || {
+        Err(anyhow::anyhow!("schema query failed"))
+    })
+    .expect("interactive mode may preserve plaintext rows after schema failure");
+    assert!(domain_tag.is_none());
+
+    let rows = vec![
+        CookieRow {
+            name: "plain".into(),
+            value: "available".into(),
+            encrypted_bytes: Vec::new(),
+        },
+        CookieRow {
+            name: "session".into(),
+            value: String::new(),
+            encrypted_bytes: vec![1, 2, 3],
+        },
+    ];
+    let cookies = decrypt_rows(rows, None, domain_tag.unwrap_or(false));
+    assert_eq!(cookies.get("plain").map(String::as_str), Some("available"));
+    assert!(!cookies.contains_key("session"));
+}
+
+#[test]
+fn noninteractive_schema_failure_is_preserved() {
+    let err = load_cookie_domain_tag_if_needed(true, KeychainInteraction::Never, || {
+        Err(anyhow::anyhow!("schema query failed"))
+    })
+    .expect_err("non-interactive extraction must fail closed on unknown schema");
+    assert!(err.to_string().contains("schema query failed"));
 }
 
 #[test]

--- a/src/auth/cookies/tests.rs
+++ b/src/auth/cookies/tests.rs
@@ -2,6 +2,8 @@
 
 //! Tests for browser cookie extraction, crypto, and DB parsing.
 
+#[cfg(target_os = "macos")]
+use super::lock_ignoring_poison;
 use super::{
     CookieSource, KeychainInteraction, cookie_rows_need_key, crypto::*, db::*,
     keychain_interaction_from_env_os_value, keychain_interaction_from_env_value,
@@ -146,6 +148,20 @@ fn non_utf8_keychain_interaction_value_fails_closed() {
         keychain_interaction_from_env_os_value(Some(value.as_os_str())),
         KeychainInteraction::Never
     );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn keychain_serialization_recovers_after_mutex_poisoning() {
+    let mutex = std::sync::Arc::new(std::sync::Mutex::new(()));
+    let poisoner = std::sync::Arc::clone(&mutex);
+    let _ = std::thread::spawn(move || {
+        let _guard = poisoner.lock().expect("initial lock");
+        panic!("controlled mutex poisoning");
+    })
+    .join();
+
+    let _guard = lock_ignoring_poison(&mutex);
 }
 
 #[test]

--- a/src/auth/cookies/tests.rs
+++ b/src/auth/cookies/tests.rs
@@ -3,8 +3,9 @@
 //! Tests for browser cookie extraction, crypto, and DB parsing.
 
 use super::{
-    CookieSource, KeychainInteraction, crypto::*, db::*, keychain_interaction_from_env_value,
-    resolve_cookie_lookup,
+    CookieSource, KeychainInteraction, cookie_rows_need_key, crypto::*, db::*,
+    keychain_interaction_from_env_os_value, keychain_interaction_from_env_value,
+    load_cookie_key_if_needed, resolve_cookie_lookup, rich_cookie_rows_need_key,
 };
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
@@ -132,6 +133,70 @@ fn keychain_interaction_policy_defaults_to_allow_and_fails_closed_when_configure
             "configured value {value:?} must not unexpectedly allow UI"
         );
     }
+}
+
+#[cfg(unix)]
+#[test]
+fn non_utf8_keychain_interaction_value_fails_closed() {
+    use std::os::unix::ffi::OsStringExt;
+
+    let value = std::ffi::OsString::from_vec(vec![0xff]);
+    assert_eq!(
+        keychain_interaction_from_env_os_value(Some(value.as_os_str())),
+        KeychainInteraction::Never
+    );
+}
+
+#[test]
+fn mixed_plaintext_and_encrypted_rows_require_a_successful_key_read() {
+    let rows = vec![
+        CookieRow {
+            name: "plain".into(),
+            value: "available".into(),
+            encrypted_bytes: Vec::new(),
+        },
+        CookieRow {
+            name: "session".into(),
+            value: String::new(),
+            encrypted_bytes: vec![1, 2, 3],
+        },
+    ];
+    assert!(cookie_rows_need_key(&rows));
+
+    let err = load_cookie_key_if_needed(true, || {
+        Err(anyhow::anyhow!("Keychain interaction is not allowed"))
+    })
+    .expect_err("encrypted rows must preserve the key-read failure");
+    assert!(err.to_string().contains("interaction is not allowed"));
+}
+
+#[test]
+fn plaintext_rows_skip_keychain_loading() {
+    let rows = vec![CookieRow {
+        name: "plain".into(),
+        value: "available".into(),
+        encrypted_bytes: Vec::new(),
+    }];
+    assert!(!cookie_rows_need_key(&rows));
+    let key = load_cookie_key_if_needed(false, || panic!("plaintext rows must not read Keychain"))
+        .expect("plaintext rows should not need a key");
+    assert!(key.is_none());
+}
+
+#[test]
+fn rich_encrypted_rows_require_a_key() {
+    let rows = vec![RichCookieRow {
+        name: "session".into(),
+        value: String::new(),
+        encrypted_bytes: vec![1, 2, 3],
+        host_key: ".example.com".into(),
+        path: "/".into(),
+        expires_utc: 0,
+        is_httponly: true,
+        is_secure: true,
+        samesite: 1,
+    }];
+    assert!(rich_cookie_rows_need_key(&rows));
 }
 
 #[test]

--- a/src/auth/cookies/tests.rs
+++ b/src/auth/cookies/tests.rs
@@ -2,7 +2,10 @@
 
 //! Tests for browser cookie extraction, crypto, and DB parsing.
 
-use super::{CookieSource, crypto::*, db::*};
+use super::{
+    CookieSource, KeychainInteraction, crypto::*, db::*, keychain_interaction_from_env_value,
+    resolve_cookie_lookup,
+};
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
 
@@ -107,6 +110,85 @@ fn keychain_service_firefox_safari_are_empty() {
     assert!(CookieSource::Safari.keychain_service().is_empty());
 }
 
+#[test]
+fn keychain_interaction_policy_defaults_to_allow_and_fails_closed_when_configured() {
+    for value in [None, Some(""), Some("allow"), Some("true"), Some("1")] {
+        assert_eq!(
+            keychain_interaction_from_env_value(value),
+            KeychainInteraction::Allow,
+            "value {value:?} should preserve explicit CLI behavior"
+        );
+    }
+    for value in [
+        Some("never"),
+        Some("false"),
+        Some("0"),
+        Some("off"),
+        Some("typo"),
+    ] {
+        assert_eq!(
+            keychain_interaction_from_env_value(value),
+            KeychainInteraction::Never,
+            "configured value {value:?} must not unexpectedly allow UI"
+        );
+    }
+}
+
+#[test]
+fn noninteractive_cookie_lookup_never_invokes_prompt_capable_fallback() {
+    let fallback_called = std::cell::Cell::new(false);
+    let native_error = anyhow::anyhow!("Keychain interaction is not allowed");
+
+    let err = resolve_cookie_lookup(Err(native_error), KeychainInteraction::Never, || {
+        fallback_called.set(true);
+        Ok(std::collections::HashMap::from([(
+            "session".to_string(),
+            "must-not-be-read".to_string(),
+        )]))
+    })
+    .expect_err("the native diagnostic should be preserved");
+
+    assert!(err.to_string().contains("interaction is not allowed"));
+    assert!(!fallback_called.get(), "Python fallback could prompt again");
+}
+
+#[test]
+fn noninteractive_empty_native_result_stays_empty_without_fallback() {
+    let fallback_called = std::cell::Cell::new(false);
+    let cookies = resolve_cookie_lookup(
+        Ok(std::collections::HashMap::new()),
+        KeychainInteraction::Never,
+        || {
+            fallback_called.set(true);
+            Ok(std::collections::HashMap::from([(
+                "session".to_string(),
+                "unexpected".to_string(),
+            )]))
+        },
+    )
+    .expect("an empty native store is not an error");
+
+    assert!(cookies.is_empty());
+    assert!(!fallback_called.get(), "Python fallback could prompt again");
+}
+
+#[test]
+fn interactive_lookup_retains_python_fallback() {
+    let cookies = resolve_cookie_lookup(
+        Ok(std::collections::HashMap::new()),
+        KeychainInteraction::Allow,
+        || {
+            Ok(std::collections::HashMap::from([(
+                "session".to_string(),
+                "expected".to_string(),
+            )]))
+        },
+    )
+    .expect("interactive fallback should remain available");
+
+    assert_eq!(cookies.get("session").map(String::as_str), Some("expected"));
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn cookie_paths_use_macos_locations() {
@@ -183,7 +265,7 @@ fn cookie_paths_use_windows_locations() {
 #[test]
 fn non_macos_keychain_lookup_returns_fallback_error() {
     let err = CookieSource::Chrome
-        .get_keychain_key()
+        .get_keychain_key_with_interaction(KeychainInteraction::Allow)
         .expect_err("non-macOS should not attempt native keychain lookup");
     assert!(
         err.to_string().contains("Python cookie fallback"),


### PR DESCRIPTION
Closes #257.

## What changed

- Add NAB_KEYCHAIN_INTERACTION=never for background callers.
- Disable macOS Keychain UI around native cookie-password reads and serialize every process-global Keychain interaction-policy transition.
- Skip prompt-capable Python fallback in non-interactive mode.
- Avoid Keychain and schema reads for plaintext-only or empty result sets.
- Fail closed on non-UTF-8 policy values, native key failures, SQLite nonzero exits, and malformed schema versions.
- Preserve recoverable plaintext cookies in normal interactive mode when encrypted rows cannot be decoded.
- Apply the contract to ordinary and rich-cookie extraction and document it in README and the man page.

Default direct CLI behavior remains interactive when the variable is unset.

## Root cause and impact

Automated callers could launch multiple Nab processes. Native macOS cookie decryption could open a Keychain authorization dialog, then Python fallback could prompt again. The new mode provides a zero-dialog contract: no Keychain UI and no prompt-capable fallback.

## Validation

- cargo fmt --all -- --check: passed.
- cargo clippy --all-targets -- -D warnings: passed.
- Cookie extraction suite: 64 passed.
- Full library suite: 1,402 passed, 7 ignored.
- Final independent review: no Critical, Important, or Minor findings.
- New-head CI: formatting, Clippy, macOS library, security, packaging, and all build matrices passed; remaining required test check-runs are tracked until GitHub marks them complete.

Repository-wide cargo test still has three live httpbin.org HTTP 503 failures reproduced on untouched origin/main; tracked separately in #259. The unchanged optional-PDF all-features compile failure is tracked in #260. Neither is introduced by this PR.
