### PR TITLE
docs: align CLI, feature flag and SSRF docs with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,8 @@ Optional plugin configuration at `~/.config/nab/plugins.toml`. See [docs/getting
 | `HTTP_PROXY` / `http_proxy` | HTTP proxy URL |
 | `ALL_PROXY` / `all_proxy` | Proxy for all protocols |
 | `RUST_LOG` | Logging level (e.g., `nab=debug`) |
+| `NAB_SSRF_ALLOW_PRIVATE` | Set to `1`/`true` to allow fetching private/internal addresses (RFC 1918, IPv6 ULA, CGN). Off by default. Loopback and cloud-metadata addresses stay blocked |
+| `NAB_SSRF_ALLOWLIST` | Comma-separated CIDR/IP allowlist exempting only those private ranges (e.g. `10.252.0.0/16,192.168.1.5`). Empty by default; preferred over the blanket flag above |
 | `NAB_KEYCHAIN_INTERACTION` | Set to `never` for background automation: macOS Keychain reads cannot open UI, and prompt-capable Python cookie fallback is disabled |
 | `PUSHOVER_USER` / `PUSHOVER_TOKEN` | Pushover notifications for MFA |
 | `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` | Telegram notifications for MFA |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,9 +31,10 @@ This document describes the internal architecture of nab, a token-optimized web 
                                      │
 ┌────────────────────────────────────┼────────────────────────────────────┐
 │                         CLI (main.rs)                                   │
-│  Commands: fetch, fetch_batch, submit, login, auth, cookies, otp,      │
-│  spa, stream, analyze, annotate, fingerprint, bench, validate,         │
-│  export-rules, context                                                  │
+│  Commands: fetch, browser, spa, bench, fingerprint, auth, validate,     │
+│  doctor, otp, stream, analyze, annotate, submit, login, context,        │
+│  cookies, rules, provider, watch, models, upgrade, linkedin, mcp,       │
+│  task (built only with --features task)                                 │
 └────────────────────────────┬───────────────────────────────────────────┘
                              │
         ┌────────────────────┼────────────────────────────────┐
@@ -369,6 +370,7 @@ title = "h1.page-title"
 - DNS pinning via `resolve_and_validate()` to prevent DNS rebinding attacks
 - Redirect target validation before following each hop
 - Returns `NabError::SsrfBlocked` with descriptive reason
+- Two opt-in relaxations, both off by default: `NAB_SSRF_ALLOW_PRIVATE=1` (or `--allow-private-ips`) unblocks RFC 1918, IPv6 ULA and CGN addresses, and `NAB_SSRF_ALLOWLIST` (or repeated `--allow-private-ip <CIDR>`) unblocks only the listed ranges. Neither can unblock loopback, link-local/cloud-metadata, or any other always-denied range (`ssrf.rs:73-92`, `ssrf.rs:265-331`)
 
 **Used By**: All HTTP client fetch operations (validated before connection)
 
@@ -486,7 +488,8 @@ The CLI layer in `src/cmd/` maps each subcommand to its implementation:
 cmd/
 ├── mod.rs              # Command dispatch
 ├── fetch.rs            # Single URL fetch
-├── fetch_batch.rs      # Parallel multi-URL fetch
+├── fetch_batch.rs      # Parallel multi-URL fetch (`nab fetch --batch <file>`)
+├── browser.rs          # Render a JS-heavy URL through a configured CDP endpoint
 ├── submit.rs           # Form submission
 ├── login.rs            # Auto-login flow
 ├── auth.rs             # Credential lookup
@@ -500,7 +503,15 @@ cmd/
 ├── stream.rs           # Media streaming
 ├── spa.rs              # SPA data extraction
 ├── context.rs          # Context/session management
-├── export_rules.rs     # Export embedded rule configs
+├── doctor.rs           # Environment diagnosis (e.g. shadowed installs on PATH)
+├── watch.rs            # Monitor URLs for content changes
+├── models.rs           # Manage locally-built inference model binaries
+├── provider.rs         # WASM provider marketplace (install, list, remove)
+├── mcp.rs              # MCP server management (serve, install)
+├── linkedin.rs         # LinkedIn official data-archive export
+├── upgrade.rs          # Post-install migrations and release notes
+├── task.rs             # Experimental web-task engine (`--features task`)
+├── export_rules.rs     # Export embedded rule configs (`nab rules export`)
 └── output.rs           # Output formatting (markdown/JSON/compact)
 ```
 
@@ -633,5 +644,12 @@ See `Cargo.toml` for complete list with feature flags.
 | `cli` | yes | CLI binary (`nab`) with clap argument parsing |
 | `http3` | yes | HTTP/3 + QUIC via quinn |
 | `impersonate` | yes | TLS fingerprint impersonation via rquest + BoringSSL |
+| `analyze` | yes | Audio extraction and the ASR (speech-to-text) trait; backends are separate flags |
+| `browser-launcher` | yes | Cross-platform default-browser launcher, used by the WAF browser escape hatch |
+| `js-dom-full` | yes | Extended DOM shim for WAF challenge scripts (navigator, performance, crypto.subtle, canvas) |
 | `pdf` | no | PDF to Markdown conversion via pdfium |
 | `browser` | no | Browser automation via Chrome DevTools Protocol |
+| `task` | no | Experimental API-first web-task engine (`nab task`) |
+| `analyze-sherpa` | no | Sherpa-ONNX ASR backend; needs model weights via `nab models fetch sherpa-onnx` |
+| `analyze-whisper` | no | Whisper ASR backend; needs model weights via `nab models fetch whisper` |
+| `wasm-providers` | no | WASM provider marketplace for third-party extractors |

--- a/docs/anti-bot-strategy.md
+++ b/docs/anti-bot-strategy.md
@@ -28,6 +28,14 @@ Tier 5.  chromiumoxide CDP — full Chrome; gated --features browser; opt-in via
 
 **Force Tier 5** via site rule (`engine = "browser"` in `linkedin.toml`). MIK-3061 adds the schema field.
 
+## Shipped alongside the ladder: WAF challenges and bot traps
+
+Two checks run on the ordinary `nab fetch` path, independent of the tiers above.
+
+**WAF challenge handling, on by default.** Every HTML response is inspected for an AWS WAF, Cloudflare Turnstile, or DataDome challenge page (`src/waf/mod.rs:70-93`). On a hit, nab prints the vendor and tries the tier named by `--waf-mode`, which defaults to `auto` (`src/main.rs:248-251`). Only AWS WAF has a replay solver today; Cloudflare and DataDome are detected and reported, and their replay path returns `NotImplemented` (`src/waf/mod.rs:127-133`). `--waf-mode browser` opens the system browser for a manual solve; `--waf-mode off` skips the check.
+
+**Bot-trap scoring, opt-in.** `--detect-labyrinth` scores the body for Cloudflare AI Labyrinth-style traps: hidden-link density, topic drift between title and body, `noindex` on a heavy page, sentence-length variance, and link-graph fanout to auto-generated-looking targets (`src/detect/labyrinth.rs`). A page classified as a trap is not returned or saved; the fetch exits with `NabError::LabyrinthDetected`. Off by default because it costs a few milliseconds per fetch.
+
 ## Three-track innovation roadmap
 
 ### Track F — official data export (ships first; ~1 day)


### PR DESCRIPTION
Four documented statements did not match the code. Each was re-verified at source before editing.

## What was wrong, and what is now written

**1. CLI command list (`docs/ARCHITECTURE.md:34-37`)**

The box listed `fetch_batch` and `export-rules` as subcommands. Neither exists: batch fetching is a flag on `fetch` (`src/main.rs:197`) and rule export is `nab rules export` (`src/main.rs:847`). Nine commands present in the `Commands` enum were missing from the doc: browser, doctor, rules, provider, watch, models, upgrade, linkedin, mcp, plus the feature-gated task. The box now lists the 24 variants of `src/main.rs:72-716`.

**2. `cmd/` module tree (`docs/ARCHITECTURE.md:487-506`)**

Nine files in `src/cmd/` were absent from the tree. Added, with the CLI spelling noted for `fetch_batch.rs` and `export_rules.rs`.

**3. Feature flags (`docs/ARCHITECTURE.md:642-648`)**

The table listed 5 flags and named 3 as default-on. `Cargo.toml:226-264` defines 12 flags, and the default set is `cli, http3, impersonate, analyze, browser-launcher, js-dom-full`. All 12 are now listed with their real default.

**4. SSRF relaxation knobs (`docs/ARCHITECTURE.md:362-373`, `README.md:460-471`)**

Both documents described the private-range block as unconditional. `src/ssrf.rs:73-92` and `src/ssrf.rs:265-331` define `NAB_SSRF_ALLOW_PRIVATE` and `NAB_SSRF_ALLOWLIST`, which relax it; `rg NAB_SSRF --glob '*.md'` returned nothing. Both are now documented in the README env table and in the SSRF section, marked off by default, with the note that loopback and cloud-metadata addresses stay blocked either way.

## Undocumented surface added

`docs/anti-bot-strategy.md` described the five-tier fetch ladder and no WAF handling. Two checks that run on the ordinary fetch path are now documented:

- WAF challenge detection and solving, **on by default** (`--waf-mode auto`, `src/main.rs:248-251`). Detection covers AWS WAF, Cloudflare Turnstile and DataDome (`src/waf/mod.rs:70-93`); only AWS WAF has a replay solver, the other two return `NotImplemented` (`src/waf/mod.rs:127-133`).
- `--detect-labyrinth` bot-trap scoring, opt-in, which refuses to return or save a page classified as a trap (`src/detect/labyrinth.rs`, `src/cmd/fetch.rs:490`).

Documentation only. No code changed.