### PR TITLE
chore(deps): bump h2 0.4.13 to 0.4.16

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -3,12 +3,10 @@
 #
 # Yanked-crate status (cargo audit prints these as non-failing warnings; the
 # CI `cargo audit` step has no `--deny yanked`, so it stays exit-0 / honest-green):
-#   * gimli 0.32.3 (yanked) — transitive via yara-x 1.16 -> walrus 0.26.1, which
-#     requires `gimli = "^0.32"` and so cannot accept the non-yanked 0.33.1.
-#     yara-x is already latest in its `^1.16` line; clearing this would mean
-#     bumping the security-critical YARA engine past its pin solely for a
-#     non-failing cosmetic warning — out of scope per #134's fail-fast. A second,
-#     non-yanked gimli 0.33.1 already coexists in the tree for the other consumers.
+#   * gimli 0.32.3 — not yanked; still present via yara-x 1.16 -> walrus 0.26.1
+#     (`gimli = "^0.32"`). A second gimli 0.33.0 (non-yanked; 0.33.1 was yanked)
+#     coexists for cranelift/wasmtime 46.
+#   * chacha20 0.10.0 was yanked; lockfile is on 0.10.2.
 #   * aes / lru — previously flagged in #134, now RESOLVED (no longer in the tree).
 # cargo-audit ignores RUSTSEC IDs, not yanked-by-crate, so gimli is documented
 # here rather than listed below.
@@ -24,9 +22,11 @@ ignore = [
     #
     # Why this cannot be bumped away today: the advisory's patched lines are
     # >=24.0.12, >=36.0.13, >=46.0.2 and >=47.0.3. There is NO patched 43.x.
-    # yara-x requires `wasmtime ^43.0.2` and 1.19.0 -- the newest published --
-    # still does, so no available yara-x release can reach a patched wasmtime.
-    # Verified against the crates.io dependency API for 1.16.0 and 1.19.0.
+    # Rechecked 2026-08-31: yara-x 1.16.0 (our pin) requires wasmtime ^43.0.1;
+    # newest yara-x 1.20.0 requires wasmtime ^45.0.3 -- still no patched 45.x
+    # line, and 1.20.0 dropped the `inventory` crate feature so it cannot be
+    # cargo-updated under the current feature list. Verified against crates.io
+    # dependency API for 1.16.0, 1.19.0, and 1.20.0.
     #
     # Why suppressing it is defensible rather than lazy: CVSS 3.8 LOW, vector
     # AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:L/A:L -- local access, high attack complexity,
@@ -50,9 +50,33 @@ ignore = [
     #
     # Remove this cargo-audit ignore when yara-x releases a version requiring a
     # patched wasmtime line. Cargo-audit cannot expire ignores itself; the
-    # corresponding OSV exception enforces a 2026-09-01 review deadline.
+    # corresponding OSV exception enforces a 2026-10-01 review deadline
+    # (re-reviewed 2026-08-31; previous 2026-09-01 date still blocked).
     # Re-check on every yara-x release. Tracked in #267.
     "RUSTSEC-2026-0222",
+    # wasmtime-wasi filesystem sandbox escape via trailing slash / symlink
+    # (RUSTSEC-2026-0269 / GHSA-vqjp-4c8c-hfgg, HIGH). Patched lines:
+    # 24.0.13, 36.0.14, 46.0.3, 47.0.4; 48.0.0+ is unaffected. No 43.x or
+    # 45.x patch. Direct optional wasmtime is 46.0.3. Remaining hit is
+    # wasmtime 43.0.2 via yara-x 1.16.0 (see 0222 for why yara-x cannot
+    # move to a patched line).
+    #
+    # The advisory is in wasmtime-wasi: a guest with a preopened directory
+    # can escape the cap-std sandbox on macOS and Linux kernels before
+    # openat2 (5.6). Verified at source 2026-08-31:
+    #   * Cargo.lock contains no `wasmtime-wasi` package.
+    #   * yara-x depends on wasmtime with default-features=false and only
+    #     `cranelift` + `runtime` -- not WASI.
+    #   * nab's wasm-providers path (src/site/wasm_provider.rs) does not
+    #     configure WASI; Component Model linker has no filesystem imports.
+    # Fetched content is YARA scan input, not a WASI guest with host dirs.
+    # cargo-audit still flags the `wasmtime` crate ID, which is why this
+    # ignore exists.
+    #
+    # RUSTSEC-2026-0268 (WASIp3 streams) is unaffected below 46.0.0 and
+    # patched at 46.0.3; it needs no ignore after the direct bump.
+    # Remove with 0222 when yara-x ships a patched wasmtime. #267.
+    "RUSTSEC-2026-0269",
     # NOTE: the lru RUSTSEC-2026-0002 ignore was removed once main moved to
     # wreq 6.0.0-rc.29 (lru >= 0.18.0, past the 0.16.3 fix). The advisory no
     # longer applies, so suppressing it would be dead config. See Cargo.toml

--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -51,5 +51,10 @@ reason = "bincode 2.0.1 is unmaintained (RUSTSEC-2025-0141, advisory class = unm
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2026-0222"
-ignoreUntil = 2026-09-01
-reason = "wasmtime 43.0.2 is transitive through yara-x; current yara-x 1.19.0 still requires ^43.0.2 and no patched 43.x exists. The CVSS 3.8 issue requires multiple engines, local high-privilege access and user interaction; Nab compiles its own built-in YARA rules in yara-x's internal engine. Nab's direct optional wasmtime is upgraded to patched 46.0.2. Recheck every yara-x release. Tracked in #267. Reviewed 2026-08-11 by Mikko/Codex."
+ignoreUntil = 2026-10-01
+reason = "wasmtime 43.0.2 is transitive through yara-x 1.16.0. Rechecked 2026-08-31: newest yara-x 1.20.0 requires wasmtime ^45.0.3, which has no patched 45.x line, and cannot be cargo-updated because 1.20.0 dropped the `inventory` crate feature. CVSS 3.8, multiple engines, local high-privilege access and user interaction; Nab compiles its own built-in YARA rules in yara-x's internal engine. Direct optional wasmtime is 46.0.3. Recheck every yara-x release. Tracked in #267. Reviewed 2026-08-31."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0269"
+ignoreUntil = 2026-10-01
+reason = "HIGH wasmtime-wasi filesystem sandbox escape (trailing slash/symlink). Direct wasmtime is patched at 46.0.3. Remaining lockfile hit is wasmtime 43.0.2 via yara-x 1.16.0; no patched 43.x/45.x exists (yara-x 1.20.0 still uses unpatched ^45.0.3). Cargo.lock has no wasmtime-wasi; yara-x enables only cranelift+runtime; nab wasm-providers do not link WASI filesystem. Fetched content is YARA scan input, not a WASI guest with host directories. Tracked in #267. Reviewed 2026-08-31."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Bumped the optional Wasmtime runtime from 46.0.2 to 46.0.3 (RUSTSEC-2026-0268,
+  RUSTSEC-2026-0269). Transitive `yara-x` 1.16.0 still pulls Wasmtime 43.0.2;
+  newest yara-x 1.20.0 uses Wasmtime ^45.0.3, which has no patched 45.x line.
+  Tracked by #267 with a review deadline of 2026-10-01.
+
 ## [0.12.2] - 2026-08-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
- "gimli 0.33.1",
+ "gimli 0.33.0",
 ]
 
 [[package]]
@@ -163,7 +163,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -174,7 +174,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -671,9 +671,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1065,11 +1065,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ca6361f42d0c945fadc1103501e1c07438e034fd5a86896a3074eff3e860bd"
+checksum = "0aadfd45214f09461ba0406f7dacecce5cac39bf0bdb4890eeb468f4ef090e07"
 dependencies = [
- "cranelift-assembler-x64-meta 0.133.2",
+ "cranelift-assembler-x64-meta 0.133.3",
 ]
 
 [[package]]
@@ -1083,11 +1083,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1dbc96db7cebf747bd5722d482338a5acff91d6be43b6bec145f9471327ffa"
+checksum = "57069faede9bd1f926364b4cf69ccc9bebc6f4af5ab897083581b7bc991bf20a"
 dependencies = [
- "cranelift-srcgen 0.133.2",
+ "cranelift-srcgen 0.133.3",
 ]
 
 [[package]]
@@ -1102,12 +1102,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353b309eef494e4adb4c6cca76f30ef27daa907534db7d05b5986500f51aa4e1"
+checksum = "0b1221450f2f9efaa996d916bf53a0a4d13346a4a75468afb828390209a4fdd4"
 dependencies = [
- "cranelift-entity 0.133.2",
- "wasmtime-internal-core 46.0.2",
+ "cranelift-entity 0.133.3",
+ "wasmtime-internal-core 46.0.3",
 ]
 
 [[package]]
@@ -1123,13 +1123,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cafe127a4c5d9765b1df54052245d2cbaca7238782805bb5ac94986ccdb591"
+checksum = "97706f2b466d67bdf0f69d1cf5c5c4a5cd31087cf1fa2e8e5fe0450dddc8661d"
 dependencies = [
  "serde",
  "serde_derive",
- "wasmtime-internal-core 46.0.2",
+ "wasmtime-internal-core 46.0.3",
 ]
 
 [[package]]
@@ -1147,7 +1147,7 @@ dependencies = [
  "cranelift-control 0.130.2",
  "cranelift-entity 0.130.2",
  "cranelift-isle 0.130.2",
- "gimli 0.33.1",
+ "gimli 0.33.0",
  "hashbrown 0.16.1",
  "libm",
  "log",
@@ -1162,25 +1162,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3964f31c6dc9d21e926ef884d3eec2f1ca83266a233521da4a737143262ceb84"
+checksum = "432246ee44b2fc0140b412dca55801d200d6fb25d2d7d18c44bb29e8cd71268b"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64 0.133.2",
- "cranelift-bforest 0.133.2",
- "cranelift-bitset 0.133.2",
- "cranelift-codegen-meta 0.133.2",
- "cranelift-codegen-shared 0.133.2",
- "cranelift-control 0.133.2",
- "cranelift-entity 0.133.2",
- "cranelift-isle 0.133.2",
- "gimli 0.33.1",
+ "cranelift-assembler-x64 0.133.3",
+ "cranelift-bforest 0.133.3",
+ "cranelift-bitset 0.133.3",
+ "cranelift-codegen-meta 0.133.3",
+ "cranelift-codegen-shared 0.133.3",
+ "cranelift-control 0.133.3",
+ "cranelift-entity 0.133.3",
+ "cranelift-isle 0.133.3",
+ "gimli 0.33.0",
  "hashbrown 0.17.0",
  "libm",
  "log",
  "postcard",
- "pulley-interpreter 46.0.2",
+ "pulley-interpreter 46.0.3",
  "regalloc2",
  "rustc-hash 2.1.2",
  "serde",
@@ -1188,7 +1188,7 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-core 46.0.2",
+ "wasmtime-internal-core 46.0.3",
 ]
 
 [[package]]
@@ -1206,15 +1206,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f8b35746603b792e4ae34499a39251f310a06c98d4bc2ca02cf4bd29ce3c84"
+checksum = "b5aa51eff0949f06a5c8f3d5adefef94a12ea99f71cd8985047b91d45f367150"
 dependencies = [
- "cranelift-assembler-x64-meta 0.133.2",
- "cranelift-codegen-shared 0.133.2",
- "cranelift-srcgen 0.133.2",
+ "cranelift-assembler-x64-meta 0.133.3",
+ "cranelift-codegen-shared 0.133.3",
+ "cranelift-srcgen 0.133.3",
  "heck",
- "pulley-interpreter 46.0.2",
+ "pulley-interpreter 46.0.3",
 ]
 
 [[package]]
@@ -1225,9 +1225,9 @@ checksum = "9195cd8aeecb55e401aa96b2eaa55921636e8246c127ed7908f7ef7e0d40f270"
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584bd91987927dfe35e79c5d6dd52a117cb64c4fce26df881d02dcc17bd59a8f"
+checksum = "6095e7095930b6169490138b4262fe7ec24290d3f604d7fe62e1e3138e740daa"
 
 [[package]]
 name = "cranelift-control"
@@ -1240,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af277352af76db01bb42fa4978b672a44406715798edb693cc02e363e12dc505"
+checksum = "e61dfa0766c0eadf42b3febd145a35f81f31086e207f534e5fb406fc3d08fc47"
 dependencies = [
  "arbitrary",
 ]
@@ -1261,14 +1261,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ad4f0c556d3d57580d07477be9e665f4d2a826971a5ab4642ead20a19df443"
+checksum = "e93867a79a06dd5d9ffeb96f7563dc7b6b142b5d89e42ab77e458a408a8aa9d5"
 dependencies = [
- "cranelift-bitset 0.133.2",
+ "cranelift-bitset 0.133.3",
  "serde",
  "serde_derive",
- "wasmtime-internal-core 46.0.2",
+ "wasmtime-internal-core 46.0.3",
 ]
 
 [[package]]
@@ -1285,11 +1285,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d69a6b7d8412c716e8599c7330dfbd122c1bc145f3bda05a9e237fba20419d"
+checksum = "d1991dc32fefa54f14d2a63570d1e963826257605e478558733f83450b7e7661"
 dependencies = [
- "cranelift-codegen 0.133.2",
+ "cranelift-codegen 0.133.3",
  "hashbrown 0.17.0",
  "log",
  "smallvec",
@@ -1304,9 +1304,9 @@ checksum = "b5a90b6ed3aba84189352a87badeb93b2126d3724225a42dc67fdce53d1b139c"
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fcdcd4a5c7fa8bfea35e72c0979ad5a699c836364870f0a84169d02a085a88"
+checksum = "784546de9988ff6e1df0fd4d2450760469a7607344156c661e69ec28082c5da4"
 
 [[package]]
 name = "cranelift-native"
@@ -1321,11 +1321,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fee933cf8ec90e58e68163a02bdb0e4d29f2260a7592b3f09cbba52fcd34d12"
+checksum = "7107a4ae4a2ba48b5df8648365e638b08322fa1da11e86206bf5eddb862b21dd"
 dependencies = [
- "cranelift-codegen 0.133.2",
+ "cranelift-codegen 0.133.3",
  "libc",
  "target-lexicon",
 ]
@@ -1338,9 +1338,9 @@ checksum = "948865622f87f30907bb46fbb081b235ae63c1896a99a83c26a003305c1fa82d"
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd75e1e2719808c80af27ebe168d2220ec10e519e1d5a52bdbed9bd5cac1a32"
+checksum = "4b3f161aa81ee5dd8d7b0eb8828988f57baf2f78d288e62b6b3714b37aa6d6a1"
 
 [[package]]
 name = "crc32fast"
@@ -1612,7 +1612,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1712,7 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2067,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.33.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
@@ -3191,7 +3191,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
- "wasmtime 46.0.2",
+ "wasmtime 46.0.3",
  "wat",
  "webbrowser",
  "which",
@@ -3249,7 +3249,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3987,14 +3987,14 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3683e69168d2e2374cea51a79fce2e9870e7c622366b8bf7af87fb5c2428a2a9"
+checksum = "3f647f8aefd39efd5e38b484a8b7a926dd035ae366127df75c1d94d196f0a4ba"
 dependencies = [
- "cranelift-bitset 0.133.2",
+ "cranelift-bitset 0.133.3",
  "log",
- "pulley-macros 46.0.2",
- "wasmtime-internal-core 46.0.2",
+ "pulley-macros 46.0.3",
+ "wasmtime-internal-core 46.0.3",
 ]
 
 [[package]]
@@ -4010,9 +4010,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
+checksum = "3e902032e329008b189b67498b1be7784d5849276f32402eca17441df08a6bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4597,7 +4597,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4656,7 +4656,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5033,7 +5033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5201,7 +5201,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6173,9 +6173,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed27b4a4a5271d2608406a99c8d1cf8aea1e894fe4ec361d470063bcf342f1d7"
+checksum = "d39226663bd765601279a79b88645a7c4a4d3c2fe73040afdc27bead02ee6659"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -6192,7 +6192,7 @@ dependencies = [
  "object 0.39.1",
  "once_cell",
  "postcard",
- "pulley-interpreter 46.0.2",
+ "pulley-interpreter 46.0.3",
  "rustix",
  "semver",
  "serde",
@@ -6200,16 +6200,16 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "wasmparser 0.251.0",
- "wasmtime-environ 46.0.2",
+ "wasmtime-environ 46.0.3",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
- "wasmtime-internal-core 46.0.2",
- "wasmtime-internal-cranelift 46.0.2",
- "wasmtime-internal-fiber 46.0.2",
- "wasmtime-internal-jit-debug 46.0.2",
- "wasmtime-internal-jit-icache-coherence 46.0.2",
- "wasmtime-internal-unwinder 46.0.2",
- "wasmtime-internal-versioned-export-macros 46.0.2",
+ "wasmtime-internal-core 46.0.3",
+ "wasmtime-internal-cranelift 46.0.3",
+ "wasmtime-internal-fiber 46.0.3",
+ "wasmtime-internal-jit-debug 46.0.3",
+ "wasmtime-internal-jit-icache-coherence 46.0.3",
+ "wasmtime-internal-unwinder 46.0.3",
+ "wasmtime-internal-versioned-export-macros 46.0.3",
  "windows-sys 0.61.2",
 ]
 
@@ -6223,7 +6223,7 @@ dependencies = [
  "cranelift-bforest 0.130.2",
  "cranelift-bitset 0.130.2",
  "cranelift-entity 0.130.2",
- "gimli 0.33.1",
+ "gimli 0.33.0",
  "hashbrown 0.16.1",
  "indexmap",
  "log",
@@ -6242,16 +6242,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7712f99b0920d4638023405eb9723ef200efd6d39bfc7466c92e926ca5d130f0"
+checksum = "2595a168541e8a7faeacf21e3d59da93628ee71468cd69fee9fc2a92c9b1c7d8"
 dependencies = [
  "anyhow",
  "cpp_demangle",
- "cranelift-bforest 0.133.2",
- "cranelift-bitset 0.133.2",
- "cranelift-entity 0.133.2",
- "gimli 0.33.1",
+ "cranelift-bforest 0.133.3",
+ "cranelift-bitset 0.133.3",
+ "cranelift-entity 0.133.3",
+ "gimli 0.33.0",
  "hashbrown 0.17.0",
  "indexmap",
  "log",
@@ -6268,14 +6268,14 @@ dependencies = [
  "wasmparser 0.251.0",
  "wasmprinter 0.251.0",
  "wasmtime-internal-component-util",
- "wasmtime-internal-core 46.0.2",
+ "wasmtime-internal-core 46.0.3",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60f3492a55dbd4eb2e4f1f33ed0626d141f5f4cf4c0194168a4c5006f6601b0"
+checksum = "9abf0fb4ce458eb6edbfaf6cbf13fcbf4216eac5a85febfe90224a1f6064c990"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -6288,9 +6288,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c777c83bb4c3414b23fe84fecd47a46016a0a0b0a39aa786cad0a701fe3cbc7f"
+checksum = "0e50df18c9a8e0deec353ad1e6364ef50538231719a12d80fa5dcb300be8d36b"
 
 [[package]]
 name = "wasmtime-internal-core"
@@ -6305,9 +6305,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb54b5de8723a9acf2c0bc531df8e773462796a5f87e8f49a3d5ea5c3b32ef7"
+checksum = "93b097389e5fad89c8ff8ee0aeafd16447b5a288d52aa1131f17ab4c19fd5be3"
 dependencies = [
  "hashbrown 0.17.0",
  "libm",
@@ -6326,7 +6326,7 @@ dependencies = [
  "cranelift-entity 0.130.2",
  "cranelift-frontend 0.130.2",
  "cranelift-native 0.130.2",
- "gimli 0.33.1",
+ "gimli 0.33.0",
  "itertools 0.14.0",
  "log",
  "object 0.38.1",
@@ -6343,29 +6343,29 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c60bb70116a88791ccceef605b31010c4888a7305e450f01dc7d4f430ad25f0"
+checksum = "08b3e909115836655b83c8bdef7c2e20a34293e785218d9f71a4e5382a09c6b0"
 dependencies = [
  "cfg-if",
- "cranelift-codegen 0.133.2",
- "cranelift-control 0.133.2",
- "cranelift-entity 0.133.2",
- "cranelift-frontend 0.133.2",
- "cranelift-native 0.133.2",
- "gimli 0.33.1",
+ "cranelift-codegen 0.133.3",
+ "cranelift-control 0.133.3",
+ "cranelift-entity 0.133.3",
+ "cranelift-frontend 0.133.3",
+ "cranelift-native 0.133.3",
+ "gimli 0.33.0",
  "itertools 0.14.0",
  "log",
  "object 0.39.1",
- "pulley-interpreter 46.0.2",
+ "pulley-interpreter 46.0.3",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.20",
  "wasmparser 0.251.0",
- "wasmtime-environ 46.0.2",
- "wasmtime-internal-core 46.0.2",
- "wasmtime-internal-unwinder 46.0.2",
- "wasmtime-internal-versioned-export-macros 46.0.2",
+ "wasmtime-environ 46.0.3",
+ "wasmtime-internal-core 46.0.3",
+ "wasmtime-internal-unwinder 46.0.3",
+ "wasmtime-internal-versioned-export-macros 46.0.3",
 ]
 
 [[package]]
@@ -6385,16 +6385,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24bdf54907e0bad31ad6676d03ed1008fa21489725635136f9c38979c39a98ed"
+checksum = "a000d1124dd40417ce8433d07de1063ecc9be7cac21745c8de7f9cf7684c3ead"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "rustix",
- "wasmtime-environ 46.0.2",
- "wasmtime-internal-versioned-export-macros 46.0.2",
+ "wasmtime-environ 46.0.3",
+ "wasmtime-internal-versioned-export-macros 46.0.3",
  "windows-sys 0.61.2",
 ]
 
@@ -6410,12 +6410,12 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4edaf07e20511f3ca070a4a0f026c407969f09e536075729872f548ca6f8d4"
+checksum = "a7439956e78ba68e2cd766f34c3f056d625fad9a055eafb0c4569ac91c09e6b4"
 dependencies = [
  "cc",
- "wasmtime-internal-versioned-export-macros 46.0.2",
+ "wasmtime-internal-versioned-export-macros 46.0.3",
 ]
 
 [[package]]
@@ -6432,13 +6432,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96a6d7eb246d1306b7db8915a169cd8628a9e6b8299d1d1f8ab109801ef0a66"
+checksum = "ee3a381a9dd1ffe3893507733300b420605f465655d78c7a75a965a09d7b43d5"
 dependencies = [
  "cfg-if",
  "libc",
- "wasmtime-internal-core 46.0.2",
+ "wasmtime-internal-core 46.0.3",
  "windows-sys 0.61.2",
 ]
 
@@ -6457,15 +6457,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39472572ea3eb11b7cc7fe7bd6df0005cef87b580eb06a3378d103ac99d45bc3"
+checksum = "22f951f78a1a09001547838fa557522d56655385db97e47307d0f582ca866974"
 dependencies = [
  "cfg-if",
- "cranelift-codegen 0.133.2",
+ "cranelift-codegen 0.133.3",
  "log",
  "object 0.39.1",
- "wasmtime-environ 46.0.2",
+ "wasmtime-environ 46.0.3",
 ]
 
 [[package]]
@@ -6481,9 +6481,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
+checksum = "51e06f9fabbe647e5c2ed186e6920ab1fb48174688d7d3fdadbda537b8499b51"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6492,9 +6492,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d9d3ffd05d6e864adc35cff702f56307c454caec3b1d2d89dd6c843219b663"
+checksum = "f49ac5121036c2255bdc203b1b75a1c04544744cd5f51c93240b58bddca9f0f1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -6653,7 +6653,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -174,7 +174,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1612,7 +1612,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1712,7 +1712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3249,7 +3249,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4597,7 +4597,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4656,7 +4656,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5033,7 +5033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5201,7 +5201,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6653,7 +6653,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ toml = "1.1"                            # Plugin config parsing
 # ═══════════════════════════════════════════════════════════════════════════════
 # Sandboxed WASM runtime for third-party site extractors.
 # No unsafe code needed — wasmtime's safe API is used throughout.
-wasmtime = { version = "46.0.2", optional = true, default-features = false, features = [
+wasmtime = { version = "46.0.3", optional = true, default-features = false, features = [
     "cranelift",         # JIT compiler backend
     "runtime",           # Core runtime
     "component-model",   # WIT Component Model (bindgen!, Linker<T>, Component)


### PR DESCRIPTION
Unblocks Dependabot merges: cargo-audit currently fails on RUSTSEC-2026-0258 (h2 0.4.13). This is a lockfile update of h2 to 0.4.16 plus a Wasmtime 46.0.2 -> 46.0.3 bump for RUSTSEC-2026-0268 and RUSTSEC-2026-0269.

Residual: yara-x 1.16.0 still pulls wasmtime 43.0.2. Newest yara-x 1.20.0 uses wasmtime ^45.0.3 (no patched 45.x line) and dropped the `inventory` crate feature, so it cannot be cargo-updated under the current feature list. Tracked in #267 with a 2026-10-01 review date. Direct wasmtime is patched; the remaining advisory is not on a WASI filesystem guest path we ship.