### PR TITLE
fix(pdf): borrow the cached pdfium handle instead of cloning it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,10 @@ jobs:
             command: cargo build --locked --bin nab-mcp --features task
           - name: mcp-task-browser
             command: cargo build --locked --bin nab-mcp --features task,browser
+          # An optional feature no job builds is a feature that rots unnoticed:
+          # a dependency upgrade broke `pdf` and every job stayed green.
+          - name: pdf
+            command: cargo build --locked --bin nab --features pdf
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/src/content/pdf.rs
+++ b/src/content/pdf.rs
@@ -40,10 +40,13 @@ impl PdfHandler {
     /// Try to load pdfium from common library paths.
     ///
     /// Searches: standard dlopen paths, /usr/local/lib, homebrew, pypdfium2.
-    fn load_pdfium() -> Result<Pdfium> {
+    fn load_pdfium() -> Result<&'static Pdfium> {
+        // Borrow the cached handle: `Pdfium` is not `Clone`, so cloning the
+        // `Result` clones the reference and the later `map_err` cannot move out
+        // of it. Both callers only need `&Pdfium`.
         PDFIUM_INSTANCE
             .get_or_init(|| Self::init_pdfium().map_err(|err| err.to_string()))
-            .clone()
+            .as_ref()
             .map_err(anyhow::Error::msg)
     }
 


### PR DESCRIPTION
## Problem

The `pdf` feature does not compile. On `main` at 30309c8:

```
$ cargo check --lib --features pdf
src/content/pdf.rs:44:9: error[E0507]: cannot move out of a shared reference:
move occurs because value has type `Result<pdfium_render::prelude::Pdfium, String>`,
which does not implement the `Copy` trait
error: could not compile `nab` (lib) due to 1 previous error
```

`OnceLock::get_or_init` returns `&Result<Pdfium, String>`. `Pdfium` has no `Clone`
impl anywhere in pdfium-render 0.9.3, so `.clone()` resolves to cloning the
*reference* rather than the value, and the following `.map_err` then tries to move
out of a shared reference.

Introduced by `96d5ceb chore: finish remaining nab dependency upgrades`, which
added those four lines.

## Why CI stayed green

`pdf` is not in `default`, and no job builds it:

| job | features |
| --- | --- |
| default-binaries | default set |
| minimal-cli-http3 | `cli,http3` |
| mcp-binary | none |
| mcp-task | `task` |
| mcp-task-browser | `task,browser` |

`--all-features` appears nowhere in `.github/workflows/`, `Cargo.toml` or `Makefile`.
A feature the manifest advertises and nothing compiles cannot fail visibly.

## Change

- `load_pdfium` returns `Result<&'static Pdfium>`. `.as_ref()` on the `&'static Result`
  yields `Result<&'static Pdfium, &'static String>`, so nothing moves out of the
  shared reference. Both call sites only invoke `&self` methods, so neither changes.
- A `pdf` entry in the build matrix, so the feature is compiled on every run.

## Verification

| check | result |
| --- | --- |
| `cargo check --lib --features pdf` on main 30309c8 | E0507 (baseline reproduced) |
| same on this branch | clean |
| `cargo clippy --locked --lib --features pdf -- -D warnings` | clean |
| `cargo fmt --check` | clean |

## Review

Two independent non-Claude reviewers, both SHIP. Both raised the same single
improvement — drop the redundant `.clone()` in the error path — which is applied here.

## Out of scope

Three further optional features are also compiled by no CI job: `analyze-sherpa`,
`analyze-whisper`, `wasm-providers`. They are not added to the matrix here because
the first two pull native audio libraries that may need runner packages; adding them
untested would trade a silent failure for a red job. Worth a follow-up decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
