### PR TITLE
release: prepare v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-08-12
+
+### Fixed
+
+- macOS browser-cookie extraction now caches each Chrome or Brave derived key
+  once per Nab process and serializes concurrent first access. Repeated calls
+  no longer repeat Keychain authorization prompts, browser services remain
+  isolated, and the native reader is authoritative so a Python fallback cannot
+  trigger a second prompt. Profile discovery is deterministic across stable,
+  Beta, Dev, Canary, and Nightly installs.
+- Default CLI tests are hermetic and cannot open real 1Password or other
+  credential-provider UI. Live network probes are explicit opt-ins, protocol
+  coverage uses bounded loopback fixtures, and the Windows CLI dispatcher uses
+  an 8 MiB stack to prevent startup stack overflow.
+
+### Security
+
+- Updated Nab's optional Wasmtime runtime to 46.0.2 and refreshed vulnerable
+  transitive dependencies. The remaining Wasmtime 43 advisory is inherited
+  from `yara-x`, has no patched compatible release, and is tracked by #267 with
+  an exception that expires on 2026-09-01.
+
 ## [0.12.1] - 2026-08-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "nab"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "addr",
  "aes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nab"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2024"
 authors = ["Mikko Parkkola"]
 description = "Token-optimized HTTP client for LLMs — fetches any URL as clean markdown"


### PR DESCRIPTION
## Summary

- bump Nab package and lockfile metadata to 0.12.2
- document the per-process Chrome/Brave derived-key cache and single-flight prompt behavior
- document hermetic CLI tests and the Windows dispatcher stack fix
- document the patched direct Wasmtime runtime and time-boxed yara-x exception tracked by #267

## Validation

- cargo metadata --locked --no-deps reports 0.12.2
- cargo fmt --all -- --check
- cargo clippy --locked --all-targets -- -D warnings
- env -u NAB_NET_TESTS cargo test --locked --workspace
- osv-scanner scan source --config=.github/osv-scanner.toml --lockfile=Cargo.lock: no issues found after the two reviewed, time-boxed filters
- cargo publish --dry-run --locked --allow-dirty
- git diff --check

## Release

After exact-head CI passes and this PR is merged, tag v0.12.2 from the merge commit. The existing failed v0.12.1 tag remains untouched.