### PR TITLE
test: make default suite environment-hermetic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,10 @@ jobs:
             os: macos-14
             command: cargo test --locked --lib
             net_tests: "0"
+          - name: windows-cli-fetch
+            os: windows-latest
+            command: cargo test --locked --test cli_fetch
+            net_tests: "0"
           - name: yara-engine
             os: ubuntu-latest
             command: cargo test --locked -p nab-yara-engine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,9 @@ jobs:
             os: macos-14
             command: cargo test --locked --lib
             net_tests: "0"
-          - name: windows-cli-fetch
+          - name: windows-cli-hermetic
             os: windows-latest
-            command: cargo test --locked --test cli_fetch
+            command: cargo test --locked --test cli_fetch --test cli_auth
             net_tests: "0"
           - name: yara-engine
             os: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,22 +89,30 @@ jobs:
             os: ubuntu-latest
             command: cargo test --locked
             net_tests: "0"
+            rustflags: -Dwarnings
           - name: macos-lib
             os: macos-14
             command: cargo test --locked --lib
             net_tests: "0"
+            rustflags: -Dwarnings
           - name: windows-cli-hermetic
             os: windows-latest
             command: cargo test --locked --test cli_fetch --test cli_auth
             net_tests: "0"
+            # Session persistence is intentionally disabled on Windows until
+            # per-user ACL hardening lands, leaving its helpers dormant there.
+            # Keep their warnings visible without blocking these integration tests.
+            rustflags: ""
           - name: yara-engine
             os: ubuntu-latest
             command: cargo test --locked -p nab-yara-engine
             net_tests: "0"
+            rustflags: -Dwarnings
           - name: task-feature
             os: ubuntu-latest
             command: cargo test --locked --features task --lib --bin nab task
             net_tests: "0"
+            rustflags: -Dwarnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -112,6 +120,7 @@ jobs:
       - run: ${{ matrix.command }}
         env:
           NAB_NET_TESTS: ${{ matrix.net_tests }}
+          RUSTFLAGS: ${{ matrix.rustflags }}
 
   build:
     name: Build (${{ matrix.name }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,8 @@ jobs:
           key: test-${{ matrix.os }}
       - name: Run tests
         run: cargo test --locked --workspace
+        env:
+          NAB_NET_TESTS: "0"
 
   build:
     name: Build ${{ matrix.target }}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -13,11 +13,23 @@ pub mod cookies;
 
 pub use cookies::{CookieSource, CredentialRetriever, CredentialSource};
 
+use std::ffi::OsString;
 use std::process::Command;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
+
+pub(crate) const OP_BIN_ENV: &str = "NAB_OP_BIN";
+pub(crate) const MCP_CLI_BIN_ENV: &str = "NAB_MCP_CLI_BIN";
+
+pub(crate) fn op_command() -> OsString {
+    std::env::var_os(OP_BIN_ENV).unwrap_or_else(|| OsString::from("op"))
+}
+
+fn mcp_cli_command() -> OsString {
+    std::env::var_os(MCP_CLI_BIN_ENV).unwrap_or_else(|| OsString::from("mcp-cli"))
+}
 
 /// OTP (One-Time Password) with source information.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -112,7 +124,7 @@ impl OnePasswordAuth {
     /// Check if 1Password CLI is available and authenticated.
     #[must_use]
     pub fn is_available() -> bool {
-        Command::new("op")
+        Command::new(op_command())
             .args(["account", "list"])
             .output()
             .is_ok_and(|o| o.status.success())
@@ -127,7 +139,7 @@ impl OnePasswordAuth {
 
         debug!("Searching 1Password for domain: {}", domain);
 
-        let mut cmd = Command::new("op");
+        let mut cmd = Command::new(op_command());
         cmd.args(["item", "list", "--format=json"]);
         if let Some(ref vault) = self.vault {
             cmd.args(["--vault", vault]);
@@ -172,7 +184,7 @@ impl OnePasswordAuth {
 
         debug!("Listing all 1Password credentials for domain: {}", domain);
 
-        let mut cmd = Command::new("op");
+        let mut cmd = Command::new(op_command());
         cmd.args(["item", "list", "--format=json"]);
         if let Some(ref vault) = self.vault {
             cmd.args(["--vault", vault]);
@@ -208,7 +220,7 @@ impl OnePasswordAuth {
     fn get_item_details(item_id: &str) -> Result<Option<Credential>> {
         debug!("Getting 1Password item details: {}", item_id);
 
-        let output = Command::new("op")
+        let output = Command::new(op_command())
             .args(["item", "get", item_id, "--format=json"])
             .output()
             .context("Failed to run 'op item get'")?;
@@ -278,7 +290,7 @@ impl OnePasswordAuth {
 
     /// Get current TOTP code for an item.
     fn get_totp_code(item_id: &str) -> Result<Option<String>> {
-        let output = Command::new("op")
+        let output = Command::new(op_command())
             .args(["item", "get", item_id, "--otp"])
             .output()
             .context("Failed to get TOTP")?;
@@ -309,7 +321,7 @@ impl OnePasswordAuth {
 
     /// Get TOTP directly by item title.
     pub fn get_totp_by_title(&self, title: &str) -> Result<Option<OtpCode>> {
-        let output = Command::new("op")
+        let output = Command::new(op_command())
             .args(["item", "get", title, "--otp"])
             .output()
             .context("Failed to get TOTP")?;
@@ -330,7 +342,7 @@ impl OnePasswordAuth {
 
     /// List all available passkeys.
     pub fn list_passkeys(&self) -> Result<Vec<Credential>> {
-        let mut cmd = Command::new("op");
+        let mut cmd = Command::new(op_command());
         cmd.args(["item", "list", "--categories=Passkey", "--format=json"]);
         if let Some(ref vault) = self.vault {
             cmd.args(["--vault", vault]);
@@ -386,7 +398,7 @@ impl OtpRetriever {
 
     #[allow(clippy::unnecessary_wraps)]
     fn get_sms_otp(domain: &str) -> Result<Option<OtpCode>> {
-        let output = Command::new("mcp-cli")
+        let output = Command::new(mcp_cli_command())
             .args([
                 "beeper/search_messages",
                 &format!(r#"{{"query": "{domain} code OR {domain} verification", "limit": 5}}"#),
@@ -411,7 +423,7 @@ impl OtpRetriever {
 
     #[allow(clippy::unnecessary_wraps)]
     fn get_email_otp(domain: &str) -> Result<Option<OtpCode>> {
-        let output = Command::new("mcp-cli")
+        let output = Command::new(mcp_cli_command())
             .args([
                 "gmail/search_emails",
                 &format!(
@@ -469,14 +481,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn op_available_check_does_not_panic() {
-        let available = OnePasswordAuth::is_available();
-        println!("1Password CLI available: {available}");
+    fn otp_extraction_recognizes_common_code_formats() {
+        assert_eq!(
+            OtpRetriever::extract_otp_from_text("verification code: 123456"),
+            Some("123456".to_owned())
+        );
+        assert_eq!(
+            OtpRetriever::extract_otp_from_text("OTP 123-456"),
+            Some("123456".to_owned())
+        );
     }
 
     #[test]
-    fn otp_extraction_compiles_and_does_not_panic() {
-        // Verifies the regex patterns compile correctly
-        let _ = OnePasswordAuth::is_available();
+    fn otp_extraction_rejects_unrelated_text() {
+        assert_eq!(
+            OtpRetriever::extract_otp_from_text("there is no code here"),
+            None
+        );
     }
 }

--- a/src/fetch_bridge.rs
+++ b/src/fetch_bridge.rs
@@ -23,6 +23,16 @@ use url::Url;
 
 use crate::ssrf::{self, DEFAULT_MAX_REDIRECTS};
 
+fn resolve_fetch_url(url: String, base_url: &str) -> String {
+    if url.starts_with("http://") || url.starts_with("https://") {
+        url
+    } else if url.starts_with('/') && !base_url.is_empty() {
+        format!("{base_url}{url}")
+    } else {
+        url
+    }
+}
+
 /// HTTP client wrapper for fetch bridge
 #[derive(Clone)]
 pub struct FetchClient {
@@ -90,13 +100,7 @@ impl FetchClient {
     /// - Caps redirect chain at 5 hops
     pub fn fetch_sync(&self, url: String) -> Result<String> {
         // Resolve relative URLs against base_url
-        let full_url = if url.starts_with("http://") || url.starts_with("https://") {
-            url
-        } else if url.starts_with('/') && !self.base_url.is_empty() {
-            format!("{}{}", self.base_url, url)
-        } else {
-            url
-        };
+        let full_url = resolve_fetch_url(url, &self.base_url);
 
         // Parse URL for SSRF validation
         let mut current_url: Url = full_url
@@ -460,30 +464,19 @@ mod tests {
     #[test]
     fn fetch_sync_resolves_relative_url_with_base() {
         let client = FetchClient::new(None, Some("https://example.com".to_string()));
-        // This will fail at network level (example.com), but should pass URL resolution
-        let result = client.fetch_sync("/api/data".to_string());
-        // Check that the error is NOT about invalid URL format
-        if let Err(e) = result {
-            let err_str = e.to_string();
-            assert!(
-                !err_str.contains("Invalid URL"),
-                "Should not fail on URL parsing for relative URLs with base_url"
-            );
-        }
+        assert_eq!(
+            resolve_fetch_url("/api/data".to_owned(), &client.base_url),
+            "https://example.com/api/data"
+        );
     }
 
     #[test]
     fn fetch_sync_accepts_absolute_url() {
         let client = FetchClient::new(None, None);
-        // This will fail at network level, but URL should be valid
-        let result = client.fetch_sync("https://example.com".to_string());
-        if let Err(e) = result {
-            let err_str = e.to_string();
-            assert!(
-                !err_str.contains("Invalid URL"),
-                "Should not fail on URL parsing for absolute URLs"
-            );
-        }
+        assert_eq!(
+            resolve_fetch_url("https://example.com".to_owned(), &client.base_url),
+            "https://example.com"
+        );
     }
 
     #[test]

--- a/src/fetch_bridge.rs
+++ b/src/fetch_bridge.rs
@@ -454,9 +454,9 @@ mod tests {
     #[test]
     fn fetch_sync_blocks_ftp_scheme() {
         let client = FetchClient::new(None, None);
-        let result = client.fetch_sync("ftp://internal.server/data".to_string());
+        let result = client.fetch_sync("ftp://93.184.216.34/data".to_string());
         assert!(result.is_err());
-        // Should fail at SSRF validation (no host_str) or connection
+        // The unsupported scheme must be rejected without a DNS lookup.
     }
 
     // ─── Relative URL resolution tests ───────────────────────────────────

--- a/src/fingerprint/autoupdate.rs
+++ b/src/fingerprint/autoupdate.rs
@@ -233,21 +233,31 @@ impl BrowserVersions {
                 std::thread::sleep(std::time::Duration::from_millis(delay_ms));
             }
 
-            match reqwest::blocking::get(url) {
-                Ok(resp) => match resp.error_for_status() {
-                    Ok(resp) => match resp.json::<serde_json::Value>() {
-                        Ok(json) => return Ok(json),
-                        Err(e) => last_error = Some(format!("JSON parse error: {e}")),
-                    },
-                    Err(e) => last_error = Some(format!("HTTP error: {e}")),
-                },
-                Err(e) => last_error = Some(format!("Network error: {e}")),
+            // `reqwest::blocking` owns an internal Tokio runtime. Browser
+            // profiles are lazily initialized from async request paths, and
+            // dropping that internal runtime on a Tokio worker panics. Keep
+            // the complete blocking request lifecycle on a plain OS thread.
+            let url = url.to_owned();
+            match std::thread::spawn(move || Self::fetch_json_once(&url)).join() {
+                Ok(Ok(json)) => return Ok(json),
+                Ok(Err(error)) => last_error = Some(error),
+                Err(_) => last_error = Some("Version-fetch worker panicked".to_string()),
             }
         }
 
         Err(last_error
             .unwrap_or_else(|| "Unknown error".to_string())
             .into())
+    }
+
+    fn fetch_json_once(url: &str) -> Result<serde_json::Value, String> {
+        let response = reqwest::blocking::get(url).map_err(|e| format!("Network error: {e}"))?;
+        let response = response
+            .error_for_status()
+            .map_err(|e| format!("HTTP error: {e}"))?;
+        response
+            .json::<serde_json::Value>()
+            .map_err(|e| format!("JSON parse error: {e}"))
     }
 
     fn fetch_firefox_versions() -> Result<Vec<String>, Box<dyn std::error::Error>> {
@@ -351,6 +361,8 @@ impl Default for BrowserVersions {
 mod tests {
     use super::*;
     use chrono::Duration;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
 
     /// Floor for the bundled-default Chrome major version.
     ///
@@ -489,6 +501,37 @@ mod tests {
             versions,
             vec!["136.0", "135.0", "134.0", "133.0", "132.0", "131.0"]
         );
+    }
+
+    #[test]
+    fn blocking_version_fetch_is_safe_inside_tokio_runtime() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind local HTTP server");
+        let address = listener.local_addr().expect("read local HTTP address");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept version request");
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).expect("read version request");
+            let body = r#"{"versions":[]}"#;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .expect("write version response");
+        });
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build Tokio runtime");
+        let response = runtime
+            .block_on(async { BrowserVersions::fetch_with_retry(&format!("http://{address}"), 1) });
+
+        assert_eq!(
+            response.expect("fetch JSON")["versions"],
+            serde_json::json!([])
+        );
+        server.join().expect("local HTTP server should finish");
     }
 
     #[test]

--- a/src/http3_client.rs
+++ b/src/http3_client.rs
@@ -263,6 +263,7 @@ mod tests {
     use crate::fingerprint::chrome_profile;
 
     #[tokio::test]
+    #[ignore = "requires live network; run explicitly with --ignored"]
     async fn test_h3_detection() {
         // Cloudflare always supports H3
         let supports = Http3Client::supports_h3("https://cloudflare.com").await;
@@ -271,6 +272,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires live network; run explicitly with --ignored"]
     async fn test_h3_fetch() {
         let profile = chrome_profile();
         let client = Http3Client::new(profile).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -940,9 +940,32 @@ enum ModelsAction {
     Verify,
 }
 
+#[cfg(not(windows))]
 #[tokio::main]
-#[allow(clippy::too_many_lines)] // Main function dispatches to all commands; cannot be split
 async fn main() -> Result<()> {
+    run_cli().await
+}
+
+#[cfg(windows)]
+fn main() -> Result<()> {
+    const WINDOWS_CLI_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+    std::thread::Builder::new()
+        .name("nab-cli".to_string())
+        .stack_size(WINDOWS_CLI_STACK_SIZE)
+        .spawn(|| {
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()?
+                .block_on(run_cli())
+        })
+        .map_err(|error| anyhow::anyhow!("Failed to start Nab CLI thread: {error}"))?
+        .join()
+        .map_err(|_| anyhow::anyhow!("Nab CLI thread panicked"))?
+}
+
+#[allow(clippy::too_many_lines)] // Main command dispatcher; splitting obscures exhaustive routing.
+async fn run_cli() -> Result<()> {
     let cli = Cli::parse();
 
     // Initialize logging. `nab context` defaults to ERROR-only for clean

--- a/src/mfa.rs
+++ b/src/mfa.rs
@@ -13,7 +13,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
-use crate::auth::{OnePasswordAuth, OtpRetriever, OtpSource};
+use crate::auth::{OnePasswordAuth, OtpRetriever, OtpSource, op_command};
 
 /// Type of MFA challenge detected
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -241,7 +241,7 @@ impl MfaHandler {
 
         // Try using op CLI to sign (if supported)
         debug!("Attempting passkey sign via 1Password CLI");
-        let output = Command::new("op")
+        let output = Command::new(op_command())
             .args(["item", "list", "--categories=Passkey", "--format=json"])
             .output();
 

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -374,6 +374,7 @@ mod tests {
     // -- Integration test (network-dependent) --
 
     #[tokio::test]
+    #[ignore = "requires external echo.websocket.org"]
     async fn test_websocket_echo() {
         // Install crypto provider for rustls
         let _ = rustls::crypto::ring::default_provider().install_default();

--- a/tests/cli_auth.rs
+++ b/tests/cli_auth.rs
@@ -9,7 +9,6 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
-use std::path::Path;
 use tempfile::TempDir;
 
 /// Helper: get a Command for the `nab` binary.
@@ -19,37 +18,12 @@ fn nab() -> Command {
 
 fn isolate_external_tools(command: &mut Command) -> TempDir {
     let tool_dir = tempfile::tempdir().expect("create isolated tool directory");
-    write_failing_tool(tool_dir.path(), "op");
-    write_failing_tool(tool_dir.path(), "mcp-cli");
-
-    let mut paths = vec![tool_dir.path().to_path_buf()];
-    if let Some(path) = std::env::var_os("PATH") {
-        paths.extend(std::env::split_paths(&path));
-    }
+    command.env("NAB_OP_BIN", tool_dir.path().join("op-unavailable"));
     command.env(
-        "PATH",
-        std::env::join_paths(paths).expect("build isolated PATH"),
+        "NAB_MCP_CLI_BIN",
+        tool_dir.path().join("mcp-cli-unavailable"),
     );
     tool_dir
-}
-
-#[cfg(unix)]
-fn write_failing_tool(directory: &Path, name: &str) {
-    use std::os::unix::fs::PermissionsExt;
-
-    let path = directory.join(name);
-    std::fs::write(&path, "#!/bin/sh\nexit 1\n").expect("write failing tool stub");
-    let mut permissions = std::fs::metadata(&path)
-        .expect("read failing tool metadata")
-        .permissions();
-    permissions.set_mode(0o755);
-    std::fs::set_permissions(path, permissions).expect("make failing tool executable");
-}
-
-#[cfg(windows)]
-fn write_failing_tool(directory: &Path, name: &str) {
-    std::fs::write(directory.join(format!("{name}.cmd")), "@exit /b 1\r\n")
-        .expect("write failing tool stub");
 }
 
 // ─── Auth command ────────────────────────────────────────────────────────────

--- a/tests/cli_auth.rs
+++ b/tests/cli_auth.rs
@@ -1,17 +1,55 @@
 //! Integration tests for the `nab auth` and `nab otp` commands.
 //!
-//! These commands interact with 1Password and system-level OTP sources,
-//! so we test only argument parsing and graceful degradation when the
-//! external tools are not available.
+//! These commands interact with 1Password and system-level OTP sources in
+//! production. Tests shadow those tools with deterministic failing stubs so
+//! the default suite can only exercise graceful degradation and never invoke
+//! the user's real credential tools.
 
 #![allow(deprecated)] // cargo_bin deprecation — replacement not yet stable
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::path::Path;
+use tempfile::TempDir;
 
 /// Helper: get a Command for the `nab` binary.
 fn nab() -> Command {
     Command::cargo_bin("nab").expect("binary 'nab' should be built")
+}
+
+fn isolate_external_tools(command: &mut Command) -> TempDir {
+    let tool_dir = tempfile::tempdir().expect("create isolated tool directory");
+    write_failing_tool(tool_dir.path(), "op");
+    write_failing_tool(tool_dir.path(), "mcp-cli");
+
+    let mut paths = vec![tool_dir.path().to_path_buf()];
+    if let Some(path) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&path));
+    }
+    command.env(
+        "PATH",
+        std::env::join_paths(paths).expect("build isolated PATH"),
+    );
+    tool_dir
+}
+
+#[cfg(unix)]
+fn write_failing_tool(directory: &Path, name: &str) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = directory.join(name);
+    std::fs::write(&path, "#!/bin/sh\nexit 1\n").expect("write failing tool stub");
+    let mut permissions = std::fs::metadata(&path)
+        .expect("read failing tool metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("make failing tool executable");
+}
+
+#[cfg(windows)]
+fn write_failing_tool(directory: &Path, name: &str) {
+    std::fs::write(directory.join(format!("{name}.cmd")), "@exit /b 1\r\n")
+        .expect("write failing tool stub");
 }
 
 // ─── Auth command ────────────────────────────────────────────────────────────
@@ -27,10 +65,11 @@ fn auth_missing_url_fails() {
 
 #[test]
 fn auth_runs_without_crash() {
-    // The auth command calls 1Password CLI which may block waiting for
-    // authentication.  We use .output() with a timeout so the test
-    // always completes, then verify the process at least started.
-    let output = nab()
+    // Real credential tools are shadowed on PATH, so this exercises the
+    // deterministic unavailable-provider path without authentication UI.
+    let mut command = nab();
+    let _tool_dir = isolate_external_tools(&mut command);
+    let output = command
         .args(["auth", "https://example.com"])
         .timeout(std::time::Duration::from_secs(5))
         .output()
@@ -40,8 +79,7 @@ fn auth_runs_without_crash() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let combined = format!("{stdout}{stderr}");
 
-    // The command should at least print a search/credential message before
-    // the 1Password CLI potentially blocks.
+    // The command should report graceful unavailability without crashing.
     assert!(
         combined.contains("1Password")
             || combined.contains("credential")
@@ -64,8 +102,10 @@ fn otp_missing_domain_fails() {
 
 #[test]
 fn otp_runs_without_crash() {
-    // OTP command may call external tools that block.  Same pattern as auth.
-    let output = nab()
+    // All external OTP providers are shadowed on PATH.
+    let mut command = nab();
+    let _tool_dir = isolate_external_tools(&mut command);
+    let output = command
         .args(["otp", "example.com"])
         .timeout(std::time::Duration::from_secs(5))
         .output()
@@ -88,17 +128,17 @@ fn otp_runs_without_crash() {
 fn otp_accepts_url_format() {
     // The otp command should also work when given a full URL
     // (it strips down to domain internally).
-    let output = nab()
+    let mut command = nab();
+    let _tool_dir = isolate_external_tools(&mut command);
+    let output = command
         .args(["otp", "https://accounts.example.com/login"])
         .timeout(std::time::Duration::from_secs(5))
         .output()
         .expect("command should execute");
 
-    // Accept either success or timeout-interrupted (1Password may block).
-    // The key test is that it didn't panic or crash with a non-timeout error.
     assert!(
-        output.status.success() || output.status.code().is_none(), // None = killed by timeout
-        "otp should succeed or be interrupted, got: {:?}",
+        output.status.success(),
+        "otp should degrade cleanly: {:?}",
         output.status
     );
 }

--- a/tests/cli_fetch.rs
+++ b/tests/cli_fetch.rs
@@ -1,26 +1,148 @@
 //! Integration tests for the `nab fetch` command.
 //!
-//! Uses httpbin.org for deterministic responses.  Tests that require network
-//! access are gated behind the `NAB_NET_TESTS` env var so CI can skip them
-//! when offline.
+//! Protocol-level request/response behavior uses a local deterministic proxy.
+//! Tests that genuinely require external network access are gated behind the
+//! `NAB_NET_TESTS` env var so CI can skip them when offline.
 
 #![allow(deprecated)] // cargo_bin deprecation — replacement not yet stable
+
+mod common;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
 use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 #[cfg(unix)]
 use std::process::Command as StdCommand;
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use common::{net_tests_enabled, net_tests_enabled_for};
 
 /// Helper: get a Command for the `nab` binary.
 fn nab() -> Command {
     Command::cargo_bin("nab").expect("binary 'nab' should be built")
 }
 
-/// Returns `true` when network integration tests are enabled.
-fn net_tests_enabled() -> bool {
-    // Default to running network tests unless explicitly disabled.
-    std::env::var("NAB_NET_TESTS").map_or(true, |v| v != "0" && v.to_lowercase() != "false")
+/// Public IP literal used as the logical destination for local proxy tests.
+///
+/// Using an IP literal avoids DNS, while routing through `spawn_test_proxy`
+/// prevents any connection to the address itself.
+const PROXY_TEST_ORIGIN: &str = "http://93.184.216.34";
+
+fn spawn_test_proxy<F>(response: &str, inspect_request: F) -> (String, Receiver<Result<(), String>>)
+where
+    F: FnOnce(&str) + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local test proxy");
+    listener
+        .set_nonblocking(true)
+        .expect("make local test proxy nonblocking");
+    let address = listener
+        .local_addr()
+        .expect("read local test proxy address");
+    let response = response.to_owned();
+    let (result_sender, result_receiver) = mpsc::channel();
+
+    thread::spawn(move || {
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let deadline = Instant::now() + Duration::from_secs(15);
+            let (mut stream, _) = loop {
+                match listener.accept() {
+                    Ok(connection) => break connection,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        assert!(
+                            Instant::now() < deadline,
+                            "timed out waiting for proxied request"
+                        );
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("accept proxied request: {error}"),
+                }
+            };
+            stream
+                .set_read_timeout(Some(Duration::from_secs(10)))
+                .expect("set proxied request read timeout");
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 4096];
+
+            loop {
+                let read = stream.read(&mut buffer).expect("read proxied request");
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                assert!(
+                    request.len() <= 1024 * 1024,
+                    "proxied request exceeded 1 MiB"
+                );
+
+                let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n")
+                else {
+                    continue;
+                };
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().expect("valid content length"))
+                    })
+                    .unwrap_or(0);
+                if request.len() >= header_end + 4 + content_length {
+                    break;
+                }
+            }
+
+            let request = String::from_utf8(request).expect("HTTP request should be UTF-8");
+            inspect_request(&request);
+            stream
+                .write_all(response.as_bytes())
+                .expect("write proxy response");
+        }));
+
+        let outcome = outcome.map_err(|panic| {
+            panic.downcast_ref::<&str>().map_or_else(
+                || {
+                    panic.downcast_ref::<String>().map_or_else(
+                        || "test proxy panicked".to_owned(),
+                        std::clone::Clone::clone,
+                    )
+                },
+                |message| (*message).to_owned(),
+            )
+        });
+        let _ = result_sender.send(outcome);
+    });
+
+    (format!("http://{address}"), result_receiver)
+}
+
+fn wait_for_test_proxy(result: &Receiver<Result<(), String>>) {
+    result
+        .recv_timeout(Duration::from_secs(20))
+        .expect("test proxy should finish before its deadline")
+        .expect("test proxy should finish cleanly");
+}
+
+fn http_response(status: &str, body: &str) -> String {
+    format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    )
+}
+
+#[test]
+fn external_network_tests_are_explicitly_opt_in() {
+    assert!(!net_tests_enabled_for(None));
+    assert!(!net_tests_enabled_for(Some(std::ffi::OsStr::new("0"))));
+    assert!(!net_tests_enabled_for(Some(std::ffi::OsStr::new("false"))));
+    assert!(net_tests_enabled_for(Some(std::ffi::OsStr::new("1"))));
+    assert!(net_tests_enabled_for(Some(std::ffi::OsStr::new("TRUE"))));
+    assert!(net_tests_enabled_for(Some(std::ffi::OsStr::new("yes"))));
 }
 
 #[test]
@@ -285,11 +407,20 @@ fn fetch_custom_method_head() {
 
 #[test]
 fn fetch_custom_header() {
-    if !net_tests_enabled() {
-        return;
-    }
+    let body = r#"{"headers":{"X-Nab-Test":"integration"}}"#;
+    let (proxy_url, proxy_result) = spawn_test_proxy(&http_response("200 OK", body), |request| {
+        assert!(
+            request.starts_with("GET http://93.184.216.34/headers HTTP/1.1\r\n"),
+            "unexpected request line: {request}"
+        );
+        assert!(
+            request
+                .lines()
+                .any(|line| line.eq_ignore_ascii_case("X-Nab-Test: integration")),
+            "custom header missing from request: {request}"
+        );
+    });
 
-    // httpbin.org/headers echoes request headers in JSON
     nab()
         .args([
             "fetch",
@@ -299,12 +430,15 @@ fn fetch_custom_header() {
             "X-Nab-Test: integration",
             "--cookies",
             "none",
-            "https://httpbin.org/headers",
+            "--proxy",
+            &proxy_url,
+            &format!("{PROXY_TEST_ORIGIN}/headers"),
         ])
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(10))
         .assert()
         .success()
         .stdout(predicate::str::contains("X-Nab-Test"));
+    wait_for_test_proxy(&proxy_result);
 }
 
 #[test]
@@ -372,16 +506,26 @@ fn fetch_invalid_url_fails() {
 
 #[test]
 fn fetch_unreachable_host_fails() {
+    let (proxy_url, proxy_result) = spawn_test_proxy("", |request| {
+        assert!(
+            request.starts_with("GET http://93.184.216.34/disconnect HTTP/1.1\r\n"),
+            "unexpected request line: {request}"
+        );
+    });
+
     nab()
         .args([
             "fetch",
             "--cookies",
             "none",
-            "https://this-domain-does-not-exist-12345.example",
+            "--proxy",
+            &proxy_url,
+            &format!("{PROXY_TEST_ORIGIN}/disconnect"),
         ])
         .timeout(std::time::Duration::from_secs(15))
         .assert()
         .failure();
+    wait_for_test_proxy(&proxy_result);
 }
 
 // ─── Cookie flag parsing ─────────────────────────────────────────────────────
@@ -425,11 +569,14 @@ fn fetch_cookies_flag_accepts_browser_names() {
 
 #[test]
 fn fetch_no_redirect_captures_302() {
-    if !net_tests_enabled() {
-        return;
-    }
+    let response = "HTTP/1.1 302 Found\r\nLocation: http://93.184.216.34/final\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+    let (proxy_url, proxy_result) = spawn_test_proxy(response, |request| {
+        assert!(
+            request.starts_with("GET http://93.184.216.34/redirect/1 HTTP/1.1\r\n"),
+            "unexpected request line: {request}"
+        );
+    });
 
-    // httpbin.org/redirect/1 issues a 302 redirect
     nab()
         .args([
             "fetch",
@@ -438,23 +585,33 @@ fn fetch_no_redirect_captures_302() {
             "compact",
             "--cookies",
             "none",
-            "https://httpbin.org/redirect/1",
+            "--proxy",
+            &proxy_url,
+            &format!("{PROXY_TEST_ORIGIN}/redirect/1"),
         ])
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(10))
         .assert()
         .success()
         .stdout(predicate::str::is_match(r"^302 ").unwrap());
+    wait_for_test_proxy(&proxy_result);
 }
 
 // ─── POST with data ─────────────────────────────────────────────────────────
 
 #[test]
 fn fetch_post_with_data() {
-    if !net_tests_enabled() {
-        return;
-    }
+    let body = r#"{"json":{"key": "value"}}"#;
+    let (proxy_url, proxy_result) = spawn_test_proxy(&http_response("200 OK", body), |request| {
+        assert!(
+            request.starts_with("POST http://93.184.216.34/post HTTP/1.1\r\n"),
+            "unexpected request line: {request}"
+        );
+        assert!(
+            request.ends_with(r#"{"key":"value"}"#),
+            "POST body missing from request: {request}"
+        );
+    });
 
-    // httpbin.org/post echoes back the posted data
     nab()
         .args([
             "fetch",
@@ -466,13 +623,15 @@ fn fetch_post_with_data() {
             "--raw-html",
             "--cookies",
             "none",
-            "https://httpbin.org/post",
+            "--proxy",
+            &proxy_url,
+            &format!("{PROXY_TEST_ORIGIN}/post"),
         ])
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(10))
         .assert()
         .success()
-        // httpbin echoes posted data; the json field will contain parsed key/value
         .stdout(predicate::str::contains(r#""key": "value""#));
+    wait_for_test_proxy(&proxy_result);
 }
 
 #[cfg(unix)]

--- a/tests/cli_fetch.rs
+++ b/tests/cli_fetch.rs
@@ -31,6 +31,10 @@ fn nab() -> Command {
 /// Using an IP literal avoids DNS, while routing through `spawn_test_proxy`
 /// prevents any connection to the address itself.
 const PROXY_TEST_ORIGIN: &str = "http://93.184.216.34";
+const PROXY_ACCEPT_TIMEOUT: Duration = Duration::from_secs(15);
+const PROXY_READ_TIMEOUT: Duration = Duration::from_secs(15);
+const PROXY_COMMAND_TIMEOUT: Duration = Duration::from_secs(25);
+const PROXY_COMPLETION_TIMEOUT: Duration = Duration::from_secs(35);
 
 fn spawn_test_proxy<F>(response: &str, inspect_request: F) -> (String, Receiver<Result<(), String>>)
 where
@@ -48,7 +52,7 @@ where
 
     thread::spawn(move || {
         let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let deadline = Instant::now() + Duration::from_secs(15);
+            let deadline = Instant::now() + PROXY_ACCEPT_TIMEOUT;
             let (mut stream, _) = loop {
                 match listener.accept() {
                     Ok(connection) => break connection,
@@ -63,7 +67,10 @@ where
                 }
             };
             stream
-                .set_read_timeout(Some(Duration::from_secs(10)))
+                .set_nonblocking(false)
+                .expect("make proxied connection blocking");
+            stream
+                .set_read_timeout(Some(PROXY_READ_TIMEOUT))
                 .expect("set proxied request read timeout");
             let mut request = Vec::new();
             let mut buffer = [0_u8; 4096];
@@ -123,7 +130,7 @@ where
 
 fn wait_for_test_proxy(result: &Receiver<Result<(), String>>) {
     result
-        .recv_timeout(Duration::from_secs(20))
+        .recv_timeout(PROXY_COMPLETION_TIMEOUT)
         .expect("test proxy should finish before its deadline")
         .expect("test proxy should finish cleanly");
 }
@@ -434,7 +441,7 @@ fn fetch_custom_header() {
             &proxy_url,
             &format!("{PROXY_TEST_ORIGIN}/headers"),
         ])
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(PROXY_COMMAND_TIMEOUT)
         .assert()
         .success()
         .stdout(predicate::str::contains("X-Nab-Test"));
@@ -522,7 +529,7 @@ fn fetch_unreachable_host_fails() {
             &proxy_url,
             &format!("{PROXY_TEST_ORIGIN}/disconnect"),
         ])
-        .timeout(std::time::Duration::from_secs(15))
+        .timeout(PROXY_COMMAND_TIMEOUT)
         .assert()
         .failure();
     wait_for_test_proxy(&proxy_result);
@@ -589,7 +596,7 @@ fn fetch_no_redirect_captures_302() {
             &proxy_url,
             &format!("{PROXY_TEST_ORIGIN}/redirect/1"),
         ])
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(PROXY_COMMAND_TIMEOUT)
         .assert()
         .success()
         .stdout(predicate::str::is_match(r"^302 ").unwrap());
@@ -627,7 +634,7 @@ fn fetch_post_with_data() {
             &proxy_url,
             &format!("{PROXY_TEST_ORIGIN}/post"),
         ])
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(PROXY_COMMAND_TIMEOUT)
         .assert()
         .success()
         .stdout(predicate::str::contains(r#""key": "value""#));

--- a/tests/cli_spa.rs
+++ b/tests/cli_spa.rs
@@ -8,17 +8,15 @@
 
 #![allow(deprecated)] // cargo_bin deprecation — replacement not yet stable
 
+mod common;
+
 use assert_cmd::Command;
+use common::net_tests_enabled;
 use predicates::prelude::*;
 
 /// Helper: get a Command for the `nab` binary.
 fn nab() -> Command {
     Command::cargo_bin("nab").expect("binary 'nab' should be built")
-}
-
-/// Returns `true` when network integration tests are enabled.
-fn net_tests_enabled() -> bool {
-    std::env::var("NAB_NET_TESTS").map_or(true, |v| v != "0" && v.to_lowercase() != "false")
 }
 
 // ─── Argument validation ─────────────────────────────────────────────────────

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,14 @@
+use std::ffi::OsStr;
+
+pub fn net_tests_enabled() -> bool {
+    net_tests_enabled_for(std::env::var_os("NAB_NET_TESTS").as_deref())
+}
+
+pub fn net_tests_enabled_for(value: Option<&OsStr>) -> bool {
+    value.is_some_and(|value| {
+        matches!(
+            value.to_string_lossy().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes"
+        )
+    })
+}

--- a/tests/ssrf_tests.rs
+++ b/tests/ssrf_tests.rs
@@ -459,7 +459,7 @@ fn redirect_blocks_loopback() {
 
 #[test]
 fn redirect_allows_public_http() {
-    let url = Url::parse("https://example.com/page").unwrap();
+    let url = Url::parse("https://93.184.216.34/page").unwrap();
     assert!(validate_redirect_target(&url).is_ok());
 }
 

--- a/tests/ssrf_tests.rs
+++ b/tests/ssrf_tests.rs
@@ -423,6 +423,7 @@ fn validate_url_blocks_nat64_private() {
 }
 
 #[test]
+#[ignore = "requires external DNS resolution"]
 fn validate_url_resolves_public_hostname() {
     // example.com resolves to a public IP
     let url = Url::parse("https://example.com").unwrap();


### PR DESCRIPTION
Closes #259.
Closes #265.
Closes #268.

## What changed

- replace live `httpbin.org` protocol tests and DNS-based failure cases with a deterministic loopback proxy fixture
- keep the logical destination as a fixed public IP literal so the CLI follows its real SSRF-safe path without DNS or external HTTP
- assert the exact proxied request line, custom header, POST body, and redirect response
- restore blocking mode on accepted proxy connections and use ordered, bounded accept/read/child/completion deadlines
- centralize genuinely live CLI smoke tests behind explicit `NAB_NET_TESTS=1` opt-in
- ignore external DNS, HTTP/3, and WebSocket probes in the default suite
- replace URL-resolution tests that performed real fetches with pure URL assertions
- shadow `op` and `mcp-cli` with deterministic unavailable absolute paths in CLI auth tests so the suite never opens real credential UI
- require auth and OTP degradation tests to exit successfully instead of accepting timeout-killed children
- run both CLI fetch and auth targets on Windows CI, while explicitly disabling live tests in the release workflow
- run the large CLI dispatcher on an 8 MiB thread on Windows, preventing startup stack overflow while leaving non-Windows entrypoints unchanged

Production fetch, SSRF, cookie, and explicit credential behavior is unchanged.

## Validation

- reproduced the `v0.12.1` release failure in the live `httpbin.org` redirect test
- reproduced repeated 1Password unlock requests from the default `cli_auth` tests
- reproduced Windows startup stack overflow before command dispatch in all 5 `cli_auth` tests
- `cargo test --locked --test cli_auth`: 5 passed locally, with no new 1Password authentication prompt logged
- `cargo test --locked --test cli_fetch`: 24 passed locally
- focused loopback proxy tests: 4 passed
- `sandbox-exec` with external outbound denied and only localhost allowed, then `env -u NAB_NET_TESTS cargo test --locked --workspace -q`: full workspace and doctests passed
- full library result: 1,400 passed, 10 ignored at the hermetic-test head
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`

## Acceptance mapping

- default tests do not call live HTTP/DNS/WebSocket/HTTP3 services or real credential providers
- header, POST body, disconnect, and no-redirect behavior use deterministic local CLI tests
- auth and OTP degradation paths are cross-platform and cannot invoke the user's 1Password, Beeper, or Gmail tools
- proxy lifecycle operations are blocking after accept and have bounded, ordered deadlines
- Windows compiles and executes the CLI fixtures in CI without using the undersized main-thread stack
