### PR TITLE
feat(mcp): publish server.json to the MCP registry via crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,21 @@ jobs:
             exit 1
           fi
           echo "version OK: tag v$tag == Cargo.toml $ver"
+          # Same drift guard for server.json (MCP registry metadata): a stale
+          # repo copy misleads anyone reading the file, even though
+          # publish-mcp-registry re-stamps the exact version from the tag at
+          # publish time regardless of what's checked in.
+          server_ver="$(jq -r '.version' server.json)"
+          if [ "$server_ver" != "$ver" ]; then
+            echo "::error::server.json version $server_ver does not match Cargo.toml version $ver. Bump server.json before tagging."
+            exit 1
+          fi
+          cargo_pkg_ver="$(jq -r '.packages[] | select(.registryType == "cargo") | .version' server.json)"
+          if [ "$cargo_pkg_ver" != "$ver" ]; then
+            echo "::error::server.json cargo package version $cargo_pkg_ver does not match Cargo.toml version $ver."
+            exit 1
+          fi
+          echo "server.json OK: matches Cargo.toml $ver"
       - name: Scan Cargo dependencies against OSV
         uses: google/osv-scanner-action/osv-scanner-action@6e4298ebc4db23e847df9b2e2de2939d6f066c67 # v2.5.1
         with:
@@ -209,3 +224,37 @@ jobs:
         run: cargo publish --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    # Gated on the crates.io publish, not just the earlier version checks:
+    # a failed `cargo publish` must never leave the MCP registry pointing at
+    # a version that doesn't actually exist on crates.io.
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Stamp release version into server.json
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg version "$VERSION" \
+            '.version = $version
+             | (.packages[] | select(.registryType == "cargo") | .version) = $version' \
+            server.json > server.tmp
+          mv server.tmp server.json
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.MikkoParkkola/nab",
+  "title": "nab",
+  "description": "Token-optimized HTTP client for LLMs — fetches any URL as clean markdown. MCP server with fetch, login, watch, and fingerprint tools.",
+  "version": "0.12.3",
+  "repository": {
+    "url": "https://github.com/MikkoParkkola/nab",
+    "source": "github"
+  },
+  "websiteUrl": "https://github.com/MikkoParkkola/nab",
+  "packages": [
+    {
+      "registryType": "cargo",
+      "registryBaseUrl": "https://crates.io",
+      "identifier": "nab",
+      "version": "0.12.3",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "NAB_SSRF_ALLOW_PRIVATE",
+          "description": "Set to allow fetching private/internal IP addresses (corporate dashboards). Never unblocks loopback, link-local/cloud-metadata, or other always-denied ranges. Off by default.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "NAB_SSRF_ALLOWLIST",
+          "description": "Comma-separated list of private IP/CIDR ranges to exempt from the SSRF guard (e.g. 10.252.0.0/16,192.168.1.5). Narrower, preferred alternative to NAB_SSRF_ALLOW_PRIVATE. Empty by default.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "NAB_WEBMCP_STRICT",
+          "description": "Set to a truthy value to require fetched pages advertising a WebMCP manifest to match NAB_WEBMCP_OPT_IN before ingestion is allowed (defense against prompt injection via fetched content). Off by default.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "NAB_WEBMCP_OPT_IN",
+          "description": "Comma-separated allowlist consulted when NAB_WEBMCP_STRICT is enabled. Empty by default.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "NAB_STATE_DIR",
+          "description": "Overrides the directory used to persist session/cookie state (default: ~/.nab).",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "NAB_KEYCHAIN_INTERACTION",
+          "description": "Controls whether cookie extraction may prompt macOS Keychain for authorization. Set to 'never' in automated/headless callers so a background fetch cannot open a GUI dialog.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "NAB_OP_BIN",
+          "description": "Path to the 1Password CLI binary used for credential retrieval during the login tool (default: op).",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "NAB_MCP_CLI_BIN",
+          "description": "Path to the mcp-cli binary used for MCP-based credential retrieval (default: mcp-cli).",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds `server.json` and a publisher job so nab appears in the official MCP
registry. It ships a `nab-mcp` binary and its README mentions MCP throughout,
but the registry currently holds no entry for it at all.

## Why this matters more than it looks

Third-party MCP catalogs are registry scrapers. With no record to read, they
fall back to guessing from the repo — which is how listings elsewhere ended up
with invented package names and API keys marked required that are in fact
optional. An absent registry entry is not a neutral state; it is an invitation
for a catalog to invent the metadata.

## What is in here

- `server.json` declaring the cargo package and **8 environment variables**,
  each marked explicitly rather than left for a scraper to infer.
- A `publish-mcp-registry` job in the release workflow, **gated on the
  crates.io publish succeeding**, so the registry can never advertise a version
  that is not actually installable.
- A drift guard in the same workflow: the release fails if `server.json`'s
  version, or its cargo package version, disagrees with `Cargo.toml`. A stale
  metadata file is the failure mode this is built to prevent, so it is checked
  rather than trusted.

## Scope

Merging this publishes nothing. The registry push happens on a release tag.
