### PR TITLE
fix(release): re-time-box bincode unmaintained advisory

### DIFF
--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -46,8 +46,8 @@
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2025-0141"
-ignoreUntil = 2026-09-01   # review by this date; after it the gate fires again
-reason = "bincode 2.0.1 is unmaintained (RUSTSEC-2025-0141, advisory class = unmaintained). No upstream fix / patched release exists — there is nothing to bump to. Pulled in transitively; not a code-execution vulnerability. Time-boxed pending an upstream maintenance resumption or a transitive-dep migration off bincode. Reviewed 2026-06-05 by Claude (Opus 4.8)."
+ignoreUntil = 2026-12-01   # review by this date; after it the gate fires again
+reason = "bincode 2.0.1 is unmaintained (RUSTSEC-2025-0141, advisory class = unmaintained). Rechecked 2026-09-04: still no patched release (osv-scanner FIXED VERSION --). Transitive; not a code-execution vulnerability. Time-boxed pending upstream maintenance or a migration off bincode. Reviewed 2026-09-04."
 
 [[IgnoredVulns]]
 id = "RUSTSEC-2026-0222"


### PR DESCRIPTION
## Summary
v0.12.3 tag security-gate failed: RUSTSEC-2025-0141 (bincode 2.0.1 unmaintained) had ignoreUntil 2026-09-01. Local osv-scanner confirms still no patched release (FIXED VERSION --). Extend the time-box to 2026-12-01.

crates.io is still 0.12.2 and there is no GitHub Release for v0.12.3, so after this merges the unpublished v0.12.3 tag will be moved onto this commit and the release workflow re-run.

## Test plan
- [ ] local \`osv-scanner --config=.github/osv-scanner.toml --recursive ./\` exits 0
- [ ] After merge, retag v0.12.3 and security-gate is green