### PR TITLE
fix(fetch): fail closed on empty extraction; recover NVIDIA and LessWrong bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `nab fetch` now fails closed when HTML extraction recovers near-zero content
+  from a non-empty body (`NabError::ThinContent`): large thin pages and
+  Angular/Vue empty app shells warn on stderr and exit non-zero instead of
+  looking like a successful empty article (#280, #246).
+- WordPress `div.entry-content` is preferred over hero `srcset` markup, so
+  NVIDIA developer blog posts extract the article prose (#280).
+- Canonical `lesswrong.com` posts are handled by the LessWrong provider: the
+  `/api/post/{slug}` markdown API plus ForumMagnum embedded `html` JSON, not
+  the author-bio DOM (#198).
+- PDF `OnceLock` initialization is covered for repeated calls after the
+  all-features compile fix (#260, #308).
+
 ## [0.12.3] - 2026-09-04
 
 ### Security

--- a/src/cmd/fetch.rs
+++ b/src/cmd/fetch.rs
@@ -598,7 +598,49 @@ pub async fn cmd_fetch(cfg: &FetchConfig) -> Result<()> {
         },
     )?;
 
+    if let Some(err) = extraction_exit_error(
+        Some(&content_type),
+        &raw_text,
+        body_len,
+        &body_text,
+        quality.as_ref(),
+    ) {
+        return Err(err.into());
+    }
+
     Ok(())
+}
+
+/// Fail closed when HTML extraction recovered almost nothing from a non-empty
+/// body. Callers that only check the exit code otherwise treat a JS shell as
+/// an empty page.
+fn extraction_exit_error(
+    content_type: Option<&str>,
+    html: &str,
+    html_len: usize,
+    markdown: &str,
+    quality: Option<&nab::content::quality::QualityScore>,
+) -> Option<nab::NabError> {
+    if let Some(message) = nab::content::html::detect_empty_spa_shell(html, markdown) {
+        return Some(nab::NabError::ThinContent {
+            html_bytes: html_len,
+            markdown_chars: markdown.len(),
+            reason: message,
+        });
+    }
+    if classify_thin_content(content_type, html_len, markdown.len(), quality).is_some() {
+        let message = thin_content_message(ThinContentDiagnostic {
+            html_bytes: html_len,
+            markdown_chars: markdown.len(),
+            low_confidence: quality.is_some_and(|score| score.confidence < 0.5),
+        });
+        return Some(nab::NabError::ThinContent {
+            html_bytes: html_len,
+            markdown_chars: markdown.len(),
+            reason: message,
+        });
+    }
+    None
 }
 
 /// Authed DOM-render path: inject the user's existing browser session cookies
@@ -1593,6 +1635,57 @@ mod tests {
         assert!(
             !warning.contains("login page"),
             "warning should not pretend a bare 401 is a login page, got: {warning}"
+        );
+    }
+
+    #[test]
+    fn extraction_exit_error_fails_closed_on_thin_html() {
+        let err = super::extraction_exit_error(
+            Some("text/html"),
+            "<html></html>",
+            20_000,
+            &"x".repeat(100),
+            None,
+        )
+        .expect("thin HTML must fail closed");
+        let nab::NabError::ThinContent {
+            html_bytes,
+            markdown_chars,
+            ..
+        } = err
+        else {
+            panic!("expected ThinContent, got {err:?}");
+        };
+        assert_eq!(html_bytes, 20_000);
+        assert_eq!(markdown_chars, 100);
+    }
+
+    #[test]
+    fn extraction_exit_error_fails_closed_on_angular_shell() {
+        let html = include_str!("../../tests/fixtures/angular-scania-shell.html");
+        let err = super::extraction_exit_error(
+            Some("text/html"),
+            html,
+            html.len(),
+            "Scania Developer Portal",
+            None,
+        )
+        .expect("Angular app-root shell must fail closed");
+        assert!(err.to_string().contains("SPA shell"));
+    }
+
+    #[test]
+    fn extraction_exit_error_allows_short_static_pages() {
+        let html = "<html><body><p>Hello from a small static page.</p></body></html>";
+        assert!(
+            super::extraction_exit_error(
+                Some("text/html"),
+                html,
+                html.len(),
+                "Hello from a small static page.",
+                None
+            )
+            .is_none()
         );
     }
 

--- a/src/content/html.rs
+++ b/src/content/html.rs
@@ -347,6 +347,43 @@ fn is_thin_content(html_len: usize, markdown_len: usize) -> bool {
     ratio_percent < THIN_RATIO_PERCENT
 }
 
+/// Client-rendered shells (Angular `app-root`, Vue CLI `#app` + chunk vendors)
+/// that ship almost no visible text in the initial HTML.
+#[must_use]
+pub fn looks_like_client_spa_shell(html: &str) -> bool {
+    let lower = html.to_ascii_lowercase();
+    if lower.contains("<app-root") || lower.contains("ng-version") {
+        return true;
+    }
+    let has_vue_app = lower.contains("id=\"app\"") || lower.contains("id='app'");
+    has_vue_app && (lower.contains("chunk-vendors") || lower.contains("polyfills"))
+}
+
+/// Detect an Angular/Vue-style empty app shell whose extracted markdown is
+/// just the document title.
+///
+/// Unlike [`detect_thin_content`], this fires on small HTML (a 2 KB Angular
+/// index.html never reaches the 5 KB thin-content floor).
+#[must_use]
+pub fn detect_empty_spa_shell(html: &str, markdown: &str) -> Option<String> {
+    const MAX_SHELL_MARKDOWN_CHARS: usize = 200;
+    if !looks_like_client_spa_shell(html) {
+        return None;
+    }
+    if markdown.trim().chars().count() >= MAX_SHELL_MARKDOWN_CHARS {
+        return None;
+    }
+    Some(format!(
+        "Extracted only {} chars from a client-rendered SPA shell ({} bytes of HTML). \
+         The article body is populated by JavaScript that nab does not execute. Try:\n  \
+         1. nab spa <url>              (extract embedded SPA data)\n  \
+         2. nab browser <url>          (explicit external-CDP browser rendering)\n  \
+         3. nab fetch --render <url>   (same, via fetch)",
+        markdown.trim().chars().count(),
+        html.len()
+    ))
+}
+
 /// Fetch content from Jina reader as an opt-in fallback for JS-rendered pages.
 ///
 /// Jina reader (`r.jina.ai`) renders JavaScript and returns clean markdown.
@@ -890,8 +927,9 @@ pub fn is_boilerplate(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        HtmlConversionOptions, html_to_markdown_with_url, html_to_markdown_with_url_and_fetcher,
-        html_to_markdown_with_url_and_sources, is_thin_content, strip_embedded_data_sections,
+        HtmlConversionOptions, detect_empty_spa_shell, html_to_markdown_with_url,
+        html_to_markdown_with_url_and_fetcher, html_to_markdown_with_url_and_sources,
+        is_thin_content, looks_like_client_spa_shell, strip_embedded_data_sections,
         strip_hidden_sections, strip_noise_sections,
     };
 
@@ -1486,5 +1524,48 @@ mod tests {
             authored_ratio >= 0.80,
             "authored markdown ratio too low: {authored_ratio:.2}; markdown: {md}"
         );
+    }
+
+    #[test]
+    fn looks_like_client_spa_shell_detects_angular_app_root() {
+        let html = r#"<!DOCTYPE html><html><head><title>Scania Developer Portal</title>
+            <base href="/"></head>
+            <body><app-root></app-root>
+            <script src="polyfills.js"></script></body></html>"#;
+        assert!(looks_like_client_spa_shell(html));
+        assert!(!looks_like_client_spa_shell(
+            "<html><body><p>A static article with no SPA markers.</p></body></html>"
+        ));
+    }
+
+    #[test]
+    fn detect_empty_spa_shell_fires_on_title_only_angular_index() {
+        let html = include_str!("../../tests/fixtures/angular-scania-shell.html");
+        let markdown = "Scania Developer Portal";
+        let warning = detect_empty_spa_shell(html, markdown)
+            .expect("empty Angular shell must not report success");
+        assert!(warning.contains("client-rendered SPA shell"));
+        assert!(
+            !is_thin_content(html.len(), markdown.len()),
+            "2 KB Angular shells sit below the 5 KB thin-content floor"
+        );
+    }
+
+    #[test]
+    fn html_to_markdown_keeps_wordpress_entry_content() {
+        const NEEDLE: &str = "Before loading a model, first ask where a compatible copy of its weights already lives";
+        let html = format!(
+            r#"<html><body><main>
+                <img srcset="{}">
+                <div class="entry-content">
+                    <p>Every byte moved has a cost when checkpoints grow.</p>
+                    <p>{NEEDLE}</p>
+                    <p>MX transfers weights over P2P RDMA instead of object storage.</p>
+                </div>
+            </main></body></html>"#,
+            "https://cdn.example/hero.jpg 1024w, https://cdn.example/hero-2x.jpg 2048w"
+        );
+        let md = html_to_markdown_with_url(&html, Some("https://developer.nvidia.com/blog/x/"));
+        assert!(md.contains(NEEDLE), "lost authored body: {md}");
     }
 }

--- a/src/content/pdf.rs
+++ b/src/content/pdf.rs
@@ -508,4 +508,22 @@ mod tests {
         let handler = PdfHandler::new();
         assert_eq!(handler.supported_types(), &["application/pdf"]);
     }
+
+    #[test]
+    fn load_pdfium_is_stable_across_repeated_calls() {
+        match (PdfHandler::load_pdfium(), PdfHandler::load_pdfium()) {
+            (Ok(first), Ok(second)) => {
+                assert!(
+                    std::ptr::eq(first, second),
+                    "cached Pdfium handle must be reused"
+                );
+            }
+            (Err(first), Err(second)) => {
+                assert_eq!(first.to_string(), second.to_string());
+            }
+            (Ok(_), Err(err)) | (Err(err), Ok(_)) => {
+                panic!("cached pdfium result must be stable, got mixed Ok/Err: {err}");
+            }
+        }
+    }
 }

--- a/src/content/readability.rs
+++ b/src/content/readability.rs
@@ -53,6 +53,13 @@ static SUBSTACK_NOISE_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
     )
     .expect("static substack noise selector")
 });
+static WP_ENTRY_CONTENT_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse("div.entry-content").expect("static wordpress entry-content selector")
+});
+static WP_NOISE_SELECTOR: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse("figure, picture, source, img, svg, iframe, form, input, button")
+        .expect("static wordpress noise selector")
+});
 
 /// Extracted article content from HTML.
 #[derive(Debug, Clone)]
@@ -79,6 +86,15 @@ pub fn extract_article(html: &str, url: &str) -> Option<Article> {
             url
         );
         return Some(substack_result);
+    }
+
+    if let Some(wordpress_result) = extract_wordpress_article(html) {
+        tracing::debug!(
+            "wordpress entry-content extraction: {} chars for {}",
+            wordpress_result.text_content.len(),
+            url
+        );
+        return Some(wordpress_result);
     }
 
     let readability_result = extract_with_readability_crate(html, url);
@@ -229,9 +245,54 @@ fn extract_og_title(document: &Html) -> Option<String> {
 }
 
 fn strip_substack_noise(html: &str) -> String {
+    strip_selected_noise(html, &SUBSTACK_NOISE_SELECTOR)
+}
+
+/// Extract the authored body from `WordPress` `div.entry-content`.
+///
+/// NVIDIA developer blogs (and other WP templates) put the article in
+/// `.entry-content` but wrap it in `<main>` alongside hero images whose
+/// `srcset` attributes dominate `html2md` output. Prefer the authored node
+/// the same way Substack prefers `.available-content .body.markup`.
+fn extract_wordpress_article(html: &str) -> Option<Article> {
+    let document = Html::parse_document(html);
+    let body = document.select(&WP_ENTRY_CONTENT_SELECTOR).next()?;
+    let title = extract_title(&document);
+    let body_html = strip_selected_noise(&body.html(), &WP_NOISE_SELECTOR);
+
+    let mut content_html = String::from("<article>");
+    if !title.is_empty() && title != "Untitled" {
+        content_html.push_str("<h1>");
+        content_html.push_str(&escape_html_text(&title));
+        content_html.push_str("</h1>");
+    }
+    content_html.push_str(&body_html);
+    content_html.push_str("</article>");
+
+    let text_content = strip_html_tags(&content_html);
+    if text_content.len() < 100 {
+        return None;
+    }
+
+    let excerpt = text_content
+        .chars()
+        .take(200)
+        .collect::<String>()
+        .trim()
+        .to_string();
+
+    Some(Article {
+        title,
+        content_html,
+        excerpt,
+        text_content,
+    })
+}
+
+fn strip_selected_noise(html: &str, selector: &Selector) -> String {
     let document = Html::parse_fragment(html);
     let excluded_ids = document
-        .select(&SUBSTACK_NOISE_SELECTOR)
+        .select(selector)
         .map(|el| el.id())
         .collect::<std::collections::HashSet<_>>();
 
@@ -889,5 +950,49 @@ mod tests {
         let doc = Html::parse_fragment(html);
         let element = doc.select(&DIV_SELECTOR).next().unwrap();
         assert!(!is_unlikely_candidate(&element));
+    }
+
+    #[test]
+    fn extracts_wordpress_entry_content_instead_of_hero_srcset() {
+        const NEEDLE: &str = "Before loading a model, first ask where a compatible copy of its weights already lives";
+        let srcset = "https://cdn.example/hero-1024.jpg 1024w, https://cdn.example/hero-2048.jpg 2048w, https://cdn.example/hero-4096.jpg 4096w";
+        let html = format!(
+            r#"
+            <html>
+              <body>
+                <main class="main-content col-lg-9">
+                  <img class="wp-post-image" srcset="{srcset}" alt="">
+                  <figure><img srcset="{srcset}" alt="hero"></figure>
+                  <h1>ModelExpress: Distributing Model Artifacts at the Speed of Light</h1>
+                  <div class="entry-content">
+                    <p class="wp-block-paragraph">Every byte moved has a cost. As model checkpoints grow to hundreds of gigabytes, that cost adds up quickly.</p>
+                    <p class="wp-block-paragraph">NVIDIA ModelExpress (MX) is built around a simple idea: {NEEDLE}. Rather than treating every replica as an independent cold start, MX chooses the fastest available source and transfer path.</p>
+                    <p class="wp-block-paragraph">When a serving peer already holds compatible weights in GPU, MX transfers them directly from GPU to GPU over P2P RDMA.</p>
+                  </div>
+                  <div class="entry-content-comments"><p>A long comment should not be selected as the article.</p></div>
+                </main>
+              </body>
+            </html>
+            "#
+        );
+
+        let article =
+            extract_article(&html, "https://developer.nvidia.com/blog/modelexpress/").unwrap();
+        assert!(
+            article.text_content.contains(NEEDLE),
+            "missing authored sentence; text: {}",
+            article.text_content
+        );
+        assert!(!article.content_html.contains("srcset"));
+        assert!(
+            !article
+                .text_content
+                .contains("A long comment should not be selected")
+        );
+        let markdown = article_to_markdown(&article);
+        assert!(
+            markdown.contains(NEEDLE),
+            "markdown lost the article: {markdown}"
+        );
     }
 }

--- a/src/content/response_classifier.rs
+++ b/src/content/response_classifier.rs
@@ -244,6 +244,18 @@ pub fn classify_response(analysis: ResponseAnalysis<'_>) -> ResponseClassificati
         });
     }
 
+    if super::html::looks_like_client_spa_shell(analysis.body)
+        && analysis
+            .markdown
+            .is_some_and(|markdown| markdown.trim().chars().count() < 200)
+    {
+        classification.push(ResponseSignal {
+            class: ResponseClass::ThinContent,
+            confidence: 0.95,
+            reason: "client-rendered SPA shell with no extractable article body",
+        });
+    }
+
     if let (Some(html_bytes), Some(markdown_chars)) = (analysis.html_bytes, analysis.markdown_chars)
         && classify_thin_content(
             analysis.content_type,
@@ -793,6 +805,21 @@ mod tests {
             html_bytes: Some(20_000),
             markdown: Some("short"),
             markdown_chars: Some(120),
+            quality: None,
+        });
+        assert!(classification.has_class(ResponseClass::ThinContent));
+    }
+
+    #[test]
+    fn classify_response_marks_angular_app_root_shell() {
+        let html = include_str!("../../tests/fixtures/angular-scania-shell.html");
+        let classification = classify_response(ResponseAnalysis {
+            status: 200,
+            body: html,
+            content_type: Some("text/html"),
+            html_bytes: Some(html.len()),
+            markdown: Some("Scania Developer Portal"),
+            markdown_chars: Some(22),
             quality: None,
         });
         assert!(classification.has_class(ResponseClass::ThinContent));

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,6 +77,22 @@ pub enum NabError {
         verdict: String,
     },
 
+    /// HTML fetched successfully but extraction produced near-zero content.
+    ///
+    /// Distinct from a transport failure: the bytes arrived, the converter
+    /// did not recover the article (JS shell, wrong DOM root, etc.).
+    #[error(
+        "extraction produced near-zero content ({markdown_chars} chars from {html_bytes} byte body): {reason}"
+    )]
+    ThinContent {
+        /// Raw response body size in bytes.
+        html_bytes: usize,
+        /// Extracted markdown size in characters.
+        markdown_chars: usize,
+        /// Why this was classified as empty extraction.
+        reason: String,
+    },
+
     /// Catch-all for unclassified errors propagated from internal anyhow chains.
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/src/site/lesswrong.rs
+++ b/src/site/lesswrong.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
 
-//! `LessWrong` mirror extraction.
+//! `LessWrong` / `GreaterWrong` extraction.
 //!
-//! `greaterwrong.com` is a JavaScript viewer for `LessWrong` content. The static
-//! HTML returned to non-browser clients contains only viewer chrome, while the
-//! equivalent `lesswrong.com` page contains the article data that nab's generic
-//! HTML pipeline already extracts well.
+//! Canonical `lesswrong.com` posts SSR the author bio into the DOM and stash
+//! the article body in a `ForumMagnum` JSON `html` field. `GreaterWrong` is a
+//! JavaScript viewer whose static HTML is chrome-only. Both resolve to the
+//! markdown API at `/api/post/{slug}` when the path is a post.
 
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
@@ -16,6 +16,7 @@ use crate::content::html::html_to_markdown_with_url;
 use crate::http_client::AcceleratedClient;
 
 const LESSWRONG_HOST: &str = "www.lesswrong.com";
+const LESSWRONG_HOSTS: &[&str] = &["lesswrong.com", "www.lesswrong.com"];
 const GREATERWRONG_HOSTS: &[&str] = &["greaterwrong.com", "www.greaterwrong.com"];
 
 /// Provider for `LessWrong` mirror URLs.
@@ -28,7 +29,7 @@ impl SiteProvider for LessWrongProvider {
     }
 
     fn matches(&self, url: &str) -> bool {
-        is_greaterwrong_url(url)
+        is_lesswrong_family_url(url)
     }
 
     async fn extract(
@@ -36,9 +37,15 @@ impl SiteProvider for LessWrongProvider {
         url: &str,
         client: &AcceleratedClient,
         _cookies: Option<&str>,
-        _prefetched_html: Option<&[u8]>,
+        prefetched_html: Option<&[u8]>,
     ) -> Result<SiteContent> {
         let canonical_url = canonical_lesswrong_url(url)?;
+        if let Some(bytes) = prefetched_html
+            && let Ok(html) = std::str::from_utf8(bytes)
+        {
+            return Ok(site_content_from_html(html, &canonical_url));
+        }
+
         if let Some(api_url) = lesswrong_markdown_api_url(&canonical_url)? {
             let markdown = client
                 .inner()
@@ -60,36 +67,38 @@ impl SiteProvider for LessWrongProvider {
         let html = client
             .fetch_text(&canonical_url)
             .await
-            .with_context(|| format!("failed to fetch LessWrong mirror URL '{canonical_url}'"))?;
+            .with_context(|| format!("failed to fetch LessWrong URL '{canonical_url}'"))?;
 
         Ok(site_content_from_html(&html, &canonical_url))
     }
 }
 
-fn is_greaterwrong_url(url: &str) -> bool {
+fn is_lesswrong_family_url(url: &str) -> bool {
     let Ok(parsed) = Url::parse(url) else {
         return false;
     };
     let Some(host) = parsed.host_str() else {
         return false;
     };
-    GREATERWRONG_HOSTS.contains(&host.to_ascii_lowercase().as_str())
+    let host = host.to_ascii_lowercase();
+    LESSWRONG_HOSTS.contains(&host.as_str()) || GREATERWRONG_HOSTS.contains(&host.as_str())
 }
 
 fn canonical_lesswrong_url(url: &str) -> Result<String> {
-    let mut parsed = Url::parse(url).context("invalid GreaterWrong URL")?;
+    let mut parsed = Url::parse(url).context("invalid LessWrong URL")?;
     let host = parsed
         .host_str()
         .map(str::to_ascii_lowercase)
-        .context("GreaterWrong URL has no host")?;
+        .context("LessWrong URL has no host")?;
 
-    if !GREATERWRONG_HOSTS.contains(&host.as_str()) {
-        bail!("URL is not a GreaterWrong mirror URL");
+    if GREATERWRONG_HOSTS.contains(&host.as_str()) || host == "lesswrong.com" {
+        parsed
+            .set_host(Some(LESSWRONG_HOST))
+            .context("failed to rewrite LessWrong host")?;
+    } else if host != LESSWRONG_HOST {
+        bail!("URL is not a LessWrong family URL");
     }
 
-    parsed
-        .set_host(Some(LESSWRONG_HOST))
-        .context("failed to rewrite GreaterWrong host")?;
     parsed.set_fragment(None);
 
     Ok(parsed.to_string())
@@ -135,7 +144,16 @@ fn site_content_from_markdown(markdown: &str, canonical_url: &str) -> SiteConten
 }
 
 fn site_content_from_html(html: &str, canonical_url: &str) -> SiteContent {
-    let markdown = html_to_markdown_with_url(html, Some(canonical_url));
+    let from_dom = html_to_markdown_with_url(html, Some(canonical_url));
+    let markdown = extract_forummagnum_embedded_html(html)
+        .map(|embedded| {
+            html_to_markdown_with_url(
+                &format!("<article>{embedded}</article>"),
+                Some(canonical_url),
+            )
+        })
+        .filter(|from_json| from_json.len() > from_dom.len())
+        .unwrap_or(from_dom);
     let title = html_heading_title(html).or_else(|| markdown_title(&markdown));
 
     SiteContent {
@@ -161,6 +179,46 @@ fn markdown_title(markdown: &str) -> Option<String> {
     })
 }
 
+/// Pull the longest `ForumMagnum` JSON `"html":"..."` payload out of SSR HTML.
+fn extract_forummagnum_embedded_html(html: &str) -> Option<String> {
+    const MARKER: &str = "\"html\":\"";
+    let mut search = html;
+    let mut best: Option<String> = None;
+    while let Some(idx) = search.find(MARKER) {
+        let rest = &search[idx + MARKER.len()..];
+        if let Some(value) = parse_json_string_body(rest)
+            && value.contains('<')
+            && value.len() > best.as_ref().map_or(0, String::len)
+        {
+            best = Some(value);
+        }
+        search = &search[idx + MARKER.len()..];
+    }
+    best
+}
+
+fn parse_json_string_body(rest: &str) -> Option<String> {
+    let mut encoded = String::from('"');
+    let mut chars = rest.chars();
+    loop {
+        match chars.next()? {
+            '"' => {
+                encoded.push('"');
+                break;
+            }
+            '\\' => {
+                encoded.push('\\');
+                encoded.push(chars.next()?);
+            }
+            c => encoded.push(c),
+        }
+        if encoded.len() > 2_000_000 {
+            return None;
+        }
+    }
+    serde_json::from_str(&encoded).ok()
+}
+
 fn html_heading_title(html: &str) -> Option<String> {
     let document = scraper::Html::parse_document(html);
     let selector = scraper::Selector::parse("h1").ok()?;
@@ -181,12 +239,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn matches_greaterwrong_mirror_hosts_only() {
+    fn matches_lesswrong_family_hosts() {
         let provider = LessWrongProvider;
 
         assert!(provider.matches("https://greaterwrong.com/posts/abc/title"));
         assert!(provider.matches("https://www.greaterwrong.com/posts/abc/title"));
-        assert!(!provider.matches("https://www.lesswrong.com/posts/abc/title"));
+        assert!(provider.matches("https://www.lesswrong.com/posts/abc/title"));
+        assert!(provider.matches("https://lesswrong.com/posts/abc/title"));
         assert!(!provider.matches("https://example.com/posts/abc/title"));
     }
 
@@ -330,5 +389,45 @@ Late last year a new AI psychosis kicked off. This time it was coding agents.
             Some("The World Can't Keep Up With AI Labs")
         );
         assert_eq!(content.metadata.platform, "lesswrong");
+    }
+
+    #[test]
+    fn extracts_article_from_forummagnum_embedded_html_json() {
+        let body = "<p>The hidden structures of problems include coordination traps and value lock-in, a 31-item taxonomy that must survive extraction.</p>";
+        let encoded = serde_json::to_string(body).unwrap();
+        let html = format!(
+            r#"
+            <html>
+              <body>
+                <div class="author-bio">Denkenberger has worked on food security for years and this bio is in the DOM.</div>
+                <article><p>.</p></article>
+                <script type="application/json">{{"html":{encoded},"wordCount":4888}}</script>
+              </body>
+            </html>
+            "#
+        );
+
+        let content = site_content_from_html(
+            &html,
+            "https://www.lesswrong.com/posts/Cisy9STMoFYwboTsy/the-hidden-structures-of-problems",
+        );
+
+        assert!(
+            content.markdown.contains("31-item taxonomy"),
+            "expected JSON body, got: {}",
+            content.markdown
+        );
+        assert!(!content.markdown.contains("Denkenberger"));
+    }
+
+    #[test]
+    fn canonicalizes_lesswrong_com_to_www() {
+        assert_eq!(
+            canonical_lesswrong_url(
+                "https://lesswrong.com/posts/Cisy9STMoFYwboTsy/the-hidden-structures-of-problems#comments"
+            )
+            .unwrap(),
+            "https://www.lesswrong.com/posts/Cisy9STMoFYwboTsy/the-hidden-structures-of-problems"
+        );
     }
 }

--- a/tests/fixtures/angular-scania-shell.html
+++ b/tests/fixtures/angular-scania-shell.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en" data-beasties-container>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta charset="utf-8">
+    <title>Scania Developer Portal</title>
+    <meta name="description" content="Let's create the future of connected transport together!">
+    <base href="/">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/x-icon" href="favicon.ico">
+    <script src="https://example.invalid/corporate-ui.js?preload=false"></script>
+    <script src="https://example.invalid/polyfills.js"></script>
+  </head>
+  <body>
+    <app-root></app-root>
+    <script src="https://example.invalid/main.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

`nab fetch` could return HTTP 200 with almost no article text. Callers that only check the exit code treated that as an empty page.

- **#280** WordPress `div.entry-content` is preferred over hero `srcset` markup (NVIDIA developer blogs). Fixture asserts the ModelExpress sentence.
- **#246 / #280 EXTRACT.3** Thin HTML and Angular/Vue empty app shells warn on stderr and exit non-zero (`NabError::ThinContent`). The 2 KB Scania `app-root` shell is below the old 5 KB thin-content floor, so it now has its own detector.
- **#198** Canonical `lesswrong.com` posts go through the existing `/api/post/{slug}` markdown API and ForumMagnum embedded `html` JSON instead of the author-bio DOM.
- **#260** PDF `OnceLock` handle is covered for repeated `load_pdfium` calls (compile fix already landed in #308).

## Test plan

- [x] `cargo test --lib content::html`
- [x] `cargo test --lib content::readability`
- [x] `cargo test --lib site::lesswrong`
- [x] `cargo test --lib content::response_classifier`
- [x] `cargo test --bin nab cmd::fetch::tests`
- [x] `cargo test --lib --features pdf content::pdf`
- [x] `cargo clippy --lib --bins -- -D warnings`

Hosted CI may not start (account spending limit). Local proof is the gate.

## Not in this PR

- **#267** yara-x still pulls Wasmtime 43; newest 1.20.0 still requires unpatched `^45.0.3`. Recheck posted on the issue.
- **#196** DocLang opt-in deferred: no `doclang` crate on crates.io, Markdown stays default per the issue fail-fast.