### PR TITLE
release: prepare v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-08-11
+
+### Fixed
+
+- Background callers can set `NAB_KEYCHAIN_INTERACTION=never` to guarantee
+  zero macOS Keychain authorization dialogs during browser-cookie extraction.
+  Native Keychain reads temporarily disable interaction under a process-wide
+  lock, prompt-capable Python fallback is skipped, and failures return without
+  discarding recoverable plaintext cookies in the default interactive mode.
+
 ## [0.11.0] - 2026-05-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "nab"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "addr",
  "aes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nab"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 authors = ["Mikko Parkkola"]
 description = "Token-optimized HTTP client for LLMs — fetches any URL as clean markdown"

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ This tool includes browser cookie extraction and fingerprint spoofing capabiliti
 
 **MCP server not connecting?** Run `nab-mcp` directly in your terminal to see errors. Verify the binary exists with `which nab-mcp`. If installed via `cargo install nab`, both `nab` and `nab-mcp` should be on your `$PATH`.
 
-**Cookie extraction failing?** Grant Full Disk Access to your terminal in **System Settings > Privacy & Security > Full Disk Access** (macOS). Browser cookies are stored in protected directories. Use `--cookies brave` to target a specific browser. Background tools that must never show a Keychain authorization dialog can run `NAB_KEYCHAIN_INTERACTION=never nab ...`; this fails closed instead of invoking a prompt-capable fallback.
+**Cookie extraction failing?** Grant Full Disk Access to your terminal in **System Settings > Privacy & Security > Full Disk Access** (macOS). Browser cookies are stored in protected directories. Use `--cookies brave` to target a specific browser. Background tools that must never show a Keychain authorization dialog can run `NAB_KEYCHAIN_INTERACTION=never nab ...`. Plaintext cookies and credentials that macOS can provide silently still work; credentials that require approval are unavailable, and Nab fails closed instead of invoking a prompt-capable fallback.
 
 **ASR model not found?** Run `nab models fetch fluidaudio` to download the model (~542 MB). The model directory is `~/.nab/models/`. Use `nab models list` to see what's installed.
 

--- a/man/nab.1
+++ b/man/nab.1
@@ -152,6 +152,8 @@ HTTPS proxy URL.
 .B NAB_KEYCHAIN_INTERACTION
 Set to \fBnever\fR for background automation. macOS Keychain reads cannot open
 authorization UI, and the prompt-capable Python cookie fallback is disabled.
+Plaintext cookies and Keychain credentials available without UI still work;
+credentials requiring approval are unavailable.
 .TP
 .B ANTHROPIC_API_KEY
 Claude API key for video vision analysis (\fBanalyze\fR command).


### PR DESCRIPTION
## Summary

- bump Nab from 0.12.0 to 0.12.1
- document the zero-dialog background Keychain contract delivered by #258
- clarify that plaintext cookies and silently accessible Keychain credentials still work, while credentials requiring approval are unavailable
- keep Cargo.toml and Cargo.lock release metadata aligned

## Validation

- cargo metadata --locked --no-deps reports Nab 0.12.1
- cargo fmt --all -- --check passes
- cargo check --locked --lib passes
- git diff --check passes

The implementation was already validated in #258 with 65 focused cookie tests, 1,402 full-library tests with 7 ignored, all-target Clippy, an independent review, and a green required CI Gate.
