### PR TITLE
fix(auth): minimize browser keychain prompts

### DIFF
--- a/src/auth/cookies/mod.rs
+++ b/src/auth/cookies/mod.rs
@@ -22,8 +22,9 @@ mod tests;
 
 use std::collections::HashMap;
 use std::process::Command;
-#[cfg(target_os = "macos")]
 use std::sync::Mutex;
+#[cfg(target_os = "macos")]
+use std::sync::OnceLock;
 
 use anyhow::{Context, Result};
 use tracing::{debug, info, warn};
@@ -43,6 +44,20 @@ enum KeychainInteraction {
     Allow,
     Never,
 }
+
+#[derive(Debug, Clone)]
+enum CachedKeychainKey {
+    Derived(Vec<u8>),
+    InteractiveFailure(String),
+}
+
+#[derive(Debug, Default)]
+struct KeychainKeyCache {
+    by_service: HashMap<&'static str, CachedKeychainKey>,
+}
+
+#[cfg(target_os = "macos")]
+static KEYCHAIN_KEY_CACHE: OnceLock<Mutex<KeychainKeyCache>> = OnceLock::new();
 
 fn keychain_interaction_from_env_value(value: Option<&str>) -> KeychainInteraction {
     match value.map(str::trim).map(str::to_ascii_lowercase).as_deref() {
@@ -80,14 +95,85 @@ where
     }
 }
 
+fn resolve_cookie_lookup_for_source<F>(
+    source: CookieSource,
+    native: Result<HashMap<String, String>>,
+    interaction: KeychainInteraction,
+    fallback: F,
+) -> Result<HashMap<String, String>>
+where
+    F: FnOnce() -> Result<HashMap<String, String>>,
+{
+    if source.native_cookie_result_is_authoritative() {
+        return native;
+    }
+    resolve_cookie_lookup(native, interaction, fallback)
+}
+
 #[cfg(target_os = "macos")]
 static KEYCHAIN_UI_LOCK: Mutex<()> = Mutex::new(());
 
-#[cfg(target_os = "macos")]
 fn lock_ignoring_poison<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
     mutex
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn load_cookie_key_cached<F>(
+    cache: &Mutex<KeychainKeyCache>,
+    service: &'static str,
+    interaction: KeychainInteraction,
+    load: F,
+) -> Result<Vec<u8>>
+where
+    F: FnOnce() -> Result<Vec<u8>>,
+{
+    let mut cache = lock_ignoring_poison(cache);
+    if let Some(entry) = cache.by_service.get(service) {
+        return match entry {
+            CachedKeychainKey::Derived(key) => Ok(key.clone()),
+            CachedKeychainKey::InteractiveFailure(message) => Err(anyhow::anyhow!(message.clone())),
+        };
+    }
+
+    match load() {
+        Ok(key) => {
+            cache
+                .by_service
+                .insert(service, CachedKeychainKey::Derived(key.clone()));
+            Ok(key)
+        }
+        Err(error) => {
+            if interaction == KeychainInteraction::Allow {
+                cache.by_service.insert(
+                    service,
+                    CachedKeychainKey::InteractiveFailure(error.to_string()),
+                );
+            }
+            Err(error)
+        }
+    }
+}
+
+fn load_first_usable_cookie_store<T, F, E>(
+    paths: &[std::path::PathBuf],
+    mut load: F,
+    is_empty: E,
+) -> Result<T>
+where
+    T: Default,
+    F: FnMut(&std::path::Path) -> Result<T>,
+    E: Fn(&T) -> bool,
+{
+    let mut first_error = None;
+    for path in paths {
+        match load(path) {
+            Ok(value) if !is_empty(&value) => return Ok(value),
+            Err(error) if first_error.is_none() => first_error = Some(error),
+            Ok(_) | Err(_) => {}
+        }
+    }
+    first_error.map_or_else(|| Ok(T::default()), Err)
 }
 
 fn cookie_rows_need_key(rows: &[db::CookieRow]) -> bool {
@@ -167,8 +253,13 @@ impl CookieSource {
     }
 
     /// Get the cookie database path for this browser.
+    #[cfg(test)]
     fn cookie_path(self) -> Option<std::path::PathBuf> {
-        platform_cookie_path(self)
+        platform_default_cookie_path(self)
+    }
+
+    fn cookie_paths(self) -> Vec<std::path::PathBuf> {
+        platform_cookie_paths(self)
     }
 
     /// Get the Keychain service name for this browser.
@@ -177,6 +268,18 @@ impl CookieSource {
             CookieSource::Brave => "Brave Safe Storage",
             CookieSource::Chrome => "Chrome Safe Storage",
             CookieSource::Firefox | CookieSource::Safari => "",
+        }
+    }
+
+    fn native_cookie_result_is_authoritative(self) -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            !self.keychain_service().is_empty()
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            false
         }
     }
 
@@ -192,8 +295,22 @@ impl CookieSource {
         if service.is_empty() {
             anyhow::bail!("Browser does not use Keychain encryption");
         }
-        let password = Self::read_keychain_password(service, interaction)?;
-        crypto::derive_cookie_key(&password)
+
+        let load = || {
+            let password = Self::read_keychain_password(service, interaction)?;
+            crypto::derive_cookie_key(&password)
+        };
+
+        #[cfg(target_os = "macos")]
+        {
+            let cache = KEYCHAIN_KEY_CACHE.get_or_init(|| Mutex::new(KeychainKeyCache::default()));
+            load_cookie_key_cached(cache, service, interaction, load)
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            load()
+        }
     }
 
     /// Read the raw password bytes from the macOS Keychain.
@@ -242,8 +359,12 @@ impl CookieSource {
     /// Get cookies for a domain from the specified browser.
     ///
     /// Tries native Rust extraction first and normally falls back to Python
-    /// `browser_cookie3`. When [`KEYCHAIN_INTERACTION_ENV`] forbids UI, the
-    /// Python fallback is skipped because it can perform a second Keychain read.
+    /// `browser_cookie3`. On macOS, native Chromium extraction covers the
+    /// established Chrome/Brave channels and their profile databases, so it is
+    /// authoritative even when no cookies are found: retrying through Python
+    /// could display a duplicate Keychain prompt for the same browser service.
+    /// When [`KEYCHAIN_INTERACTION_ENV`] forbids UI, the Python fallback is also
+    /// skipped because it can perform a second Keychain read.
     pub fn get_cookies(&self, domain: &str) -> Result<HashMap<String, String>> {
         self.get_cookies_with_interaction(domain, configured_keychain_interaction())
     }
@@ -256,6 +377,7 @@ impl CookieSource {
         debug!("Getting cookies for {} from {:?}", domain, self);
 
         let native = self.get_cookies_native(domain, interaction);
+        let native_is_authoritative = self.native_cookie_result_is_authoritative();
         match &native {
             Ok(cookies) if !cookies.is_empty() => {
                 info!(
@@ -263,17 +385,22 @@ impl CookieSource {
                     cookies.len()
                 );
             }
+            Ok(_) if native_is_authoritative => {
+                debug!("Native Chromium extraction completed; Python fallback disabled");
+            }
             Ok(_) if interaction == KeychainInteraction::Never => {
                 debug!("Native extraction returned empty; prompt-capable fallback disabled");
             }
             Ok(_) => debug!("Native extraction returned empty, trying Python fallback"),
-            Err(e) if interaction == KeychainInteraction::Never => {
+            Err(e) if native_is_authoritative || interaction == KeychainInteraction::Never => {
                 debug!("Native extraction failed; prompt-capable fallback disabled: {e}");
             }
             Err(e) => debug!("Native extraction failed: {e}, trying Python fallback"),
         }
 
-        resolve_cookie_lookup(native, interaction, || self.get_cookies_via_python(domain))
+        resolve_cookie_lookup_for_source(self, native, interaction, || {
+            self.get_cookies_via_python(domain)
+        })
     }
 
     /// Native Rust cookie extraction from the browser `SQLite` database.
@@ -288,15 +415,34 @@ impl CookieSource {
         domain: &str,
         interaction: KeychainInteraction,
     ) -> Result<HashMap<String, String>> {
-        let cookie_path = self
-            .cookie_path()
-            .context("Could not determine cookie path")?;
-        if !cookie_path.exists() {
-            warn!("Cookie database not found: {:?}", cookie_path);
+        let cookie_paths = self.cookie_paths();
+        let existing_paths = cookie_paths
+            .iter()
+            .filter(|path| path.exists())
+            .cloned()
+            .collect::<Vec<_>>();
+        if existing_paths.is_empty() {
+            warn!(
+                "Cookie database not found in candidates: {:?}",
+                cookie_paths
+            );
             return Ok(HashMap::new());
         }
 
-        let temp_db = copy_db_to_temp(&cookie_path)?;
+        load_first_usable_cookie_store(
+            &existing_paths,
+            |cookie_path| self.get_cookies_native_from_path(domain, interaction, cookie_path),
+            HashMap::is_empty,
+        )
+    }
+
+    fn get_cookies_native_from_path(
+        self,
+        domain: &str,
+        interaction: KeychainInteraction,
+        cookie_path: &std::path::Path,
+    ) -> Result<HashMap<String, String>> {
+        let temp_db = copy_db_to_temp(cookie_path)?;
         let extraction = (|| {
             let rows = query_cookie_db(&temp_db, domain)?;
             let needs_key = cookie_rows_need_key(&rows);
@@ -446,15 +592,34 @@ except Exception as e:
         domain: &str,
         interaction: KeychainInteraction,
     ) -> Result<Vec<PlaywrightCookie>> {
-        let cookie_path = self
-            .cookie_path()
-            .context("Could not determine cookie path")?;
-        if !cookie_path.exists() {
-            warn!("Cookie database not found: {:?}", cookie_path);
+        let cookie_paths = self.cookie_paths();
+        let existing_paths = cookie_paths
+            .iter()
+            .filter(|path| path.exists())
+            .cloned()
+            .collect::<Vec<_>>();
+        if existing_paths.is_empty() {
+            warn!(
+                "Cookie database not found in candidates: {:?}",
+                cookie_paths
+            );
             return Ok(Vec::new());
         }
 
-        let temp_db = copy_db_to_temp(&cookie_path)?;
+        load_first_usable_cookie_store(
+            &existing_paths,
+            |cookie_path| self.get_cookies_rich_native_from_path(domain, interaction, cookie_path),
+            Vec::is_empty,
+        )
+    }
+
+    fn get_cookies_rich_native_from_path(
+        self,
+        domain: &str,
+        interaction: KeychainInteraction,
+        cookie_path: &std::path::Path,
+    ) -> Result<Vec<PlaywrightCookie>> {
+        let temp_db = copy_db_to_temp(cookie_path)?;
         let extraction = (|| {
             let rows = query_cookie_db_rich(&temp_db, domain)?;
             let needs_key = rich_cookie_rows_need_key(&rows);
@@ -499,11 +664,92 @@ fn synthesize_cookie(name: String, value: String, domain: &str) -> PlaywrightCoo
     }
 }
 
+fn chromium_cookie_paths_under(roots: &[std::path::PathBuf]) -> Vec<std::path::PathBuf> {
+    let mut paths = Vec::new();
+    for root in roots {
+        let Ok(entries) = std::fs::read_dir(root) else {
+            continue;
+        };
+        let mut profiles = entries
+            .flatten()
+            .filter_map(|entry| {
+                entry
+                    .file_type()
+                    .ok()
+                    .filter(std::fs::FileType::is_dir)
+                    .map(|_| entry.path())
+            })
+            .collect::<Vec<_>>();
+        profiles.sort();
+        for profile in profiles {
+            for relative in ["Cookies", "Network/Cookies"] {
+                let candidate = profile.join(relative);
+                if candidate.is_file() {
+                    paths.push(candidate);
+                }
+            }
+        }
+    }
+    paths
+}
+
 #[cfg(target_os = "macos")]
-fn platform_cookie_path(source: CookieSource) -> Option<std::path::PathBuf> {
+fn macos_chromium_roots(
+    app_support: &std::path::Path,
+    source: CookieSource,
+) -> Vec<std::path::PathBuf> {
+    match source {
+        CookieSource::Chrome => [
+            "Google/Chrome",
+            "Google/Chrome Beta",
+            "Google/Chrome Dev",
+            "Google/Chrome Canary",
+            "Chromium",
+        ]
+        .map(|path| app_support.join(path))
+        .to_vec(),
+        CookieSource::Brave => [
+            "BraveSoftware/Brave-Browser",
+            "BraveSoftware/Brave-Browser-Beta",
+            "BraveSoftware/Brave-Browser-Dev",
+            "BraveSoftware/Brave-Browser-Nightly",
+        ]
+        .map(|path| app_support.join(path))
+        .to_vec(),
+        CookieSource::Firefox | CookieSource::Safari => Vec::new(),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn platform_cookie_paths(source: CookieSource) -> Vec<std::path::PathBuf> {
+    let Some(app_support) = dirs::config_dir() else {
+        return Vec::new();
+    };
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+
+    let roots = match source {
+        CookieSource::Brave | CookieSource::Chrome => macos_chromium_roots(&app_support, source),
+        CookieSource::Firefox => return vec![app_support.join("Firefox/Profiles")],
+        CookieSource::Safari => {
+            return vec![home.join("Library/Cookies/Cookies.binarycookies")];
+        }
+    };
+
+    let mut paths = chromium_cookie_paths_under(&roots);
+    if paths.is_empty()
+        && let Some(root) = roots.first()
+    {
+        paths.push(root.join("Default/Cookies"));
+    }
+    paths
+}
+
+#[cfg(all(test, target_os = "macos"))]
+fn platform_default_cookie_path(source: CookieSource) -> Option<std::path::PathBuf> {
     let app_support = dirs::config_dir()?;
     let home = dirs::home_dir()?;
-
     Some(match source {
         CookieSource::Brave => app_support.join("BraveSoftware/Brave-Browser/Default/Cookies"),
         CookieSource::Chrome => app_support.join("Google/Chrome/Default/Cookies"),
@@ -513,35 +759,63 @@ fn platform_cookie_path(source: CookieSource) -> Option<std::path::PathBuf> {
 }
 
 #[cfg(target_os = "linux")]
-fn platform_cookie_path(source: CookieSource) -> Option<std::path::PathBuf> {
-    let config_dir = dirs::config_dir()?;
-    let home = dirs::home_dir()?;
+fn platform_cookie_paths(source: CookieSource) -> Vec<std::path::PathBuf> {
+    let Some(config_dir) = dirs::config_dir() else {
+        return Vec::new();
+    };
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
 
     match source {
-        CookieSource::Brave => Some(config_dir.join("BraveSoftware/Brave-Browser/Default/Cookies")),
-        CookieSource::Chrome => Some(config_dir.join("google-chrome/Default/Cookies")),
-        CookieSource::Firefox => Some(home.join(".mozilla/firefox")),
-        CookieSource::Safari => None,
+        CookieSource::Brave => vec![config_dir.join("BraveSoftware/Brave-Browser/Default/Cookies")],
+        CookieSource::Chrome => vec![config_dir.join("google-chrome/Default/Cookies")],
+        CookieSource::Firefox => vec![home.join(".mozilla/firefox")],
+        CookieSource::Safari => Vec::new(),
     }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+fn platform_default_cookie_path(source: CookieSource) -> Option<std::path::PathBuf> {
+    platform_cookie_paths(source).into_iter().next()
 }
 
 #[cfg(target_os = "windows")]
-fn platform_cookie_path(source: CookieSource) -> Option<std::path::PathBuf> {
-    let local_data = dirs::data_local_dir()?;
-    let config_dir = dirs::config_dir()?;
+fn platform_cookie_paths(source: CookieSource) -> Vec<std::path::PathBuf> {
+    let Some(local_data) = dirs::data_local_dir() else {
+        return Vec::new();
+    };
+    let Some(config_dir) = dirs::config_dir() else {
+        return Vec::new();
+    };
 
     match source {
         CookieSource::Brave => {
-            Some(local_data.join("BraveSoftware/Brave-Browser/User Data/Default/Cookies"))
+            vec![local_data.join("BraveSoftware/Brave-Browser/User Data/Default/Cookies")]
         }
-        CookieSource::Chrome => Some(local_data.join("Google/Chrome/User Data/Default/Cookies")),
-        CookieSource::Firefox => Some(config_dir.join("Mozilla/Firefox/Profiles")),
-        CookieSource::Safari => None,
+        CookieSource::Chrome => {
+            vec![local_data.join("Google/Chrome/User Data/Default/Cookies")]
+        }
+        CookieSource::Firefox => vec![config_dir.join("Mozilla/Firefox/Profiles")],
+        CookieSource::Safari => Vec::new(),
     }
 }
 
+#[cfg(all(test, target_os = "windows"))]
+fn platform_default_cookie_path(source: CookieSource) -> Option<std::path::PathBuf> {
+    platform_cookie_paths(source).into_iter().next()
+}
+
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-fn platform_cookie_path(_source: CookieSource) -> Option<std::path::PathBuf> {
+fn platform_cookie_paths(_source: CookieSource) -> Vec<std::path::PathBuf> {
+    Vec::new()
+}
+
+#[cfg(all(
+    test,
+    not(any(target_os = "macos", target_os = "linux", target_os = "windows"))
+))]
+fn platform_default_cookie_path(_source: CookieSource) -> Option<std::path::PathBuf> {
     None
 }
 

--- a/src/auth/cookies/mod.rs
+++ b/src/auth/cookies/mod.rs
@@ -22,6 +22,7 @@ mod tests;
 
 use std::collections::HashMap;
 use std::process::Command;
+#[cfg(any(test, target_os = "macos"))]
 use std::sync::Mutex;
 #[cfg(target_os = "macos")]
 use std::sync::OnceLock;
@@ -46,12 +47,14 @@ enum KeychainInteraction {
 }
 
 #[derive(Debug, Clone)]
+#[cfg(any(test, target_os = "macos"))]
 enum CachedKeychainKey {
     Derived(Vec<u8>),
     InteractiveFailure(String),
 }
 
 #[derive(Debug, Default)]
+#[cfg(any(test, target_os = "macos"))]
 struct KeychainKeyCache {
     by_service: HashMap<&'static str, CachedKeychainKey>,
 }
@@ -113,12 +116,14 @@ where
 #[cfg(target_os = "macos")]
 static KEYCHAIN_UI_LOCK: Mutex<()> = Mutex::new(());
 
+#[cfg(any(test, target_os = "macos"))]
 fn lock_ignoring_poison<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
     mutex
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
+#[cfg(any(test, target_os = "macos"))]
 fn load_cookie_key_cached<F>(
     cache: &Mutex<KeychainKeyCache>,
     service: &'static str,
@@ -664,6 +669,26 @@ fn synthesize_cookie(name: String, value: String, domain: &str) -> PlaywrightCoo
     }
 }
 
+#[cfg(any(test, target_os = "macos"))]
+fn chromium_profile_sort_key(path: &std::path::Path) -> (u8, u64, String) {
+    let name = path
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .unwrap_or_default();
+    match name {
+        "Default" => (0, 0, String::new()),
+        "Guest Profile" => (1, 0, String::new()),
+        _ => name
+            .strip_prefix("Profile ")
+            .and_then(|number| number.parse::<u64>().ok())
+            .map_or_else(
+                || (3, 0, name.to_owned()),
+                |number| (2, number, String::new()),
+            ),
+    }
+}
+
+#[cfg(any(test, target_os = "macos"))]
 fn chromium_cookie_paths_under(roots: &[std::path::PathBuf]) -> Vec<std::path::PathBuf> {
     let mut paths = Vec::new();
     for root in roots {
@@ -680,7 +705,7 @@ fn chromium_cookie_paths_under(roots: &[std::path::PathBuf]) -> Vec<std::path::P
                     .map(|_| entry.path())
             })
             .collect::<Vec<_>>();
-        profiles.sort();
+        profiles.sort_by_key(|path| chromium_profile_sort_key(path));
         for profile in profiles {
             for relative in ["Cookies", "Network/Cookies"] {
                 let candidate = profile.join(relative);

--- a/src/auth/cookies/mod.rs
+++ b/src/auth/cookies/mod.rs
@@ -277,15 +277,7 @@ impl CookieSource {
     }
 
     fn native_cookie_result_is_authoritative(self) -> bool {
-        #[cfg(target_os = "macos")]
-        {
-            !self.keychain_service().is_empty()
-        }
-
-        #[cfg(not(target_os = "macos"))]
-        {
-            false
-        }
+        cfg!(target_os = "macos") && matches!(self, Self::Brave | Self::Chrome)
     }
 
     /// Get the raw Keychain password for this browser and derive the AES key.

--- a/src/auth/cookies/tests.rs
+++ b/src/auth/cookies/tests.rs
@@ -4,11 +4,14 @@
 
 #[cfg(target_os = "macos")]
 use super::lock_ignoring_poison;
+#[cfg(target_os = "macos")]
+use super::macos_chromium_roots;
 use super::{
-    CookieSource, KeychainInteraction, cookie_rows_need_key, crypto::*, db::*,
-    keychain_interaction_from_env_os_value, keychain_interaction_from_env_value,
-    load_cookie_domain_tag_if_needed, load_cookie_key_if_needed, resolve_cookie_lookup,
-    rich_cookie_rows_need_key,
+    CookieSource, KeychainInteraction, KeychainKeyCache, chromium_cookie_paths_under,
+    cookie_rows_need_key, crypto::*, db::*, keychain_interaction_from_env_os_value,
+    keychain_interaction_from_env_value, load_cookie_domain_tag_if_needed, load_cookie_key_cached,
+    load_cookie_key_if_needed, load_first_usable_cookie_store, resolve_cookie_lookup,
+    resolve_cookie_lookup_for_source, rich_cookie_rows_need_key,
 };
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────
@@ -112,6 +115,270 @@ fn keychain_service_brave_and_chrome_are_nonempty() {
 fn keychain_service_firefox_safari_are_empty() {
     assert!(CookieSource::Firefox.keychain_service().is_empty());
     assert!(CookieSource::Safari.keychain_service().is_empty());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn completed_chromium_native_lookup_is_authoritative_on_macos() {
+    assert!(
+        CookieSource::Chrome.native_cookie_result_is_authoritative(),
+        "Chrome must not retry through a second prompt-capable implementation"
+    );
+    assert!(
+        CookieSource::Brave.native_cookie_result_is_authoritative(),
+        "Brave must not retry through a second prompt-capable implementation"
+    );
+    assert!(!CookieSource::Firefox.native_cookie_result_is_authoritative());
+    assert!(!CookieSource::Safari.native_cookie_result_is_authoritative());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn repeated_chromium_native_errors_never_launch_python_fallback() {
+    let fallback_calls = std::cell::Cell::new(0);
+
+    for _ in 0..2 {
+        let error = resolve_cookie_lookup_for_source(
+            CookieSource::Chrome,
+            Err(anyhow::anyhow!("database unavailable before Keychain read")),
+            KeychainInteraction::Allow,
+            || {
+                fallback_calls.set(fallback_calls.get() + 1);
+                Ok(std::collections::HashMap::new())
+            },
+        )
+        .expect_err("the native diagnostic must remain authoritative");
+        assert!(error.to_string().contains("database unavailable"));
+    }
+
+    assert_eq!(fallback_calls.get(), 0, "Python could prompt on every call");
+}
+
+#[test]
+fn chromium_paths_cover_default_network_and_named_profiles() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let root = temp.path().join("Chrome");
+    for relative in [
+        "Default/Cookies",
+        "Default/Network/Cookies",
+        "Profile 1/Cookies",
+        "Profile 2/Network/Cookies",
+        "Guest Profile/Cookies",
+    ] {
+        let path = root.join(relative);
+        std::fs::create_dir_all(path.parent().expect("cookie parent")).expect("profile dir");
+        std::fs::write(path, b"sqlite placeholder").expect("cookie db placeholder");
+    }
+    std::fs::create_dir_all(root.join("System Profile")).expect("unrelated profile dir");
+
+    let paths = chromium_cookie_paths_under(std::slice::from_ref(&root));
+    for relative in [
+        "Default/Cookies",
+        "Default/Network/Cookies",
+        "Profile 1/Cookies",
+        "Profile 2/Network/Cookies",
+        "Guest Profile/Cookies",
+    ] {
+        assert!(paths.contains(&root.join(relative)), "missing {relative}");
+    }
+    assert_eq!(paths.len(), 5, "only real cookie databases are returned");
+    assert_eq!(paths[0], root.join("Default/Cookies"));
+    assert_eq!(paths[1], root.join("Default/Network/Cookies"));
+    assert_eq!(paths[2], root.join("Guest Profile/Cookies"));
+    assert_eq!(paths[3], root.join("Profile 1/Cookies"));
+    assert_eq!(paths[4], root.join("Profile 2/Network/Cookies"));
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_chromium_roots_cover_supported_channels_in_priority_order() {
+    let app_support = std::path::Path::new("/Library/Application Support");
+
+    assert_eq!(
+        macos_chromium_roots(app_support, CookieSource::Chrome),
+        [
+            "Google/Chrome",
+            "Google/Chrome Beta",
+            "Google/Chrome Dev",
+            "Google/Chrome Canary",
+            "Chromium",
+        ]
+        .map(|path| app_support.join(path))
+    );
+    assert_eq!(
+        macos_chromium_roots(app_support, CookieSource::Brave),
+        [
+            "BraveSoftware/Brave-Browser",
+            "BraveSoftware/Brave-Browser-Beta",
+            "BraveSoftware/Brave-Browser-Dev",
+            "BraveSoftware/Brave-Browser-Nightly",
+        ]
+        .map(|path| app_support.join(path))
+    );
+}
+
+#[test]
+fn cookie_store_selection_stops_at_first_usable_profile() {
+    let paths = ["empty", "profile-1", "profile-2"]
+        .map(std::path::PathBuf::from)
+        .to_vec();
+    let visited = std::cell::RefCell::new(Vec::new());
+
+    let cookies = load_first_usable_cookie_store(
+        &paths,
+        |path| {
+            visited.borrow_mut().push(path.to_path_buf());
+            let value = match path.to_string_lossy().as_ref() {
+                "empty" => std::collections::HashMap::new(),
+                "profile-1" => std::collections::HashMap::from([(
+                    "session".to_string(),
+                    "first-identity".to_string(),
+                )]),
+                _ => std::collections::HashMap::from([(
+                    "session".to_string(),
+                    "different-identity".to_string(),
+                )]),
+            };
+            Ok(value)
+        },
+        std::collections::HashMap::is_empty,
+    )
+    .expect("first usable profile");
+
+    assert_eq!(
+        cookies.get("session").map(String::as_str),
+        Some("first-identity")
+    );
+    assert_eq!(
+        visited.into_inner(),
+        paths[..2],
+        "later browser identities must not be read or merged"
+    );
+}
+
+#[test]
+fn successful_keychain_key_is_loaded_once_per_service() {
+    let cache = std::sync::Mutex::new(KeychainKeyCache::default());
+    let calls = std::cell::Cell::new(0);
+
+    for _ in 0..2 {
+        let key = load_cookie_key_cached(
+            &cache,
+            "Chrome Safe Storage",
+            KeychainInteraction::Allow,
+            || {
+                calls.set(calls.get() + 1);
+                Ok(vec![7; 16])
+            },
+        )
+        .expect("derived key should load");
+        assert_eq!(key, vec![7; 16]);
+    }
+
+    assert_eq!(calls.get(), 1, "the same service must prompt at most once");
+}
+
+#[test]
+fn interactive_keychain_failure_is_not_retried_in_process() {
+    let cache = std::sync::Mutex::new(KeychainKeyCache::default());
+    let calls = std::cell::Cell::new(0);
+
+    for _ in 0..2 {
+        let error = load_cookie_key_cached(
+            &cache,
+            "Chrome Safe Storage",
+            KeychainInteraction::Allow,
+            || {
+                calls.set(calls.get() + 1);
+                Err(anyhow::anyhow!("approval denied"))
+            },
+        )
+        .expect_err("denied lookup must remain unavailable");
+        assert!(error.to_string().contains("approval denied"));
+    }
+
+    assert_eq!(calls.get(), 1, "a denial must not trigger another prompt");
+}
+
+#[test]
+fn noninteractive_failure_does_not_block_later_interactive_lookup() {
+    let cache = std::sync::Mutex::new(KeychainKeyCache::default());
+    let calls = std::cell::Cell::new(0);
+
+    load_cookie_key_cached(
+        &cache,
+        "Chrome Safe Storage",
+        KeychainInteraction::Never,
+        || {
+            calls.set(calls.get() + 1);
+            Err(anyhow::anyhow!("interaction disabled"))
+        },
+    )
+    .expect_err("noninteractive lookup should fail closed");
+
+    let key = load_cookie_key_cached(
+        &cache,
+        "Chrome Safe Storage",
+        KeychainInteraction::Allow,
+        || {
+            calls.set(calls.get() + 1);
+            Ok(vec![9; 16])
+        },
+    )
+    .expect("explicit interactive lookup should still be attempted");
+
+    assert_eq!(key, vec![9; 16]);
+    assert_eq!(calls.get(), 2);
+}
+
+#[test]
+fn browser_keychain_services_have_independent_cache_entries() {
+    let cache = std::sync::Mutex::new(KeychainKeyCache::default());
+    let calls = std::cell::Cell::new(0);
+
+    for service in ["Chrome Safe Storage", "Brave Safe Storage"] {
+        load_cookie_key_cached(&cache, service, KeychainInteraction::Allow, || {
+            calls.set(calls.get() + 1);
+            Ok(vec![calls.get() as u8; 16])
+        })
+        .expect("each browser key should load");
+    }
+
+    assert_eq!(calls.get(), 2, "distinct services must not share keys");
+}
+
+#[test]
+fn concurrent_keychain_load_is_single_flight_per_service() {
+    let cache = std::sync::Arc::new(std::sync::Mutex::new(KeychainKeyCache::default()));
+    let calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+    let mut handles = Vec::new();
+
+    for _ in 0..2 {
+        let cache = std::sync::Arc::clone(&cache);
+        let calls = std::sync::Arc::clone(&calls);
+        let barrier = std::sync::Arc::clone(&barrier);
+        handles.push(std::thread::spawn(move || {
+            barrier.wait();
+            load_cookie_key_cached(
+                &cache,
+                "Chrome Safe Storage",
+                KeychainInteraction::Allow,
+                || {
+                    calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                    Ok(vec![3; 16])
+                },
+            )
+            .expect("derived key")
+        }));
+    }
+    barrier.wait();
+
+    for handle in handles {
+        assert_eq!(handle.join().expect("loader thread"), vec![3; 16]);
+    }
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
 }
 
 #[test]

--- a/src/auth/cookies/tests.rs
+++ b/src/auth/cookies/tests.rs
@@ -163,7 +163,9 @@ fn chromium_paths_cover_default_network_and_named_profiles() {
         "Default/Network/Cookies",
         "Profile 1/Cookies",
         "Profile 2/Network/Cookies",
+        "Profile 10/Cookies",
         "Guest Profile/Cookies",
+        "Alpha Profile/Cookies",
     ] {
         let path = root.join(relative);
         std::fs::create_dir_all(path.parent().expect("cookie parent")).expect("profile dir");
@@ -177,16 +179,20 @@ fn chromium_paths_cover_default_network_and_named_profiles() {
         "Default/Network/Cookies",
         "Profile 1/Cookies",
         "Profile 2/Network/Cookies",
+        "Profile 10/Cookies",
         "Guest Profile/Cookies",
+        "Alpha Profile/Cookies",
     ] {
         assert!(paths.contains(&root.join(relative)), "missing {relative}");
     }
-    assert_eq!(paths.len(), 5, "only real cookie databases are returned");
+    assert_eq!(paths.len(), 7, "only real cookie databases are returned");
     assert_eq!(paths[0], root.join("Default/Cookies"));
     assert_eq!(paths[1], root.join("Default/Network/Cookies"));
     assert_eq!(paths[2], root.join("Guest Profile/Cookies"));
     assert_eq!(paths[3], root.join("Profile 1/Cookies"));
     assert_eq!(paths[4], root.join("Profile 2/Network/Cookies"));
+    assert_eq!(paths[5], root.join("Profile 10/Cookies"));
+    assert_eq!(paths[6], root.join("Alpha Profile/Cookies"));
 }
 
 #[cfg(target_os = "macos")]

--- a/src/auth/cookies/tests.rs
+++ b/src/auth/cookies/tests.rs
@@ -6,12 +6,14 @@
 use super::lock_ignoring_poison;
 #[cfg(target_os = "macos")]
 use super::macos_chromium_roots;
+#[cfg(target_os = "macos")]
+use super::resolve_cookie_lookup_for_source;
 use super::{
     CookieSource, KeychainInteraction, KeychainKeyCache, chromium_cookie_paths_under,
     cookie_rows_need_key, crypto::*, db::*, keychain_interaction_from_env_os_value,
     keychain_interaction_from_env_value, load_cookie_domain_tag_if_needed, load_cookie_key_cached,
     load_cookie_key_if_needed, load_first_usable_cookie_store, resolve_cookie_lookup,
-    resolve_cookie_lookup_for_source, rich_cookie_rows_need_key,
+    rich_cookie_rows_need_key,
 };
 
 // ─── Test helpers ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- cache successful Chrome/Brave derived keys once per process and serialize concurrent first access
- cache an interactive denial once per browser service, while allowing a later interactive retry after a noninteractive miss
- keep Chrome and Brave credentials isolated
- use the native macOS cookie reader authoritatively so Python fallback cannot trigger a second Keychain prompt
- discover stable, Beta, Dev, Canary, and Nightly profile roots deterministically
- use the same candidate order for flat and rich extraction and stop at the first profile with usable cookies

Closes #266.

## UX outcome

The minimum feasible prompt count is now one per browser service per Nab process when macOS genuinely requires approval. Repeated provider calls and concurrent calls reuse the cached derived key and do not prompt again. If encrypted cookies are unavailable without interaction, noninteractive mode remains fail-closed and does not launch a prompt-capable fallback.

## Validation

- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`
- focused cookie suite: 75 passed
- independent review: no Critical or Important findings
