### PR TITLE
release: prepare v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-09-04
+
 ### Security
 
 - Bumped the optional Wasmtime runtime from 46.0.2 to 46.0.3 (RUSTSEC-2026-0268,
   RUSTSEC-2026-0269). Transitive `yara-x` 1.16.0 still pulls Wasmtime 43.0.2;
   newest yara-x 1.20.0 uses Wasmtime ^45.0.3, which has no patched 45.x line.
   Tracked by #267 with a review deadline of 2026-10-01.
+- Transitive `h2` 0.4.16 (RUSTSEC-2026-0258).
 
 ## [0.12.2] - 2026-08-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,7 +3125,7 @@ dependencies = [
 
 [[package]]
 name = "nab"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "addr",
  "aes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nab"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 authors = ["Mikko Parkkola"]
 description = "Token-optimized HTTP client for LLMs — fetches any URL as clean markdown"


### PR DESCRIPTION
## Summary
Prepare v0.12.3: Wasmtime 46.0.3 and h2 0.4.16 security bumps that were sitting on main after v0.12.2.

Tag `v0.12.3` after merge. Release workflow publishes GitHub Release and crates.io. Homebrew tap is updated after the release assets exist.

## Test plan
- [ ] CI green
- [ ] After merge, tag v0.12.3 and watch release.yml